### PR TITLE
Implement reusable search and top app bars

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -390,12 +390,11 @@ data class DownloadFile(
     ).let { maybeCorruptFileName ->
         // #17573: https://issuetracker.google.com/issues/382864232
         // guessFileName may return ".bin" as an extension
-        (FileNameAndExtension.fromString(maybeCorruptFileName)
-        // default if maybeCorruptFileName doesn't contain a '.'
-        // Add randomness to avoid file name conflicts between different decks
-            ?: FileNameAndExtension.fromString("download-${Random.nextInt()}$extension")!!).replaceExtension(
-            extension = extension
-        ) // enforce the provided extension
-            .toString()
+        val base = FileNameAndExtension.fromString(maybeCorruptFileName) ?: requireNotNull(
+            FileNameAndExtension.fromString("download-${Random.nextInt(Int.MAX_VALUE)}.tmp")
+        ) {
+            "failed to parse fallback filename"
+        }
+        base.replaceExtension(extension).toString()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -20,6 +20,15 @@ package com.ichi2.anki
 import android.app.DownloadManager
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.webkit.CookieManager
+import android.webkit.URLUtil
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -41,15 +50,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import android.webkit.CookieManager
-import android.webkit.URLUtil
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.enableEdgeToEdge
 import androidx.core.net.toUri
 import androidx.fragment.app.commit
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
@@ -321,8 +321,7 @@ class SharedDecksActivity : AnkiActivity() {
                                 )
                             }
                         }
-                    }
-                )
+                    })
             }
         }
 
