### PR TITLE
Disable haptic feedback on record button long press

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
@@ -209,7 +209,7 @@ class AudioRecordingController(
         // if the recorder is in the 'cleared' state
         // holding the 'record' button should start a recording
         // releasing the 'record' button should complete the recording
-        // TODO: remove haptics from the long press - the 'buzz' can be heard on the recording
+        recordButton.isHapticFeedbackEnabled = false
         recordButton.setOnHoldListener(
             object : OnHoldListener {
                 override fun onTouchStart() {


### PR DESCRIPTION
The system haptic feedback on long press was audible in the audio recordings. This change disables haptic feedback on the record button to prevent this. Manual vibration is already handled in controlAudioRecorder() at the start of the interaction.

Fixes TODO in AudioRecordingController.kt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled haptic feedback on the audio record button to improve recording experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->