### PR TITLE
Enhance timebox handling and testing in ReviewerViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -114,7 +114,6 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import kotlin.coroutines.resume
 
-@NeedsTest("#14709: Timebox shouldn't appear instantly when the Reviewer is opened")
 open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
     override var currentCard: Card?
         get() = viewModel.currentCardFlow.value
@@ -381,7 +380,6 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
             }
             viewModel.onEvent(ReviewerEvent.OnVoicePlaybackStateChanged(voicePlaybackViewModel.isVisible.value))
 
-            withCol { startTimebox() }
             updateCardAndRedraw()
         }
         disableDrawerSwipeOnConflicts()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -279,7 +279,10 @@ class ReviewerViewModel(app: Application) : AndroidViewModel(app), PostRequestHa
         when (event) {
             is ReviewerEvent.ShowAnswer -> showAnswer()
             is ReviewerEvent.RateCard -> rateCard(event.rating)
-            is ReviewerEvent.LoadInitialCard -> loadCard()
+            is ReviewerEvent.LoadInitialCard -> launchCardAction {
+                withCol { startTimebox() }
+                loadCardSuspend()
+            }
             is ReviewerEvent.OnTypedAnswerChanged -> onTypedAnswerChanged(event.newText)
             is ReviewerEvent.ToggleMark -> toggleMark()
             is ReviewerEvent.SetFlag -> setFlag(event.flag)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
@@ -8,7 +8,6 @@ import app.cash.turbine.test
 import com.ichi2.anki.RobolectricTest
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -68,21 +67,11 @@ class ReviewerViewModelTimeboxTest : RobolectricTest() {
             // We use a loop with awaitItem to find the specific effect.
             // This is more robust than cancelAndConsumeRemainingEvents() which might miss the event
             // if it hasn't been emitted yet (even with advanceUntilIdle).
-            var hasDialog = false
             // ReviewerViewModel might emit other effects (like ReplayMedia) during reload.
             // Turbine will time out if we wait too long without receiving the expected event.
-            try {
-                while (true) {
-                    val effect = awaitItem()
-                    if (effect is ReviewerEffect.ShowTimeboxReachedDialog) {
-                        hasDialog = true
-                        break
-                    }
-                }
-            } catch (_: Throwable) {
-                // If it times out or flow closes, hasDialog remains false
+            while (awaitItem() !is ReviewerEffect.ShowTimeboxReachedDialog) {
+                // Ignore other effects until we find the dialog reached event
             }
-            assertTrue("Timebox dialog SHOULD appear after limit is exceeded", hasDialog)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
@@ -1,0 +1,61 @@
+package com.ichi2.anki.reviewer
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.time.Time
+import com.ichi2.anki.common.time.TimeManager
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReviewerViewModelTimeboxTest : RobolectricTest() {
+    override fun getCollectionStorageMode() = CollectionStorageMode.IN_MEMORY_WITH_MEDIA
+
+    @Test
+    fun `timebox dialog does not appear because startTimebox is called during LoadInitialCard`() =
+        runTest {
+            // Mock time to 1000 seconds.
+            // If startTimebox hadn't been called, elapsed would be 1000 - 0 = 1000 > 300.
+            val mockTime = object : Time() {
+                override fun intTimeMS(): Long = 1000000L
+            }
+            TimeManager.resetWith(mockTime)
+
+            try {
+                // Given we have a card and a time limit of 5 minutes (300 seconds)
+                addBasicNote("Front", "Back")
+                col.config.set("timeLim", 300)
+
+                // And the ViewModel is initialized
+                var timeboxDialogEmitCount = 0
+                val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+
+                val job = launch {
+                    viewModel.effect.collect { effect ->
+                        if (effect is ReviewerEffect.ShowTimeboxReachedDialog) {
+                            timeboxDialogEmitCount++
+                        }
+                    }
+                }
+
+                // When we process the initial load
+                advanceRobolectricLooper()
+                advanceUntilIdle()
+
+                // Then no timebox dialog should have been emitted because startTimebox() was called at t=1000
+                // and the timer was reset to the current time.
+                assertEquals(
+                    "Timebox dialog should not appear initially",
+                    0,
+                    timeboxDialogEmitCount
+                )
+                job.cancel()
+            } finally {
+                TimeManager.reset()
+            }
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
@@ -1,13 +1,10 @@
 package com.ichi2.anki.reviewer
 
+import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.common.time.Time
-import com.ichi2.anki.common.time.TimeManager
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.advanceUntilIdle
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -18,44 +15,27 @@ class ReviewerViewModelTimeboxTest : RobolectricTest() {
     @Test
     fun `timebox dialog does not appear because startTimebox is called during LoadInitialCard`() =
         runTest {
-            // Mock time to 1000 seconds.
-            // If startTimebox hadn't been called, elapsed would be 1000 - 0 = 1000 > 300.
-            val mockTime = object : Time() {
-                override fun intTimeMS(): Long = 1000000L
-            }
-            TimeManager.resetWith(mockTime)
+            // Given we have a card
+            addBasicNote("Front", "Back")
 
-            try {
-                // Given we have a card and a time limit of 5 minutes (300 seconds)
-                addBasicNote("Front", "Back")
-                col.config.set("timeLim", 300)
+            // And a time limit of 5 minutes (300 seconds)
+            col.config.set("timeLim", 300)
 
-                // And the ViewModel is initialized
-                var timeboxDialogEmitCount = 0
-                val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            // And we mock the current time to 1000 seconds
+            collectionTime.addS(1000)
 
-                val job = launch {
-                    viewModel.effect.collect { effect ->
-                        if (effect is ReviewerEffect.ShowTimeboxReachedDialog) {
-                            timeboxDialogEmitCount++
-                        }
-                    }
-                }
+            // When the ViewModel is initialized
+            val app = ApplicationProvider.getApplicationContext<Application>()
+            val viewModel = ReviewerViewModel(app)
 
-                // When we process the initial load
+            // Then no timebox dialog should have been emitted because startTimebox()
+            // is called during LoadInitialCard, which resets the timer to current time.
+            viewModel.effect.test {
+                // Process the LoadInitialCard event triggered in init
                 advanceRobolectricLooper()
-                advanceUntilIdle()
 
-                // Then no timebox dialog should have been emitted because startTimebox() was called at t=1000
-                // and the timer was reset to the current time.
-                assertEquals(
-                    "Timebox dialog should not appear initially",
-                    0,
-                    timeboxDialogEmitCount
-                )
-                job.cancel()
-            } finally {
-                TimeManager.reset()
+                // expectNoEvents() ensures that the flow is silent and no Timebox dialog was emitted.
+                expectNoEvents()
             }
         }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTimeboxTest.kt
@@ -3,8 +3,12 @@ package com.ichi2.anki.reviewer
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.Event
 import app.cash.turbine.test
 import com.ichi2.anki.RobolectricTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -15,13 +19,11 @@ class ReviewerViewModelTimeboxTest : RobolectricTest() {
     @Test
     fun `timebox dialog does not appear because startTimebox is called during LoadInitialCard`() =
         runTest {
-            // Given we have a card
+            // Given we have a card and a 5-minute limit
             addBasicNote("Front", "Back")
-
-            // And a time limit of 5 minutes (300 seconds)
             col.config.set("timeLim", 300)
 
-            // And we mock the current time to 1000 seconds
+            // And we mock the current time to 1000 seconds BEFORE initialization
             collectionTime.addS(1000)
 
             // When the ViewModel is initialized
@@ -29,13 +31,59 @@ class ReviewerViewModelTimeboxTest : RobolectricTest() {
             val viewModel = ReviewerViewModel(app)
 
             // Then no timebox dialog should have been emitted because startTimebox()
-            // is called during LoadInitialCard, which resets the timer to current time.
+            // is called during LoadInitialCard, resetting the start time to 1000.
             viewModel.effect.test {
-                // Process the LoadInitialCard event triggered in init
+                advanceUntilIdle()
                 advanceRobolectricLooper()
 
-                // expectNoEvents() ensures that the flow is silent and no Timebox dialog was emitted.
-                expectNoEvents()
+                val events = cancelAndConsumeRemainingEvents()
+                val hasDialog = events.filterIsInstance<Event.Item<ReviewerEffect>>()
+                    .any { it.value is ReviewerEffect.ShowTimeboxReachedDialog }
+                assertFalse("Timebox dialog should NOT appear initially", hasDialog)
             }
         }
+
+    @Test
+    fun `timebox dialog appears when limit is reached after initialization`() = runTest {
+        // Given we have a card and a 5-minute limit
+        addBasicNote("Front", "Back")
+        col.config.set("timeLim", 300)
+
+        // Initialize ViewModel (resets timebox start time to current collectionTime)
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val viewModel = ReviewerViewModel(app)
+        advanceUntilIdle()
+
+        // When we advance time significantly (1000 seconds)
+        collectionTime.addS(1000)
+
+        // And trigger a card reload which checks the timebox status
+        viewModel.effect.test {
+            viewModel.onEvent(ReviewerEvent.ReloadCard)
+
+            // Ensure all coroutines and looper tasks complete
+            advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            // We use a loop with awaitItem to find the specific effect.
+            // This is more robust than cancelAndConsumeRemainingEvents() which might miss the event
+            // if it hasn't been emitted yet (even with advanceUntilIdle).
+            var hasDialog = false
+            // ReviewerViewModel might emit other effects (like ReplayMedia) during reload.
+            // Turbine will time out if we wait too long without receiving the expected event.
+            try {
+                while (true) {
+                    val effect = awaitItem()
+                    if (effect is ReviewerEffect.ShowTimeboxReachedDialog) {
+                        hasDialog = true
+                        break
+                    }
+                }
+            } catch (_: Throwable) {
+                // If it times out or flow closes, hasDialog remains false
+            }
+            assertTrue("Timebox dialog SHOULD appear after limit is exceeded", hasDialog)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }

--- a/common/src/main/java/com/ichi2/anki/common/time/MockTime.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/MockTime.kt
@@ -55,12 +55,12 @@ open class MockTime(
     }
 
     /** Add ms milliseconds  */
-    private fun addMs(ms: Long) {
+    fun addMs(ms: Long) {
         time += ms
     }
 
     /** add s seconds  */
-    private fun addS(s: Long) {
+    fun addS(s: Long) {
         addMs(s * 1000L)
     }
 
@@ -70,7 +70,7 @@ open class MockTime(
     }
 
     /** add h hours */
-    private fun addH(h: Long) {
+    fun addH(h: Long) {
         addM(h * 60)
     }
 
@@ -102,7 +102,8 @@ open class MockTime(
             milliseconds: Int = 0,
         ): Long {
             val timeZone = TimeZone.getTimeZone("GMT")
-            val gregorianCalendar: Calendar = GregorianCalendar(year, month, date, hourOfDay, minute, second)
+            val gregorianCalendar: Calendar =
+                GregorianCalendar(year, month, date, hourOfDay, minute, second)
             gregorianCalendar.timeZone = timeZone
             gregorianCalendar[Calendar.MILLISECOND] = milliseconds
             return gregorianCalendar.timeInMillis


### PR DESCRIPTION
This pull request refactors how the timebox feature is triggered in the Reviewer and ReviewerViewModel classes, ensuring that the timebox dialog does not appear immediately upon opening the reviewer. It also introduces new unit tests to verify the correct behavior of the timebox dialog and makes utility functions in `MockTime` more accessible for testing.

**Timebox feature improvements:**

* Refactored the triggering of `startTimebox()` so it is now called within the `LoadInitialCard` event handler in `ReviewerViewModel` instead of being called directly in the `Reviewer` class, preventing the timebox dialog from appearing instantly when the reviewer is opened. [[1]](diffhunk://#diff-af102bcc8448edd7abf0f2706a58514b31e7c1f0e3bdf86ad0de445fd5ad46a4L384) [[2]](diffhunk://#diff-46244be82dea8313e396e21e64be261bfbb20403d8228897536f20222d2b14c8L282-R285) [[3]](diffhunk://#diff-af102bcc8448edd7abf0f2706a58514b31e7c1f0e3bdf86ad0de445fd5ad46a4L117)

**Testing enhancements:**

* Added a new test class `ReviewerViewModelTimeboxTest` to verify that the timebox dialog does not appear immediately on initialization and that it does appear when the time limit is exceeded after initialization.

**Test utility improvements:**

* Changed the visibility of the `addMs`, `addS`, and `addH` methods in `MockTime` from private to public, making them accessible for use in tests. [[1]](diffhunk://#diff-2a50f65a0f688a96b903c036c471fed5d639d40ef836b595c2158825e49214c0L58-R63) [[2]](diffhunk://#diff-2a50f65a0f688a96b903c036c471fed5d639d40ef836b595c2158825e49214c0L73-R73)

**Code formatting:**

* Minor formatting improvement in the `MockTime` class for readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the timebox would appear instantly when opening the Reviewer.

* **Tests**
  * Added comprehensive tests to verify correct timebox initialization and dialog display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->