@@ -337,7 +336,10 @@ class SharedDecksActivity : AnkiActivity() {
             if (!supportFragmentManager.isStateSaved) {
                 val sharedDecksDownloadFragment = SharedDecksDownloadFragment()
                 sharedDecksDownloadFragment.arguments = Bundle().apply {
-                    putSerializable(DOWNLOAD_FILE, DownloadFile(url, userAgent, contentDisposition, mimetype))
+                    putSerializable(
+                        DOWNLOAD_FILE,
+                        DownloadFile(url, userAgent, contentDisposition, mimetype)
+                    )
                 }
                 supportFragmentManager.commit {
                     add(
@@ -365,18 +367,18 @@ data class DownloadFile(
 ) : Serializable {
     /** @return a filename with the provided extension */
     fun toFileName(extension: String): String = URLUtil.guessFileName(
-            this.url,
-            this.contentDisposition,
-            this.mimeType,
-        ).let { maybeCorruptFileName ->
-            // #17573: https://issuetracker.google.com/issues/382864232
-            // guessFileName may return ".bin" as an extension
-            (FileNameAndExtension.fromString(maybeCorruptFileName)
-            // default if maybeCorruptFileName doesn't contain a '.'
-            // Add randomness to avoid file name conflicts between different decks
-                ?: FileNameAndExtension.fromString("download-${Random.nextInt()}$extension")!!).replaceExtension(
-                    extension = extension
-                ) // enforce the provided extension
-                .toString()
-        }
+        this.url,
+        this.contentDisposition,
+        this.mimeType,
+    ).let { maybeCorruptFileName ->
+        // #17573: https://issuetracker.google.com/issues/382864232
+        // guessFileName may return ".bin" as an extension
+        (FileNameAndExtension.fromString(maybeCorruptFileName)
+        // default if maybeCorruptFileName doesn't contain a '.'
+        // Add randomness to avoid file name conflicts between different decks
+            ?: FileNameAndExtension.fromString("download-${Random.nextInt()}$extension")!!).replaceExtension(
+            extension = extension
+        ) // enforce the provided extension
+            .toString()
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -29,26 +29,24 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.fragment.app.commit
@@ -56,6 +54,7 @@ import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFI
 import com.ichi2.anki.SharedDecksActivity.Companion.MAX_REDIRECTS
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.compose.components.AnkiSearchBar
 import com.ichi2.anki.ui.compose.components.AnkiTopAppBar
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.utils.FileNameAndExtension
@@ -267,6 +266,12 @@ class SharedDecksActivity : AnkiActivity() {
             AnkiDroidTheme {
                 var isSearching by remember { mutableStateOf(false) }
                 var searchQuery by remember { mutableStateOf("") }
+                val searchFocusRequester = remember { FocusRequester() }
+                val searchAnim by animateFloatAsState(
+                    targetValue = if (isSearching) 1f else 0f,
+                    animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                    label = "searchAnim"
+                )
 
                 AnkiTopAppBar(
                     modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars),
@@ -280,43 +285,48 @@ class SharedDecksActivity : AnkiActivity() {
                         }
                     },
                     titleContent = {
-                        if (isSearching) {
-                            OutlinedTextField(
-                                value = searchQuery,
-                                onValueChange = { searchQuery = it },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(end = 16.dp),
-                                placeholder = { Text(getString(R.string.search_using_deck_name)) },
-                                singleLine = true,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                                keyboardActions = KeyboardActions(onSearch = {
-                                    webView.loadUrl(resources.getString(R.string.shared_decks_url) + searchQuery)
-                                    isSearching = false
-                                })
-                            )
-                        } else {
+                        if (!isSearching) {
                             Text(
                                 getString(R.string.download_deck),
                                 style = MaterialTheme.typography.displayMediumEmphasized,
-                                maxLines = 1
-                            )
+                                maxLines = 1,
+                                modifier = Modifier.graphicsLayer {
+                                    alpha = 1f - searchAnim
+                                })
                         }
                     },
                     actions = {
-                        if (!isSearching) {
-                            IconButton(onClick = { isSearching = true }) {
+                        if (isSearching) {
+                            AnkiSearchBar(
+                                query = searchQuery,
+                                onQueryChange = { searchQuery = it },
+                                onSearch = {
+                                    webView.loadUrl(resources.getString(R.string.shared_decks_url) + it)
+                                    isSearching = false
+                                },
+                                onActiveChange = { isSearching = it },
+                                placeholder = getString(R.string.search_using_deck_name),
+                                focusRequester = searchFocusRequester,
+                                searchAnim = searchAnim,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(start = 60.dp, end = 12.dp, bottom = 8.dp)
+                            )
+                        } else {
+                            IconButton(
+                                onClick = { isSearching = true },
+                                modifier = Modifier.graphicsLayer { alpha = 1f - searchAnim }) {
                                 Icon(
-                                    painter = painterResource(R.drawable.ic_search_white),
+                                    painter = painterResource(R.drawable.search_24px),
                                     contentDescription = getString(R.string.search_using_deck_name)
                                 )
                             }
                             IconButton(onClick = {
                                 shouldHistoryBeCleared = true
                                 webView.loadUrl(resources.getString(R.string.shared_decks_url))
-                            }) {
+                            }, modifier = Modifier.graphicsLayer { alpha = 1f - searchAnim }) {
                                 Icon(
-                                    painter = painterResource(R.drawable.home_icon),
+                                    painter = painterResource(R.drawable.home_24px),
                                     contentDescription = getString(R.string.home)
                                 )
                             }
@@ -337,8 +347,7 @@ class SharedDecksActivity : AnkiActivity() {
                 val sharedDecksDownloadFragment = SharedDecksDownloadFragment()
                 sharedDecksDownloadFragment.arguments = Bundle().apply {
                     putSerializable(
-                        DOWNLOAD_FILE,
-                        DownloadFile(url, userAgent, contentDisposition, mimetype)
+                        DOWNLOAD_FILE, DownloadFile(url, userAgent, contentDisposition, mimetype)
                     )
                 }
                 supportFragmentManager.commit {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -266,8 +267,8 @@ class SharedDecksActivity : AnkiActivity() {
         val composeView: ComposeView = findViewById(R.id.top_bar_compose_view)
         composeView.setContent {
             AnkiDroidTheme {
-                var isSearching by remember { mutableStateOf(false) }
-                var searchQuery by remember { mutableStateOf("") }
+                var isSearching by rememberSaveable { mutableStateOf(false) }
+                var searchQuery by rememberSaveable { mutableStateOf("") }
                 val searchFocusRequester = remember { FocusRequester() }
                 val searchAnim by animateFloatAsState(
                     targetValue = if (isSearching) 1f else 0f,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -301,7 +301,7 @@ class SharedDecksActivity : AnkiActivity() {
                                 searchAnim = searchAnim,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(60.dp)
+                                    .height(64.dp)
                                     .padding(end = 12.dp, bottom = 8.dp)
                             )
                         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -293,7 +293,11 @@ class SharedDecksActivity : AnkiActivity() {
                                 query = searchQuery,
                                 onQueryChange = { searchQuery = it },
                                 onSearch = {
-                                    webView.loadUrl(resources.getString(R.string.shared_decks_url) + it)
+                                    val searchUrl =
+                                        resources.getString(R.string.shared_decks_url).toUri()
+                                            .buildUpon().appendQueryParameter("search", it).build()
+                                            .toString()
+                                    webView.loadUrl(searchUrl)
                                     isSearching = false
                                 },
                                 onActiveChange = { isSearching = it },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -31,6 +31,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -285,17 +287,6 @@ class SharedDecksActivity : AnkiActivity() {
                         }
                     },
                     titleContent = {
-                        if (!isSearching) {
-                            Text(
-                                getString(R.string.download_deck),
-                                style = MaterialTheme.typography.displayMediumEmphasized,
-                                maxLines = 1,
-                                modifier = Modifier.graphicsLayer {
-                                    alpha = 1f - searchAnim
-                                })
-                        }
-                    },
-                    actions = {
                         if (isSearching) {
                             AnkiSearchBar(
                                 query = searchQuery,
@@ -309,10 +300,22 @@ class SharedDecksActivity : AnkiActivity() {
                                 focusRequester = searchFocusRequester,
                                 searchAnim = searchAnim,
                                 modifier = Modifier
-                                    .weight(1f)
-                                    .padding(start = 60.dp, end = 12.dp, bottom = 8.dp)
+                                    .fillMaxWidth()
+                                    .height(60.dp)
+                                    .padding(end = 12.dp, bottom = 8.dp)
                             )
                         } else {
+                            Text(
+                                getString(R.string.download_deck),
+                                style = MaterialTheme.typography.displayMediumEmphasized,
+                                maxLines = 1,
+                                modifier = Modifier.graphicsLayer {
+                                    alpha = 1f - searchAnim
+                                })
+                        }
+                    },
+                    actions = {
+                        if (!isSearching) {
                             IconButton(
                                 onClick = { isSearching = true },
                                 modifier = Modifier.graphicsLayer { alpha = 1f - searchAnim }) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -20,8 +20,27 @@ package com.ichi2.anki
 import android.app.DownloadManager
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
 import android.webkit.CookieManager
 import android.webkit.URLUtil
 import android.webkit.WebResourceError
@@ -31,17 +50,14 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.widget.SearchView
-import androidx.appcompat.widget.Toolbar
 import androidx.core.net.toUri
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.commit
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
 import com.ichi2.anki.SharedDecksActivity.Companion.MAX_REDIRECTS
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.ui.AccessibleSearchView
+import com.ichi2.anki.ui.compose.components.AnkiTopAppBar
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.utils.FileNameAndExtension
 import timber.log.Timber
 import java.io.Serializable
@@ -121,7 +137,7 @@ class SharedDecksActivity : AnkiActivity() {
         }
 
         /**
-         * Prevent the WebView from loading urls which arent needed for importing shared decks.
+         * Prevent the WebView from loading urls which aren't needed for importing shared decks.
          * This is to prevent potential misuse, such as bypassing content restrictions or
          * using the AnkiDroid WebView as a regular browser to bypass browser blocks,
          * which could lead to procrastination.
@@ -243,23 +259,72 @@ class SharedDecksActivity : AnkiActivity() {
 
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_shared_decks)
-        setTitle(R.string.download_deck)
-
-        val webviewToolbar: Toolbar = findViewById(R.id.webview_toolbar)
-        webviewToolbar.setTitleTextColor(getColor(R.color.white))
-
-        setSupportActionBar(webviewToolbar)
-
-        ViewCompat.setOnApplyWindowInsetsListener(webviewToolbar) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(v.paddingLeft, systemBars.top, v.paddingRight, v.paddingBottom)
-            insets
-        }
-
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        supportActionBar?.setDisplayShowHomeEnabled(true)
 
         webView = findViewById(R.id.media_check_webview)
+
+        val composeView: ComposeView = findViewById(R.id.top_bar_compose_view)
+        composeView.setContent {
+            AnkiDroidTheme {
+                var isSearching by remember { mutableStateOf(false) }
+                var searchQuery by remember { mutableStateOf("") }
+
+                AnkiTopAppBar(
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars),
+                    onNavigateUp = {
+                        if (isSearching) {
+                            isSearching = false
+                            searchQuery = ""
+                        } else {
+                            onBackPressedCallback.isEnabled = false
+                            onBackPressedDispatcher.onBackPressed()
+                        }
+                    },
+                    titleContent = {
+                        if (isSearching) {
+                            OutlinedTextField(
+                                value = searchQuery,
+                                onValueChange = { searchQuery = it },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(end = 16.dp),
+                                placeholder = { Text(getString(R.string.search_using_deck_name)) },
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                                keyboardActions = KeyboardActions(onSearch = {
+                                    webView.loadUrl(resources.getString(R.string.shared_decks_url) + searchQuery)
+                                    isSearching = false
+                                })
+                            )
+                        } else {
+                            Text(
+                                getString(R.string.download_deck),
+                                style = MaterialTheme.typography.displayMediumEmphasized,
+                                maxLines = 1
+                            )
+                        }
+                    },
+                    actions = {
+                        if (!isSearching) {
+                            IconButton(onClick = { isSearching = true }) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_search_white),
+                                    contentDescription = getString(R.string.search_using_deck_name)
+                                )
+                            }
+                            IconButton(onClick = {
+                                shouldHistoryBeCleared = true
+                                webView.loadUrl(resources.getString(R.string.shared_decks_url))
+                            }) {
+                                Icon(
+                                    painter = painterResource(R.drawable.home_icon),
+                                    contentDescription = getString(R.string.home)
+                                )
+                            }
+                        }
+                    }
+                )
+            }
+        }
 
         downloadManager = getSystemService(DOWNLOAD_SERVICE) as DownloadManager
 
@@ -286,40 +351,6 @@ class SharedDecksActivity : AnkiActivity() {
 
         webView.webViewClient = webViewClient
         onBackPressedDispatcher.addCallback(onBackPressedCallback)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.download_shared_decks_menu, menu)
-
-        val searchView = menu.findItem(R.id.search)?.actionView as AccessibleSearchView
-        searchView.queryHint = getString(R.string.search_using_deck_name)
-        searchView.setMaxWidth(Integer.MAX_VALUE)
-        searchView.setOnQueryTextListener(
-            object : SearchView.OnQueryTextListener {
-                override fun onQueryTextSubmit(query: String?): Boolean {
-                    webView.loadUrl(resources.getString(R.string.shared_decks_url) + query)
-                    return true
-                }
-
-                override fun onQueryTextChange(newText: String?): Boolean {
-                    // Nothing to do here
-                    return false
-                }
-            },
-        )
-        return true
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.home) {
-            // R.id.home refers to a custom 'home' menu item defined in your app resources (res/menu/...).
-            shouldHistoryBeCleared = true
-            webView.loadUrl(resources.getString(R.string.shared_decks_url))
-        } else if (item.itemId == android.R.id.home) {
-            // android.R.id.home refers to the system-provided "up" button in the app toolbar
-            onBackPressedCallback.isEnabled = false
-        }
-        return super.onOptionsItemSelected(item)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -173,6 +173,7 @@ class SharedDecksDownloadFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, onBackPressedCallback)
 
         val fileToBeDownloaded =
             arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE) ?: return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -87,7 +87,6 @@ class SharedDecksDownloadFragment : Fragment() {
 
     var isDownloadInProgress = false
 
-    private var downloadCancelConfirmationDialog: AlertDialog? = null
     private val onBackPressedCallback = object : OnBackPressedCallback(isDownloadInProgress) {
         override fun handleOnBackPressed() {
             showCancelConfirmationDialog()
@@ -153,6 +152,15 @@ class SharedDecksDownloadFragment : Fragment() {
                         state = state,
                         onNavigateUp = { activity?.onBackPressedDispatcher?.onBackPressed() },
                         onCancel = { showCancelConfirmationDialog() },
+                        onConfirmCancel = {
+                            uiState.update { it.copy(showCancelDialog = false) }
+                            downloadManager.remove(downloadId)
+                            unregisterReceiver()
+                            isDownloadInProgress = false
+                            onBackPressedCallback.isEnabled = isDownloadInProgress
+                            stopDownloadProgressChecker()
+                            parentFragmentManager.popBackStack()
+                        },
                         onRetry = {
                             downloadManager.remove(downloadId)
                             downloadFile(fileToBeDownloaded)
@@ -162,7 +170,9 @@ class SharedDecksDownloadFragment : Fragment() {
                             downloadManager.remove(downloadId)
                             openUrl(requireContext().getDeckPageUri(fileToBeDownloaded.url).toUri())
                             parentFragmentManager.popBackStack()
-                        })
+                        },
+                        onDismissCancelDialog = { uiState.update { it.copy(showCancelDialog = false) } }
+                    )
                 }
             }
         }
@@ -538,30 +548,9 @@ class SharedDecksDownloadFragment : Fragment() {
         unregisterReceiver()
         isDownloadInProgress = false
         onBackPressedCallback.isEnabled = isDownloadInProgress
-
-        // If the cancel confirmation dialog is being shown and the download is no longer in progress, then remove the dialog.
-        removeCancelConfirmationDialog()
     }
 
     private fun showCancelConfirmationDialog() {
-        downloadCancelConfirmationDialog = AlertDialog.Builder(requireContext()).create {
-            setTitle(R.string.cancel_download_question_title)
-            setPositiveButton(R.string.dialog_yes) { _, _ ->
-                downloadManager.remove(downloadId)
-                unregisterReceiver()
-                isDownloadInProgress = false
-                onBackPressedCallback.isEnabled = isDownloadInProgress
-                stopDownloadProgressChecker()
-                parentFragmentManager.popBackStack()
-            }
-            setNegativeButton(R.string.dialog_no) { _, _ ->
-                downloadCancelConfirmationDialog?.dismiss()
-            }
-        }
-        downloadCancelConfirmationDialog?.show()
-    }
-
-    private fun removeCancelConfirmationDialog() {
-        downloadCancelConfirmationDialog?.dismiss()
+        uiState.update { it.copy(showCancelDialog = true) }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -526,7 +526,7 @@ class SharedDecksDownloadFragment : Fragment() {
                 Timber.i("File is not a valid deck, hence return from the download screen")
                 context?.let { showThemedToast(it, R.string.import_log_no_apkg, false) }
                 // Go back if file is not a deck and cannot be imported
-                activity?.onBackPressedDispatcher?.onBackPressed()
+                parentFragmentManager.popBackStack()
             } else {
                 Timber.i("Download failed, update UI and provide option to retry")
                 context?.let { showThemedToast(it, R.string.something_wrong, false) }
@@ -551,7 +551,8 @@ class SharedDecksDownloadFragment : Fragment() {
                 unregisterReceiver()
                 isDownloadInProgress = false
                 onBackPressedCallback.isEnabled = isDownloadInProgress
-                activity?.onBackPressedDispatcher?.onBackPressed()
+                stopDownloadProgressChecker()
+                parentFragmentManager.popBackStack()
             }
             setNegativeButton(R.string.dialog_no) { _, _ ->
                 downloadCancelConfirmationDialog?.dismiss()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -34,12 +34,12 @@ import android.webkit.CookieManager
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
-import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
-import androidx.core.net.toUri
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.anki.snackbar.showSnackbar
@@ -48,12 +48,12 @@ import com.ichi2.anki.ui.compose.shareddecks.DownloadUiState
 import com.ichi2.anki.ui.compose.shareddecks.SharedDecksDownloadScreen
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.utils.openUrl
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.create
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import timber.log.Timber
 import java.io.File
 import java.net.URLConnection
@@ -88,12 +88,11 @@ class SharedDecksDownloadFragment : Fragment() {
     var isDownloadInProgress = false
 
     private var downloadCancelConfirmationDialog: AlertDialog? = null
-    private val onBackPressedCallback =
-        object : OnBackPressedCallback(isDownloadInProgress) {
-            override fun handleOnBackPressed() {
-                showCancelConfirmationDialog()
-            }
+    private val onBackPressedCallback = object : OnBackPressedCallback(isDownloadInProgress) {
+        override fun handleOnBackPressed() {
+            showCancelConfirmationDialog()
         }
+    }
 
     companion object {
         const val DOWNLOAD_PROGRESS_CHECK_DELAY = 1000L
@@ -121,11 +120,7 @@ class SharedDecksDownloadFragment : Fragment() {
          */
         @VisibleForTesting
         fun getDeckIdFromDownloadURL(downloadUrl: String) =
-            deckIdRegex
-                .find(downloadUrl)
-                ?.groups
-                ?.get(1)
-                ?.value
+            deckIdRegex.find(downloadUrl)?.groups?.get(1)?.value
 
         /**
          * Given the URI of a deck's download URL such as
@@ -145,15 +140,14 @@ class SharedDecksDownloadFragment : Fragment() {
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
                 AnkiDroidTheme {
                     val state by uiState.collectAsState()
-                    val fileToBeDownloaded = arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
+                    val fileToBeDownloaded =
+                        arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
                     SharedDecksDownloadScreen(
                         state = state,
                         onNavigateUp = { activity?.onBackPressedDispatcher?.onBackPressed() },
@@ -167,8 +161,7 @@ class SharedDecksDownloadFragment : Fragment() {
                             downloadManager.remove(downloadId)
                             openUrl(requireContext().getDeckPageUri(fileToBeDownloaded.url).toUri())
                             parentFragmentManager.popBackStack()
-                        }
-                    )
+                        })
                 }
             }
         }
@@ -231,7 +224,8 @@ class SharedDecksDownloadFragment : Fragment() {
         fileToBeDownloaded: DownloadFile,
         currentFileName: String,
     ): DownloadManager.Request {
-        val request: DownloadManager.Request = DownloadManager.Request(fileToBeDownloaded.url.toUri())
+        val request: DownloadManager.Request =
+            DownloadManager.Request(fileToBeDownloaded.url.toUri())
         request.setMimeType(fileToBeDownloaded.mimeType)
 
         val cookies = CookieManager.getInstance().getCookie(fileToBeDownloaded.url)
@@ -255,100 +249,112 @@ class SharedDecksDownloadFragment : Fragment() {
      * Registered in downloadFile() method.
      * When onReceive() is called, open the deck file in AnkiDroid to import it.
      */
-    private var onComplete: BroadcastReceiver =
-        object : BroadcastReceiver() {
-            override fun onReceive(
-                context: Context,
-                intent: Intent?,
-            ) {
-                Timber.i("Download might be complete now, verify and continue with import")
+    private var onComplete: BroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(
+            context: Context,
+            intent: Intent?,
+        ) {
+            Timber.i("Download might be complete now, verify and continue with import")
 
-                /**
-                 * @return Whether the data in the received data is an importable deck
-                 */
-                fun verifyDeckIsImportable(): Boolean {
-                    if (fileName == null) {
-                        // Send ACRA report
-                        CrashReportService.sendExceptionReport(
-                            "File name is null",
-                            "SharedDecksDownloadFragment::verifyDeckIsImportable",
-                        )
-                        return false
-                    }
-
-                    // Return if mDownloadId does not match with the ID of the completed download.
-                    if (downloadId != intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0)) {
-                        Timber.w("Download id did not match expected id. Ignoring this download completion")
-                        return false
-                    }
-
-                    stopDownloadProgressChecker()
-
-                    // Halt execution if file doesn't have extension as 'apkg' or 'colpkg'
-                    if (!ImportUtils.isFileAValidDeck(fileName!!)) {
-                        Timber.i("File does not have 'apkg' or 'colpkg' extension, abort the deck opening task")
-                        checkDownloadStatusAndUnregisterReceiver(isSuccessful = false, isInvalidDeckFile = true)
-                        return false
-                    }
-
-                    val query = DownloadManager.Query()
-                    query.setFilterById(downloadId)
-                    val cursor = downloadManager.query(query)
-
-                    cursor.use {
-                        // Return if cursor is empty.
-                        if (!it.moveToFirst()) {
-                            Timber.i("Empty cursor, cannot continue further with success check and deck import")
-                            checkDownloadStatusAndUnregisterReceiver(isSuccessful = false)
-                            return false
-                        }
-
-                        val columnStatusIndex: Int = it.getColumnIndex(DownloadManager.COLUMN_STATUS)
-                        val columnReasonIndex: Int = it.getColumnIndex(DownloadManager.COLUMN_REASON)
-
-                        // Return if download was not successful.
-                        if (it.getInt(columnStatusIndex) != DownloadManager.STATUS_SUCCESSFUL) {
-                            Timber.i("Download could not be successful, update UI and unregister receiver")
-                            Timber.d("Status code -> ${it.getIntOrNull(columnStatusIndex)}, reason ${it.getIntOrNull(columnReasonIndex)}")
-                            checkDownloadStatusAndUnregisterReceiver(isSuccessful = false)
-                            return false
-                        }
-                    }
-                    return true
+            /**
+             * @return Whether the data in the received data is an importable deck
+             */
+            fun verifyDeckIsImportable(): Boolean {
+                if (fileName == null) {
+                    // Send ACRA report
+                    CrashReportService.sendExceptionReport(
+                        "File name is null",
+                        "SharedDecksDownloadFragment::verifyDeckIsImportable",
+                    )
+                    return false
                 }
 
-                val verified =
-                    try {
-                        verifyDeckIsImportable()
-                    } catch (exception: Exception) {
-                        Timber.w(exception)
+                // Return if mDownloadId does not match with the ID of the completed download.
+                if (downloadId != intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0)) {
+                    Timber.w("Download id did not match expected id. Ignoring this download completion")
+                    return false
+                }
+
+                stopDownloadProgressChecker()
+
+                // Halt execution if file doesn't have extension as 'apkg' or 'colpkg'
+                if (!ImportUtils.isFileAValidDeck(fileName!!)) {
+                    Timber.i("File does not have 'apkg' or 'colpkg' extension, abort the deck opening task")
+                    checkDownloadStatusAndUnregisterReceiver(
+                        isSuccessful = false,
+                        isInvalidDeckFile = true
+                    )
+                    return false
+                }
+
+                val query = DownloadManager.Query()
+                query.setFilterById(downloadId)
+                val cursor = downloadManager.query(query)
+
+                cursor.use {
+                    // Return if cursor is empty.
+                    if (!it.moveToFirst()) {
+                        Timber.i("Empty cursor, cannot continue further with success check and deck import")
                         checkDownloadStatusAndUnregisterReceiver(isSuccessful = false)
-                        return
+                        return false
                     }
 
-                if (!verified) {
-                    // Could be a retryable fault (we received notification of another file)
-                    // Otherwise, checkDownloadStatusAndUnregisterReceiver should have been called
-                    // to update the UI
-                    return
+                    val columnStatusIndex: Int = it.getColumnIndex(DownloadManager.COLUMN_STATUS)
+                    val columnReasonIndex: Int = it.getColumnIndex(DownloadManager.COLUMN_REASON)
+
+                    // Return if download was not successful.
+                    if (it.getInt(columnStatusIndex) != DownloadManager.STATUS_SUCCESSFUL) {
+                        Timber.i("Download could not be successful, update UI and unregister receiver")
+                        Timber.d(
+                            "Status code -> ${it.getIntOrNull(columnStatusIndex)}, reason ${
+                                it.getIntOrNull(
+                                    columnReasonIndex
+                                )
+                            }"
+                        )
+                        checkDownloadStatusAndUnregisterReceiver(isSuccessful = false)
+                        return false
+                    }
                 }
-
-                if (isVisible) {
-                    // Setting these since progress checker can stop before progress is updated to represent 100%
-                    uiState.update { it.copy(
-                        progress = 100f,
-                        progressText = getString(R.string.percentage, DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE),
-                        status = DownloadStatus.Complete
-                    ) }
-                }
-
-                Timber.i("Opening downloaded deck for import")
-                openDownloadedDeck(context)
-
-                Timber.d("Checking download status and unregistering receiver")
-                checkDownloadStatusAndUnregisterReceiver(isSuccessful = true)
+                return true
             }
+
+            val verified = try {
+                verifyDeckIsImportable()
+            } catch (exception: Exception) {
+                Timber.w(exception)
+                checkDownloadStatusAndUnregisterReceiver(isSuccessful = false)
+                return
+            }
+
+            if (!verified) {
+                // Could be a retryable fault (we received notification of another file)
+                // Otherwise, checkDownloadStatusAndUnregisterReceiver should have been called
+                // to update the UI
+                return
+            }
+
+            if (isVisible) {
+                // Setting these since progress checker can stop before progress is updated to represent 100%
+                uiState.update {
+                    it.copy(
+                        progress = 100f,
+                        progressText = getString(
+                            R.string.percentage,
+                            DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE
+                        ),
+                        status = DownloadStatus.Complete
+                    )
+                }
+            }
+
+            Timber.i("Opening downloaded deck for import")
+            openDownloadedDeck(context)
+
+            Timber.d("Checking download status and unregistering receiver")
+            checkDownloadStatusAndUnregisterReceiver(isSuccessful = true)
         }
+    }
 
     /**
      * Safely retrieves the integer value from the cursor at the specified column index.
@@ -356,16 +362,15 @@ class SharedDecksDownloadFragment : Fragment() {
      * @param columnIndex The index of the column from which to retrieve the integer value.
      * @return The integer value from the cursor at the specified column index, or null if invalid or undefined.
      */
-    private fun Cursor?.getIntOrNull(columnIndex: Int): Int? =
-        try {
-            if (columnIndex != -1) {
-                this?.getInt(columnIndex)
-            } else {
-                null
-            }
-        } catch (_: Exception) {
+    private fun Cursor?.getIntOrNull(columnIndex: Int): Int? = try {
+        if (columnIndex != -1) {
+            this?.getInt(columnIndex)
+        } else {
             null
         }
+    } catch (_: Exception) {
+        null
+    }
 
     /**
      * Unregister the mOnComplete broadcast receiver.
@@ -407,10 +412,12 @@ class SharedDecksDownloadFragment : Fragment() {
         Timber.d("Starting download progress checker")
         downloadProgressChecker.run()
         isProgressCheckerRunning = true
-        uiState.update { it.copy(
-            progress = 0f,
-            progressText = getString(R.string.percentage, DOWNLOAD_STARTED_PROGRESS_PERCENTAGE)
-        ) }
+        uiState.update {
+            it.copy(
+                progress = 0f,
+                progressText = getString(R.string.percentage, DOWNLOAD_STARTED_PROGRESS_PERCENTAGE)
+            )
+        }
     }
 
     /**
@@ -438,7 +445,8 @@ class SharedDecksDownloadFragment : Fragment() {
             }
 
             // Calculate download progress and display it in the ProgressBar.
-            val downloadedBytes = it.getLong(it.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
+            val downloadedBytes =
+                it.getLong(it.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
             val totalBytes = it.getInt(it.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
             // Taking absolute value to prevent case of -0.0 % being shown.
             val downloadProgress: Float = abs(downloadedBytes * 1f / totalBytes * 100)
@@ -451,7 +459,7 @@ class SharedDecksDownloadFragment : Fragment() {
                     // Show download progress percentage up to 1 decimal place.
                     "%.1f".format(downloadProgress)
                 }
-            
+
             val columnIndexForStatus = it.getColumnIndex(DownloadManager.COLUMN_STATUS)
             val columnIndexForReason = it.getColumnIndex(DownloadManager.COLUMN_REASON)
 
@@ -460,8 +468,10 @@ class SharedDecksDownloadFragment : Fragment() {
                 return
             }
 
-            val isWaitingForNetwork = it.getInt(columnIndexForStatus) == DownloadManager.STATUS_PAUSED &&
-                it.getInt(columnIndexForReason) == DownloadManager.PAUSED_WAITING_FOR_NETWORK
+            val isWaitingForNetwork =
+                it.getInt(columnIndexForStatus) == DownloadManager.STATUS_PAUSED && it.getInt(
+                    columnIndexForReason
+                ) == DownloadManager.PAUSED_WAITING_FOR_NETWORK
 
             uiState.update { state ->
                 state.copy(
@@ -481,15 +491,14 @@ class SharedDecksDownloadFragment : Fragment() {
         val fileIntent = Intent(context, IntentHandler::class.java)
         fileIntent.action = Intent.ACTION_VIEW
 
-        val fileUri =
-            context?.let {
-                val sharedDecksPath = File(it.getExternalFilesDir(null), SHARED_DECKS_DOWNLOAD_FOLDER)
-                FileProvider.getUriForFile(
-                    it,
-                    it.applicationContext?.packageName + ".apkgfileprovider",
-                    File(sharedDecksPath, fileName.toString()),
-                )
-            }
+        val fileUri = context?.let {
+            val sharedDecksPath = File(it.getExternalFilesDir(null), SHARED_DECKS_DOWNLOAD_FOLDER)
+            FileProvider.getUriForFile(
+                it,
+                it.applicationContext?.packageName + ".apkgfileprovider",
+                File(sharedDecksPath, fileName.toString()),
+            )
+        }
         Timber.d("File URI -> $fileUri")
         fileIntent.setDataAndType(fileUri, mimeType)
         fileIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -535,20 +544,19 @@ class SharedDecksDownloadFragment : Fragment() {
     }
 
     private fun showCancelConfirmationDialog() {
-        downloadCancelConfirmationDialog =
-            AlertDialog.Builder(requireContext()).create {
-                setTitle(R.string.cancel_download_question_title)
-                setPositiveButton(R.string.dialog_yes) { _, _ ->
-                    downloadManager.remove(downloadId)
-                    unregisterReceiver()
-                    isDownloadInProgress = false
-                    onBackPressedCallback.isEnabled = isDownloadInProgress
-                    activity?.onBackPressedDispatcher?.onBackPressed()
-                }
-                setNegativeButton(R.string.dialog_no) { _, _ ->
-                    downloadCancelConfirmationDialog?.dismiss()
-                }
+        downloadCancelConfirmationDialog = AlertDialog.Builder(requireContext()).create {
+            setTitle(R.string.cancel_download_question_title)
+            setPositiveButton(R.string.dialog_yes) { _, _ ->
+                downloadManager.remove(downloadId)
+                unregisterReceiver()
+                isDownloadInProgress = false
+                onBackPressedCallback.isEnabled = isDownloadInProgress
+                activity?.onBackPressedDispatcher?.onBackPressed()
             }
+            setNegativeButton(R.string.dialog_no) { _, _ ->
+                downloadCancelConfirmationDialog?.dismiss()
+            }
+        }
         downloadCancelConfirmationDialog?.show()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -156,6 +156,7 @@ class SharedDecksDownloadFragment : Fragment() {
                     val fileToBeDownloaded = arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
                     SharedDecksDownloadScreen(
                         state = state,
+                        onNavigateUp = { activity?.onBackPressedDispatcher?.onBackPressed() },
                         onCancel = { showCancelConfirmationDialog() },
                         onRetry = {
                             downloadManager.remove(downloadId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -147,7 +147,8 @@ class SharedDecksDownloadFragment : Fragment() {
                 AnkiDroidTheme {
                     val state by uiState.collectAsState()
                     val fileToBeDownloaded =
-                        arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
+                        arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)
+                            ?: return@AnkiDroidTheme
                     SharedDecksDownloadScreen(
                         state = state,
                         onNavigateUp = { activity?.onBackPressedDispatcher?.onBackPressed() },
@@ -173,7 +174,8 @@ class SharedDecksDownloadFragment : Fragment() {
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        val fileToBeDownloaded = arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
+        val fileToBeDownloaded =
+            arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE) ?: return
         downloadManager = (activity as SharedDecksActivity).downloadManager
 
         downloadFile(fileToBeDownloaded)
@@ -281,8 +283,7 @@ class SharedDecksDownloadFragment : Fragment() {
                 if (!ImportUtils.isFileAValidDeck(fileName!!)) {
                     Timber.i("File does not have 'apkg' or 'colpkg' extension, abort the deck opening task")
                     checkDownloadStatusAndUnregisterReceiver(
-                        isSuccessful = false,
-                        isInvalidDeckFile = true
+                        isSuccessful = false, isInvalidDeckFile = true
                     )
                     return false
                 }
@@ -338,12 +339,9 @@ class SharedDecksDownloadFragment : Fragment() {
                 // Setting these since progress checker can stop before progress is updated to represent 100%
                 uiState.update {
                     it.copy(
-                        progress = 100f,
-                        progressText = getString(
-                            R.string.percentage,
-                            DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE
-                        ),
-                        status = DownloadStatus.Complete
+                        progress = 100f, progressText = getString(
+                            R.string.percentage, DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE
+                        ), status = DownloadStatus.Complete
                     )
                 }
             }
@@ -492,11 +490,12 @@ class SharedDecksDownloadFragment : Fragment() {
         fileIntent.action = Intent.ACTION_VIEW
 
         val fileUri = context?.let {
+            val currentFileName = fileName ?: return@let null
             val sharedDecksPath = File(it.getExternalFilesDir(null), SHARED_DECKS_DOWNLOAD_FOLDER)
             FileProvider.getUriForFile(
                 it,
                 it.applicationContext?.packageName + ".apkgfileprovider",
-                File(sharedDecksPath, fileName.toString()),
+                File(sharedDecksPath, currentFileName),
             )
         }
         Timber.d("File URI -> $fileUri")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -33,7 +33,6 @@ import android.view.ViewGroup
 import android.webkit.CookieManager
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -51,7 +50,6 @@ import com.ichi2.anki.utils.openUrl
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.utils.ImportUtils
-import com.ichi2.utils.create
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import timber.log.Timber
@@ -155,9 +153,7 @@ class SharedDecksDownloadFragment : Fragment() {
                         onConfirmCancel = {
                             uiState.update { it.copy(showCancelDialog = false) }
                             downloadManager.remove(downloadId)
-                            unregisterReceiver()
-                            isDownloadInProgress = false
-                            onBackPressedCallback.isEnabled = isDownloadInProgress
+                            resetDownloadState()
                             stopDownloadProgressChecker()
                             parentFragmentManager.popBackStack()
                         },
@@ -382,6 +378,15 @@ class SharedDecksDownloadFragment : Fragment() {
     }
 
     /**
+     * Resets the download state by unregistering the receiver and updating progress tracking flags.
+     */
+    private fun resetDownloadState() {
+        unregisterReceiver()
+        isDownloadInProgress = false
+        onBackPressedCallback.isEnabled = isDownloadInProgress
+    }
+
+    /**
      * Unregister the mOnComplete broadcast receiver.
      */
     private fun unregisterReceiver() {
@@ -545,9 +550,7 @@ class SharedDecksDownloadFragment : Fragment() {
             }
         }
 
-        unregisterReceiver()
-        isDownloadInProgress = false
-        onBackPressedCallback.isEnabled = isDownloadInProgress
+        resetDownloadState()
     }
 
     private fun showCancelConfirmationDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -157,6 +157,7 @@ class SharedDecksDownloadFragment : Fragment() {
                             stopDownloadProgressChecker()
                             parentFragmentManager.popBackStack()
                         },
+                        onDismissCancelDialog = { uiState.update { it.copy(showCancelDialog = false) } },
                         onRetry = {
                             downloadManager.remove(downloadId)
                             downloadFile(fileToBeDownloaded)
@@ -166,9 +167,7 @@ class SharedDecksDownloadFragment : Fragment() {
                             downloadManager.remove(downloadId)
                             openUrl(requireContext().getDeckPageUri(fileToBeDownloaded.url).toUri())
                             parentFragmentManager.popBackStack()
-                        },
-                        onDismissCancelDialog = { uiState.update { it.copy(showCancelDialog = false) } }
-                    )
+                        })
                 }
             }
         }
@@ -179,7 +178,10 @@ class SharedDecksDownloadFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, onBackPressedCallback)
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            onBackPressedCallback
+        )
 
         val fileToBeDownloaded =
             arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE) ?: return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -16,36 +16,23 @@
 
 package com.ichi2.anki.browser.compose
 
-// TODO: Re-enable NoteEditor in split view after migration is complete
-// import com.ichi2.anki.noteeditor.compose.NoteEditor
 import android.content.Intent
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.motionScheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SearchBar
-import androidx.compose.material3.SearchBarDefaults
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldColors
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,16 +44,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -79,22 +60,12 @@ import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.Statistics
 import com.ichi2.anki.preferences.PreferencesActivity
+import com.ichi2.anki.ui.compose.components.AnkiSearchBar
 import com.ichi2.anki.ui.compose.components.DeckSelector
 import com.ichi2.anki.ui.compose.navigation.AnkiNavigationRail
 import com.ichi2.anki.ui.compose.navigation.AppNavigationItem
 import com.ichi2.anki.utils.ext.showDialogFragment
 import kotlinx.coroutines.launch
-
-private val transparentTextFieldColors: @Composable () -> TextFieldColors = {
-    TextFieldDefaults.colors(
-        focusedIndicatorColor = Color.Transparent,
-        unfocusedIndicatorColor = Color.Transparent,
-        disabledIndicatorColor = Color.Transparent,
-        focusedContainerColor = Color.Transparent,
-        unfocusedContainerColor = Color.Transparent,
-        disabledContainerColor = Color.Transparent,
-    )
-}
 
 @OptIn(
     ExperimentalMaterial3Api::class,
@@ -131,8 +102,6 @@ fun CardBrowserLayout(
         targetValue = if (isSearchOpen) 1f else 0f,
         animationSpec = motionScheme.defaultEffectsSpec(),
     )
-    val density = LocalDensity.current
-    val searchOffsetPx = with(density) { (-8).dp.toPx() }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
     // Use an integer revision counter as an event-style trigger so that
@@ -151,6 +120,10 @@ fun CardBrowserLayout(
 
     LaunchedEffect(Unit) {
         availableDecks = viewModel.getAvailableDecks()
+    }
+
+    BackHandler(isSearchOpen) {
+        viewModel.collapseSearchQuery()
     }
 
     // Create Deck Dialog
@@ -243,74 +216,23 @@ fun CardBrowserLayout(
                     }
                 }, actions = {
                     if (isSearchOpen) {
-                        var textFieldValue by remember {
-                            mutableStateOf(
-                                TextFieldValue(
-                                    searchQuery,
-                                    selection = TextRange(0, searchQuery.length),
-                                ),
-                            )
-                        }
-
-                        LaunchedEffect(searchQuery) {
-                            if (textFieldValue.text != searchQuery) {
-                                textFieldValue = textFieldValue.copy(text = searchQuery)
-                            }
-                        }
-
-                        SearchBar(
-                            inputField = {
-                                TextField(
-                                    value = textFieldValue,
-                                    onValueChange = {
-                                        textFieldValue = it
-                                        viewModel.setSearchQuery(it.text)
-                                    },
-                                    placeholder = { Text(text = stringResource(R.string.card_browser_search_hint)) },
-                                    leadingIcon = {
-                                        Icon(
-                                            Icons.Default.Search,
-                                            contentDescription = stringResource(R.string.card_browser_search_hint),
-                                        )
-                                    },
-                                    trailingIcon = {
-                                        IconButton(onClick = { viewModel.collapseSearchQuery() }) {
-                                            Icon(
-                                                Icons.Default.Close,
-                                                contentDescription = stringResource(R.string.close),
-                                            )
-                                        }
-                                    },
-                                    colors = transparentTextFieldColors(),
-                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                                    keyboardActions = KeyboardActions(
-                                        onSearch = {
-                                            viewModel.search(textFieldValue.text)
-                                            keyboardController?.hide()
-                                        },
-                                    ),
-                                    singleLine = true,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .focusRequester(focusRequester)
-                                        .graphicsLayer {
-                                            alpha = searchAnim
-                                            translationY = searchOffsetPx * (1f - searchAnim)
-                                            scaleX = 0.98f + 0.02f * searchAnim
-                                            scaleY = 0.98f + 0.02f * searchAnim
-                                        },
-                                )
+                        AnkiSearchBar(
+                            query = searchQuery,
+                            onQueryChange = { viewModel.setSearchQuery(it) },
+                            onSearch = {
+                                viewModel.search(it)
+                                keyboardController?.hide()
                             },
-                            expanded = false,
-                            onExpandedChange = { },
+                            onActiveChange = { active ->
+                                if (!active) viewModel.collapseSearchQuery()
+                            },
+                            placeholder = stringResource(R.string.card_browser_search_hint),
+                            focusRequester = focusRequester,
+                            searchAnim = searchAnim,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(start = 10.dp, end = 6.dp, bottom = 16.dp),
-                            shape = SearchBarDefaults.inputFieldShape,
-                            colors = SearchBarDefaults.colors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                            ),
-                            content = { },
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                         )
                     } else {
                         FilledTonalIconButton(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.LinearProgressIndicator
@@ -62,9 +61,6 @@ import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.motionScheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SearchBar
-import androidx.compose.material3.SearchBarDefaults
-import androidx.compose.material3.SearchBarDefaults.InputField
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -85,10 +81,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -101,6 +95,7 @@ import com.ichi2.anki.SyncIconState
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 import com.ichi2.anki.libanki.sched.DeckNode
 import com.ichi2.anki.ui.compose.SnackbarPaddingBottom
+import com.ichi2.anki.ui.compose.components.AnkiSearchBar
 import com.ichi2.anki.ui.compose.components.ExpandableFab
 import com.ichi2.anki.ui.compose.components.ExpandableFabContainer
 import com.ichi2.anki.ui.compose.components.Scrim
@@ -351,8 +346,6 @@ private fun DeckPickerTopBar(
         targetValue = if (isSearchOpen) 1f else 0f,
         animationSpec = motionScheme.defaultEffectsSpec(),
     )
-    val density = LocalDensity.current
-    val searchOffsetPx = with(density) { (-8).dp.toPx() }
 
     BackHandler(isSearchOpen) {
         onSearchQueryChanged("")
@@ -390,56 +383,18 @@ private fun DeckPickerTopBar(
         },
         actions = {
             if (isSearchOpen) {
-                SearchBar(
-                    inputField = {
-                        LaunchedEffect(Unit) {
-                            searchFocusRequester.requestFocus()
-                        }
-                        InputField(
-                            query = searchQuery,
-                            onQueryChange = onSearchQueryChanged,
-                            onSearch = { /* Search is performed as user types */ },
-                            expanded = true,
-                            onExpandedChange = { },
-                            modifier = Modifier
-                                .weight(1f)
-                                .focusRequester(searchFocusRequester)
-                                .graphicsLayer {
-                                    alpha = searchAnim
-                                    translationY = searchOffsetPx * (1f - searchAnim)
-                                    scaleX = 0.98f + 0.02f * searchAnim
-                                    scaleY = 0.98f + 0.02f * searchAnim
-                                },
-                            placeholder = { Text(stringResource(R.string.search_decks)) },
-                            leadingIcon = {
-                                Icon(
-                                    painter = painterResource(R.drawable.search_24px),
-                                    contentDescription = stringResource(R.string.search_decks),
-                                )
-                            },
-                            trailingIcon = {
-                                IconButton(onClick = {
-                                    onSearchQueryChanged("")
-                                    onSearchOpenChange(false)
-                                }) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.close_24px),
-                                        contentDescription = stringResource(R.string.close),
-                                    )
-                                }
-                            },
-                        )
-                    },
-                    expanded = false,
-                    onExpandedChange = { },
+                AnkiSearchBar(
+                    query = searchQuery,
+                    onQueryChange = onSearchQueryChanged,
+                    onSearch = { /* Search is performed as user types */ },
+                    onActiveChange = onSearchOpenChange,
+                    placeholder = stringResource(R.string.search_decks),
+                    focusRequester = searchFocusRequester,
+                    searchAnim = searchAnim,
                     modifier = Modifier
                         .weight(1f)
-                        .padding(start = 16.dp, end = 12.dp)
-                        .graphicsLayer {
-                            alpha = searchAnim
-                        },
-                    shape = SearchBarDefaults.inputFieldShape,
-                    content = { },
+                        .padding(start = 16.dp, end = 12.dp),
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                 )
             } else {
                 Row(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebView.kt
@@ -88,8 +88,9 @@ fun PageWebView(
         contentWindowInsets = WindowInsets(0),
         topBar = {
             AnkiTopAppBar(
-                titleText = title, onNavigateUp = onNavigateUp, actions = { topBarActions?.invoke(this) }
-            )
+                titleText = title,
+                onNavigateUp = onNavigateUp,
+                actions = { topBarActions?.invoke(this) })
         },
     ) { padding ->
         Box(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebView.kt
@@ -28,15 +28,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CircularWavyProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -46,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,6 +52,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.compose.components.AnkiTopAppBar
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.themes.Themes
 import kotlinx.coroutines.flow.Flow
@@ -91,8 +87,8 @@ fun PageWebView(
     Scaffold(
         contentWindowInsets = WindowInsets(0),
         topBar = {
-            PageWebViewTopBar(
-                title = title, onNavigateUp = onNavigateUp, actions = topBarActions
+            AnkiTopAppBar(
+                titleText = title, onNavigateUp = onNavigateUp, actions = { topBarActions?.invoke(this) }
             )
         },
     ) { padding ->
@@ -217,42 +213,10 @@ private fun PageWebViewInternal(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun PageWebViewTopBar(
-    title: String?,
-    onNavigateUp: () -> Unit,
-    actions: @Composable (RowScope.() -> Unit)? = null,
-) {
-    TopAppBar(title = {
-        title?.let {
-            Text(
-                it, style = MaterialTheme.typography.displayMediumEmphasized, maxLines = 1
-            )
-        }
-    }, navigationIcon = {
-        FilledIconButton(
-            modifier = Modifier.padding(end = 8.dp),
-            onClick = onNavigateUp,
-            colors = IconButtonDefaults.filledIconButtonColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ),
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.arrow_back_24px),
-                contentDescription = stringResource(R.string.back),
-            )
-        }
-    }, actions = {
-        actions?.invoke(this)
-    })
-}
-
 @Preview
 @Composable
 private fun PageWebViewTopBarPreview() {
     AnkiDroidTheme {
-        PageWebViewTopBar(title = "Preview Title", onNavigateUp = {})
+        AnkiTopAppBar(titleText = "Preview Title", onNavigateUp = {})
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebView.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
@@ -53,7 +52,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ichi2.anki.R
 import com.ichi2.anki.ui.compose.components.AnkiTopAppBar
-import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.themes.Themes
 import kotlinx.coroutines.flow.Flow
 import timber.log.Timber
@@ -211,13 +209,5 @@ private fun PageWebViewInternal(
         if (hasError) {
             PageWebViewError()
         }
-    }
-}
-
-@Preview
-@Composable
-private fun PageWebViewTopBarPreview() {
-    AnkiDroidTheme {
-        AnkiTopAppBar(titleText = "Preview Title", onNavigateUp = {})
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiSearchBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiSearchBar.kt
@@ -1,0 +1,124 @@
+package com.ichi2.anki.ui.compose.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.SearchBarDefaults.InputField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ichi2.anki.R
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
+
+/**
+ * A shared search bar component that provides a consistent look and feel across the app.
+ *
+ * @param query The current search query.
+ * @param onQueryChange Called when the query changes.
+ * @param onSearch Called when the search is submitted.
+ * @param onActiveChange Called when the search bar becomes active or inactive.
+ * @param placeholder The placeholder text to display.
+ * @param focusRequester The focus requester for the search bar.
+ * @param modifier The modifier for the search bar.
+ * @param searchAnim The animation progress (0f to 1f) for opening/closing transitions.
+ * @param containerColor The background color of the search bar container.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnkiSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    onActiveChange: (Boolean) -> Unit,
+    placeholder: String,
+    focusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+    searchAnim: Float = 1f,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
+) {
+    val density = LocalDensity.current
+    val searchOffsetPx = with(density) { (-8).dp.toPx() }
+
+    SearchBar(
+        inputField = {
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+            InputField(
+                query = query,
+                onQueryChange = onQueryChange,
+                onSearch = onSearch,
+                expanded = true,
+                onExpandedChange = { },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .graphicsLayer {
+                        alpha = searchAnim
+                        translationY = searchOffsetPx * (1f - searchAnim)
+                        scaleX = 0.98f + 0.02f * searchAnim
+                        scaleY = 0.98f + 0.02f * searchAnim
+                    },
+                placeholder = { Text(placeholder) },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(R.drawable.search_24px),
+                        contentDescription = placeholder,
+                    )
+                },
+                trailingIcon = {
+                    IconButton(onClick = {
+                        onQueryChange("")
+                        onActiveChange(false)
+                    }) {
+                        Icon(
+                            painter = painterResource(R.drawable.close_24px),
+                            contentDescription = stringResource(R.string.close),
+                        )
+                    }
+                },
+            )
+        },
+        expanded = false,
+        onExpandedChange = { },
+        modifier = modifier
+            .graphicsLayer {
+                alpha = searchAnim
+            },
+        shape = SearchBarDefaults.inputFieldShape,
+        colors = SearchBarDefaults.colors(
+            containerColor = containerColor,
+        ),
+        content = { },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AnkiSearchBarPreview() {
+    AnkiDroidTheme {
+        AnkiSearchBar(
+            query = "Search query",
+            onQueryChange = {},
+            onSearch = {},
+            onActiveChange = {},
+            placeholder = "Search...",
+            focusRequester = remember { FocusRequester() }
+        )
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiSearchBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiSearchBar.kt
@@ -1,9 +1,6 @@
 package com.ichi2.anki.ui.compose.components
 
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -102,8 +99,8 @@ fun AnkiSearchBar(
             expanded = false,
             onExpandedChange = { },
             modifier = modifier.graphicsLayer {
-                    alpha = searchAnim
-                },
+                alpha = searchAnim
+            },
             shape = SearchBarDefaults.inputFieldShape,
             colors = SearchBarDefaults.colors(
                 containerColor = containerColor,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiSearchBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiSearchBar.kt
@@ -1,10 +1,14 @@
 package com.ichi2.anki.ui.compose.components
 
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarDefaults.InputField
@@ -54,58 +58,59 @@ fun AnkiSearchBar(
     val density = LocalDensity.current
     val searchOffsetPx = with(density) { (-8).dp.toPx() }
 
-    SearchBar(
-        inputField = {
-            LaunchedEffect(Unit) {
-                focusRequester.requestFocus()
-            }
-            InputField(
-                query = query,
-                onQueryChange = onQueryChange,
-                onSearch = onSearch,
-                expanded = true,
-                onExpandedChange = { },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester)
-                    .graphicsLayer {
-                        alpha = searchAnim
-                        translationY = searchOffsetPx * (1f - searchAnim)
-                        scaleX = 0.98f + 0.02f * searchAnim
-                        scaleY = 0.98f + 0.02f * searchAnim
-                    },
-                placeholder = { Text(placeholder) },
-                leadingIcon = {
-                    Icon(
-                        painter = painterResource(R.drawable.search_24px),
-                        contentDescription = placeholder,
-                    )
-                },
-                trailingIcon = {
-                    IconButton(onClick = {
-                        onQueryChange("")
-                        onActiveChange(false)
-                    }) {
+    ProvideTextStyle(MaterialTheme.typography.bodyLarge) {
+        SearchBar(
+            inputField = {
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+                InputField(
+                    query = query,
+                    onQueryChange = onQueryChange,
+                    onSearch = onSearch,
+                    expanded = true,
+                    onExpandedChange = { },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                        .graphicsLayer {
+                            alpha = searchAnim
+                            translationY = searchOffsetPx * (1f - searchAnim)
+                            scaleX = 0.98f + 0.02f * searchAnim
+                            scaleY = 0.98f + 0.02f * searchAnim
+                        },
+                    placeholder = { Text(placeholder) },
+                    leadingIcon = {
                         Icon(
-                            painter = painterResource(R.drawable.close_24px),
-                            contentDescription = stringResource(R.string.close),
+                            painter = painterResource(R.drawable.search_24px),
+                            contentDescription = placeholder,
                         )
-                    }
-                },
-            )
-        },
-        expanded = false,
-        onExpandedChange = { },
-        modifier = modifier
-            .graphicsLayer {
-                alpha = searchAnim
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = {
+                            onQueryChange("")
+                            onActiveChange(false)
+                        }) {
+                            Icon(
+                                painter = painterResource(R.drawable.close_24px),
+                                contentDescription = stringResource(R.string.close),
+                            )
+                        }
+                    },
+                )
             },
-        shape = SearchBarDefaults.inputFieldShape,
-        colors = SearchBarDefaults.colors(
-            containerColor = containerColor,
-        ),
-        content = { },
-    )
+            expanded = false,
+            onExpandedChange = { },
+            modifier = modifier.graphicsLayer {
+                    alpha = searchAnim
+                },
+            shape = SearchBarDefaults.inputFieldShape,
+            colors = SearchBarDefaults.colors(
+                containerColor = containerColor,
+            ),
+            content = { },
+        )
+    }
 }
 
 @Preview(showBackground = true)
@@ -118,7 +123,6 @@ private fun AnkiSearchBarPreview() {
             onSearch = {},
             onActiveChange = {},
             placeholder = "Search...",
-            focusRequester = remember { FocusRequester() }
-        )
+            focusRequester = remember { FocusRequester() })
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.ichi2.anki.R
 
@@ -26,7 +27,10 @@ fun AnkiTopAppBar(
     titleContent: @Composable () -> Unit = {
         titleText?.let {
             Text(
-                text = it, style = MaterialTheme.typography.displayMediumEmphasized, maxLines = 1
+                text = it,
+                style = MaterialTheme.typography.displayMediumEmphasized,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
@@ -84,23 +84,19 @@ private fun AnkiTopAppBarLongTitlePreview() {
 @Composable
 private fun AnkiTopAppBarWithActionsPreview() {
     AnkiDroidTheme {
-        AnkiTopAppBar(
-            titleText = "AnkiDroid",
-            onNavigateUp = {},
-            actions = {
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = painterResource(R.drawable.star_24px),
-                        contentDescription = "Star",
-                    )
-                }
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = painterResource(R.drawable.download_24px),
-                        contentDescription = "Download",
-                    )
-                }
+        AnkiTopAppBar(titleText = "AnkiDroid", onNavigateUp = {}, actions = {
+            IconButton(onClick = {}) {
+                Icon(
+                    painter = painterResource(R.drawable.star_24px),
+                    contentDescription = "Star",
+                )
             }
-        )
+            IconButton(onClick = {}) {
+                Icon(
+                    painter = painterResource(R.drawable.download_24px),
+                    contentDescription = "Download",
+                )
+            }
+        })
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
@@ -1,0 +1,52 @@
+package com.ichi2.anki.ui.compose.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ichi2.anki.R
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun AnkiTopAppBar(
+    onNavigateUp: () -> Unit,
+    modifier: Modifier = Modifier,
+    titleText: String? = null,
+    titleContent: @Composable () -> Unit = {
+        titleText?.let {
+            Text(
+                text = it, style = MaterialTheme.typography.displayMediumEmphasized, maxLines = 1
+            )
+        }
+    },
+    actions: @Composable (RowScope.() -> Unit) = {},
+) {
+    TopAppBar(
+        modifier = modifier, title = titleContent, navigationIcon = {
+            FilledIconButton(
+                modifier = Modifier.padding(end = 8.dp),
+                onClick = onNavigateUp,
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.arrow_back_24px),
+                    contentDescription = stringResource(R.string.back),
+                )
+            }
+        }, actions = actions
+    )
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiTopAppBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -15,8 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -53,4 +56,51 @@ fun AnkiTopAppBar(
             }
         }, actions = actions
     )
+}
+
+@Preview(name = "AnkiTopAppBar - Short Title", showBackground = true)
+@Composable
+private fun AnkiTopAppBarShortTitlePreview() {
+    AnkiDroidTheme {
+        AnkiTopAppBar(
+            titleText = "AnkiDroid",
+            onNavigateUp = {},
+        )
+    }
+}
+
+@Preview(name = "AnkiTopAppBar - Long Title", showBackground = true)
+@Composable
+private fun AnkiTopAppBarLongTitlePreview() {
+    AnkiDroidTheme {
+        AnkiTopAppBar(
+            titleText = "This is a very long title that should be elided if it doesn't fit in the screen",
+            onNavigateUp = {},
+        )
+    }
+}
+
+@Preview(name = "AnkiTopAppBar - With Actions", showBackground = true)
+@Composable
+private fun AnkiTopAppBarWithActionsPreview() {
+    AnkiDroidTheme {
+        AnkiTopAppBar(
+            titleText = "AnkiDroid",
+            onNavigateUp = {},
+            actions = {
+                IconButton(onClick = {}) {
+                    Icon(
+                        painter = painterResource(R.drawable.star_24px),
+                        contentDescription = "Star",
+                    )
+                }
+                IconButton(onClick = {}) {
+                    Icon(
+                        painter = painterResource(R.drawable.download_24px),
+                        contentDescription = "Download",
+                    )
+                }
+            }
+        )
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -59,6 +58,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.compose.components.AnkiTopAppBar
 import com.ichi2.anki.ui.compose.components.RoundedPolygonShape
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.ui.compose.theme.RobotoMono
@@ -82,6 +82,7 @@ data class DownloadUiState(
 @Composable
 fun SharedDecksDownloadScreen(
     state: DownloadUiState,
+    onNavigateUp: () -> Unit,
     onCancel: () -> Unit,
     onRetry: () -> Unit,
     onImport: () -> Unit,
@@ -89,9 +90,7 @@ fun SharedDecksDownloadScreen(
 ) {
     Scaffold(
         contentWindowInsets = WindowInsets(0), topBar = {
-            TopAppBar(title = { }, navigationIcon = {
-                // Back handled by the fragment's onBackPressedCallback or cancel button
-            })
+            AnkiTopAppBar(onNavigateUp = onNavigateUp)
         }) { innerPadding ->
         Column(
             modifier = Modifier
@@ -355,7 +354,7 @@ fun SharedDecksDownloadScreenPreview() {
             progress = 45f,
             progressText = "45.2%",
             status = DownloadStatus.Downloading
-        ), onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
+        ), onNavigateUp = {}, onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
     }
 }
 
@@ -366,7 +365,7 @@ fun SharedDecksDownloadScreenFailedPreview() {
         SharedDecksDownloadScreen(
             state = DownloadUiState(
             fileName = "Medical Terminology.apkg", status = DownloadStatus.Failed
-        ), onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
+        ), onNavigateUp = {}, onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
     }
 }
 
@@ -380,7 +379,7 @@ fun SharedDecksDownloadScreenCompletePreview() {
             progress = 100f,
             progressText = "100%",
             status = DownloadStatus.Complete
-        ), onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
+        ), onNavigateUp = {}, onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -88,31 +88,25 @@ fun SharedDecksDownloadScreen(
     onNavigateUp: () -> Unit,
     onCancel: () -> Unit,
     onConfirmCancel: () -> Unit,
+    onDismissCancelDialog: () -> Unit,
     onRetry: () -> Unit,
     onImport: () -> Unit,
     onOpenInBrowser: () -> Unit,
-    onDismissCancelDialog: () -> Unit,
 ) {
     if (state.showCancelDialog) {
-        AlertDialog(
-            onDismissRequest = onDismissCancelDialog,
-            title = {
-                Text(text = stringResource(R.string.cancel_download_question_title))
-            },
-            text = {
-                Text(text = stringResource(R.string.cancel_download_explanation))
-            },
-            confirmButton = {
-                TextButton(onClick = onConfirmCancel) {
-                    Text(stringResource(R.string.dialog_yes))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = onDismissCancelDialog) {
-                    Text(stringResource(R.string.dialog_no))
-                }
+        AlertDialog(onDismissRequest = onDismissCancelDialog, title = {
+            Text(text = stringResource(R.string.cancel_download_question_title))
+        }, text = {
+            Text(text = stringResource(R.string.cancel_download_explanation))
+        }, confirmButton = {
+            TextButton(onClick = onConfirmCancel) {
+                Text(stringResource(R.string.dialog_yes))
             }
-        )
+        }, dismissButton = {
+            TextButton(onClick = onDismissCancelDialog) {
+                Text(stringResource(R.string.dialog_no))
+            }
+        })
     }
 
     Scaffold(
@@ -385,10 +379,10 @@ fun SharedDecksDownloadScreenPreview() {
             onNavigateUp = {},
             onCancel = {},
             onConfirmCancel = {},
+            onDismissCancelDialog = {},
             onRetry = {},
             onImport = {},
-            onOpenInBrowser = {},
-            onDismissCancelDialog = {})
+            onOpenInBrowser = {})
     }
 }
 
@@ -403,10 +397,10 @@ fun SharedDecksDownloadScreenFailedPreview() {
             onNavigateUp = {},
             onCancel = {},
             onConfirmCancel = {},
+            onDismissCancelDialog = {},
             onRetry = {},
             onImport = {},
-            onOpenInBrowser = {},
-            onDismissCancelDialog = {})
+            onOpenInBrowser = {})
     }
 }
 
@@ -424,10 +418,10 @@ fun SharedDecksDownloadScreenCompletePreview() {
             onNavigateUp = {},
             onCancel = {},
             onConfirmCancel = {},
+            onDismissCancelDialog = {},
             onRetry = {},
             onImport = {},
-            onOpenInBrowser = {},
-            onDismissCancelDialog = {})
+            onOpenInBrowser = {})
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularWavyProgressIndicator
@@ -45,6 +46,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -75,7 +77,8 @@ data class DownloadUiState(
     val fileName: String = "",
     val progress: Float = 0f,
     val progressText: String = "0%",
-    val status: DownloadStatus = DownloadStatus.Idle
+    val status: DownloadStatus = DownloadStatus.Idle,
+    val showCancelDialog: Boolean = false
 )
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -84,10 +87,34 @@ fun SharedDecksDownloadScreen(
     state: DownloadUiState,
     onNavigateUp: () -> Unit,
     onCancel: () -> Unit,
+    onConfirmCancel: () -> Unit,
     onRetry: () -> Unit,
     onImport: () -> Unit,
-    onOpenInBrowser: () -> Unit
+    onOpenInBrowser: () -> Unit,
+    onDismissCancelDialog: () -> Unit,
 ) {
+    if (state.showCancelDialog) {
+        AlertDialog(
+            onDismissRequest = onDismissCancelDialog,
+            title = {
+                Text(text = stringResource(R.string.cancel_download_question_title))
+            },
+            text = {
+                Text(text = stringResource(R.string.cancel_download_explanation))
+            },
+            confirmButton = {
+                TextButton(onClick = onConfirmCancel) {
+                    Text(stringResource(R.string.dialog_yes))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissCancelDialog) {
+                    Text(stringResource(R.string.dialog_no))
+                }
+            }
+        )
+    }
+
     Scaffold(
         contentWindowInsets = WindowInsets(0), topBar = {
             AnkiTopAppBar(onNavigateUp = onNavigateUp)
@@ -354,7 +381,14 @@ fun SharedDecksDownloadScreenPreview() {
             progress = 45f,
             progressText = "45.2%",
             status = DownloadStatus.Downloading
-        ), onNavigateUp = {}, onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
+        ),
+            onNavigateUp = {},
+            onCancel = {},
+            onConfirmCancel = {},
+            onRetry = {},
+            onImport = {},
+            onOpenInBrowser = {},
+            onDismissCancelDialog = {})
     }
 }
 
@@ -365,7 +399,14 @@ fun SharedDecksDownloadScreenFailedPreview() {
         SharedDecksDownloadScreen(
             state = DownloadUiState(
             fileName = "Medical Terminology.apkg", status = DownloadStatus.Failed
-        ), onNavigateUp = {}, onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
+        ),
+            onNavigateUp = {},
+            onCancel = {},
+            onConfirmCancel = {},
+            onRetry = {},
+            onImport = {},
+            onOpenInBrowser = {},
+            onDismissCancelDialog = {})
     }
 }
 
@@ -379,7 +420,14 @@ fun SharedDecksDownloadScreenCompletePreview() {
             progress = 100f,
             progressText = "100%",
             status = DownloadStatus.Complete
-        ), onNavigateUp = {}, onCancel = {}, onRetry = {}, onImport = {}, onOpenInBrowser = {})
+        ),
+            onNavigateUp = {},
+            onCancel = {},
+            onConfirmCancel = {},
+            onRetry = {},
+            onImport = {},
+            onOpenInBrowser = {},
+            onDismissCancelDialog = {})
     }
 }
 

--- a/AnkiDroid/src/main/res/drawable/home_24px.xml
+++ b/AnkiDroid/src/main/res/drawable/home_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M160,760L160,400Q160,381 168.5,364Q177,347 192,336L432,156Q453,140 480,140Q507,140 528,156L768,336Q783,347 791.5,364Q800,381 800,400L800,760Q800,793 776.5,816.5Q753,840 720,840L600,840Q583,840 571.5,828.5Q560,817 560,800L560,600Q560,583 548.5,571.5Q537,560 520,560L440,560Q423,560 411.5,571.5Q400,583 400,600L400,800Q400,817 388.5,828.5Q377,840 360,840L240,840Q207,840 183.5,816.5Q160,793 160,760Z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/activity_shared_decks.xml
+++ b/AnkiDroid/src/main/res/layout/activity_shared_decks.xml
@@ -11,14 +11,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/webview_toolbar"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/top_bar_compose_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ActionBarStyle"
-        android:background="?attr/appBarColor"
-        app:popupTheme="@style/ActionBar.Popup"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -29,7 +25,7 @@
         android:layout_height="0dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/webview_toolbar"
+        app:layout_constraintTop_toBottomOf="@id/top_bar_compose_view"
         app:layout_constraintBottom_toBottomOf="parent" />
     
     <FrameLayout

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -313,6 +313,7 @@
     <string name="try_again">Try Again</string>
     <string name="cancel_download">Cancel download</string>
     <string name="cancel_download_question_title">Cancel download?</string>
+    <string name="cancel_download_explanation">The download progress will be lost. Do you want to stop?</string>
     <string name="downloading_file">Downloading %s</string>
     <string name="import_deck">Import Deck</string>
     <string name="something_wrong">Something went wrong, please try again</string>


### PR DESCRIPTION
This pull request refactors the `SharedDecksActivity` and `SharedDecksDownloadFragment` to modernize the UI using Jetpack Compose and improve code readability and maintainability. The most significant changes are the replacement of the traditional toolbar and menu-based search with a Compose-based top app bar and search bar, as well as various code cleanups and minor improvements.

**UI Modernization and Compose Integration:**

* Replaces the traditional `Toolbar` and menu-based search in `SharedDecksActivity` with a Compose-based `AnkiTopAppBar` and `AnkiSearchBar`, moving all top bar and search logic into Compose. The activity now uses a `ComposeView` for rendering the top bar and actions, providing a more modern and flexible UI. (`AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt`) [[1]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L23-L24) [[2]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L34-R61) [[3]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L246-L262) [[4]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L290-L323)
* Removes all references to `Toolbar`, `SearchView`, and related menu inflation and handling, as these are now handled by Compose components. (`AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt`) [[1]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L246-L262) [[2]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L290-L323)

**Code Cleanup and Minor Improvements:**

* Cleans up imports and formatting in both `SharedDecksActivity` and `SharedDecksDownloadFragment` for better readability. (`AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt`, `AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt`) [[1]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L23-L24) [[2]](diffhunk://#diff-634b2ad9d86d1ea10fcffd0bc29a882caec65b25985cd56be53c9d27414ce8f8L34-R61) [[3]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL37-R42) [[4]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL51-R56)
* Refactors multi-line function calls and lambda expressions for conciseness and clarity throughout `SharedDecksDownloadFragment`. (`AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt`) [[1]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL124-R123) [[2]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL148-R153) [[3]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL169-R164) [[4]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL233-R228) [[5]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL257-R252) [[6]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL289-R286) [[7]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL311-R322) [[8]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL337-R348) [[9]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL358-R365) [[10]](diffhunk://#diff-b7c26ae29c4c7c72c67fec7b37b082ff32f984157167dfd912214d341ed08bdfL409-R420)
* Fixes a typo in a comment ("arent" → "aren't"). (`AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt`)

These changes collectively modernize the shared decks UI, streamline the code, and set the stage for further Compose-based improvements.

Addresses #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable search bar and top app bar components; search integrated into Shared Decks with updated visuals and animations.
  * Cancel-download confirmation dialog added to download screen.

* **Refactor**
  * Modernized UI to Jetpack Compose and consolidated top-bar/search across multiple screens.

* **Bug Fixes**
  * Improved back/up behavior and hardened download/navigation flows; safer handling of missing data.

* **Chore**
  * Added a new home icon drawable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->