### PR TITLE
Fix: "Show only tags in deck" includes currently selected tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/compose/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/compose/TagsDialog.kt
@@ -172,13 +172,13 @@ fun TagsDialog(
                         shape = MaterialTheme.shapes.large
                     ) {
                         val filteredTags by remember(
-                            allTags, searchQuery, isToggleChecked, deckTags
+                            allTags, searchQuery, isToggleChecked, deckTags, checkedTags, indeterminateTags
                         ) {
                             derivedStateOf {
                                 allTags.tags.filter {
                                     it.contains(
                                         other = searchQuery, ignoreCase = true
-                                    ) && (!isToggleChecked || it in deckTags)
+                                    ) && (!isToggleChecked || it in deckTags || it in checkedTags || it in indeterminateTags)
                                 }
                             }
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/compose/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/compose/TagsDialog.kt
@@ -61,7 +61,6 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -171,34 +170,35 @@ fun TagsDialog(
                         color = MaterialTheme.colorScheme.surfaceContainer,
                         shape = MaterialTheme.shapes.large
                     ) {
-                        val filteredTags by remember(
-                            allTags, searchQuery, isToggleChecked, deckTags, checkedTags, indeterminateTags
+                        val filteredTags = remember(
+                            allTags,
+                            searchQuery,
+                            isToggleChecked,
+                            deckTags,
+                            checkedTags,
+                            indeterminateTags
                         ) {
-                            derivedStateOf {
-                                allTags.tags.filter {
-                                    it.contains(
-                                        other = searchQuery, ignoreCase = true
-                                    ) && (!isToggleChecked || it in deckTags || it in checkedTags || it in indeterminateTags)
-                                }
+                            allTags.tags.filter {
+                                it.contains(
+                                    other = searchQuery, ignoreCase = true
+                                ) && (!isToggleChecked || it in deckTags || it in checkedTags || it in indeterminateTags)
                             }
                         }
-                        val potentialNewTag by remember(
-                            searchQuery, allTags, filteredTags, checkedTags, indeterminateTags
+                        val potentialNewTag = remember(
+                            searchQuery, allTags, checkedTags, indeterminateTags
                         ) {
-                            derivedStateOf {
-                                val trimmedQuery = searchQuery.trim()
-                                if (trimmedQuery.isEmpty()) {
-                                    null
-                                } else {
-                                    val existingTagsList = allTags.tags
-                                    // Show potential new tag only if it doesn't exist in all tags or selection
-                                    trimmedQuery.takeIf {
-                                        !isDuplicateTag(
-                                            trimmedQuery,
-                                            existingTagsList,
-                                            checkedTags + indeterminateTags
-                                        )
-                                    }
+                            val trimmedQuery = searchQuery.trim()
+                            if (trimmedQuery.isEmpty()) {
+                                null
+                            } else {
+                                val existingTagsList = allTags.tags
+                                // Show potential new tag only if it doesn't exist in all tags or selection
+                                trimmedQuery.takeIf {
+                                    !isDuplicateTag(
+                                        trimmedQuery,
+                                        existingTagsList,
+                                        checkedTags + indeterminateTags
+                                    )
                                 }
                             }
                         }


### PR DESCRIPTION
This pull request updates the tag filtering logic in the `TagsDialog` component to ensure that tags which are currently checked or in an indeterminate state are always visible, even when the deck filter toggle is enabled. This improves the user experience by preventing selected or partially selected tags from being hidden by the filter.

**Tag filtering improvements:**

* Updated the `filteredTags` computation in `TagsDialog.kt` so that tags in `checkedTags` or `indeterminateTags` are always shown, even if the deck filter toggle is on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tag filtering to preserve your selected tags when using the "filter by deck" option, ensuring the tag list remains consistent with your current selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->