### PR TITLE
Add AnkiWeb Terms and Conditions link to Help screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/help/HelpScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/help/HelpScreen.kt
@@ -108,6 +108,11 @@ private val helpLinks = listOf(
         R.string.help_donate_subtitle,
         R.drawable.volunteer_activism_24px,
         "https://ankidroid.org/#donations"
+    ), HelpLink(
+        R.string.help_ankiweb_terms_title,
+        R.string.help_ankiweb_terms_subtitle,
+        R.drawable.info_24px,
+        "https://ankiweb.net/account/terms"
     )
 )
 

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -70,6 +70,8 @@
     <string name="help_issue_tracker_subtitle">Submit issues on our tracker</string>
     <string name="help_donate_title">Donate</string>
     <string name="help_donate_subtitle">Support AnkiDroid, which this app is based off of</string>
+    <string name="help_ankiweb_terms_title">Terms and Conditions</string>
+    <string name="help_ankiweb_terms_subtitle">AnkiWeb Terms and Conditions</string>
     <string name="help_hero_subtitle">Here are some helpful resources.</string>
     <string name="login_error_email_password_required">Email and password are required</string>
     <string name="login_error_authentication_failed">The email or password you entered is incorrect. Please check your credentials and try again, or reset your password.</string>


### PR DESCRIPTION
This commit adds a new item to the Help screen that links to the AnkiWeb Terms and Conditions page. It includes:
- New string resources for the title and subtitle.
- A new `HelpLink` entry in `HelpScreen.kt` using `R.drawable.info_24px`.
- The URL points to `https://ankiweb.net/account/terms`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new help link to the Help screen providing access to AnkiWeb's Terms of Service information with an informational icon.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->