### PR TITLE
Fix audio playback continuing in background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -471,9 +471,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
         super.onPause()
         gestureDetectorImpl.stopShakeDetector()
         if (this::cardMediaPlayer.isInitialized) {
-            launchCatchingTask {
-                cardMediaPlayer.setEnabled(false)
-            }
+            cardMediaPlayer.setEnabled(false)
             ReadText.stopTts()
         }
         // Prevent loss of data in Cookies
@@ -484,9 +482,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
         super.onResume()
         gestureDetectorImpl.startShakeDetector()
         if (this::cardMediaPlayer.isInitialized) {
-            launchCatchingTask {
-                cardMediaPlayer.setEnabled(true)
-            }
+            cardMediaPlayer.setEnabled(true)
         }
         // Reset the activity title
         updateActionBar()
@@ -1232,7 +1228,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
         return true
     }
 
-    private suspend fun stopCardMediaPlayer() {
+    private fun stopCardMediaPlayer() {
         cardMediaPlayer.stop()
         ReadText.stopTts()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -117,7 +117,7 @@ class CardMediaPlayer : Closeable {
     var isEnabled: Boolean = true
         private set
 
-    suspend fun setEnabled(enabled: Boolean) {
+    fun setEnabled(enabled: Boolean) {
         if (!enabled) stop()
         this.isEnabled = enabled
     }
@@ -221,9 +221,9 @@ class CardMediaPlayer : Closeable {
             }
     }
 
-    suspend fun stop() {
+    fun stop() {
         if (isPlaying) Timber.i("stopping playing all AV tags")
-        playAvTagsJob?.cancelAndJoin()
+        playAvTagsJob?.cancel()
     }
 
     override fun close() {


### PR DESCRIPTION
This pull request refactors how media playback is managed in the flashcard viewer by removing unnecessary coroutine usage for enabling, disabling, and stopping the card media player. The changes simplify the code, making media control methods synchronous and improving maintainability.

Refactoring media control methods:

* Made `setEnabled` and `stop` methods in `CardMediaPlayer` synchronous by removing the `suspend` modifier and associated coroutine logic. This simplifies their usage and avoids unnecessary coroutine overhead. [[1]](diffhunk://#diff-64cde60f078f7e8ab4f533b63ea9ac6c1b920d3c644fb4e1774794a216d7b890L120-R120) [[2]](diffhunk://#diff-64cde60f078f7e8ab4f533b63ea9ac6c1b920d3c644fb4e1774794a216d7b890L224-R226)
* Updated `stopCardMediaPlayer` in `AbstractFlashcardViewer` to be a regular function instead of a suspending one, reflecting the changes in `CardMediaPlayer`.

Simplifying lifecycle event handling:

* Removed the use of `launchCatchingTask` when enabling and disabling the card media player in the `onPause` and `onResume` lifecycle methods, since the methods are now synchronous. [[1]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6L474-L476) [[2]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6L487-L490)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal media playback control operations during app lifecycle transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->