### PR TITLE
Update font resource files to use the `android` namespace

### DIFF
--- a/AnkiDroid/src/main/res/font/google_sans_family.xml
+++ b/AnkiDroid/src/main/res/font/google_sans_family.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<font-family xmlns:app="http://schemas.android.com/apk/res-auto">
+<font-family xmlns:android="http://schemas.android.com/apk/res/android">
     <font
-        app:font="@font/google_sans_flex"
-        app:fontStyle="normal"
-        app:fontWeight="400" />
+        android:font="@font/google_sans_flex"
+        android:fontStyle="normal"
+        android:fontWeight="400" />
 </font-family>

--- a/AnkiDroid/src/main/res/font/roboto_flex.xml
+++ b/AnkiDroid/src/main/res/font/roboto_flex.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<font-family xmlns:app="http://schemas.android.com/apk/res-auto"
-        app:fontProviderAuthority="com.google.android.gms.fonts"
-        app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="Roboto Flex"
-        app:fontProviderCerts="@array/com_google_android_gms_fonts_certs">
+<font-family xmlns:android="http://schemas.android.com/apk/res/android"
+        android:fontProviderAuthority="com.google.android.gms.fonts"
+        android:fontProviderPackage="com.google.android.gms"
+        android:fontProviderQuery="Roboto Flex"
+        android:fontProviderCerts="@array/com_google_android_gms_fonts_certs">
 </font-family>

--- a/AnkiDroid/src/main/res/font/roboto_mono.xml
+++ b/AnkiDroid/src/main/res/font/roboto_mono.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<font-family xmlns:app="http://schemas.android.com/apk/res-auto"
-        app:fontProviderAuthority="com.google.android.gms.fonts"
-        app:fontProviderPackage="com.google.android.gms"
-        app:fontProviderQuery="Roboto Mono"
-        app:fontProviderCerts="@array/com_google_android_gms_fonts_certs">
+<font-family xmlns:android="http://schemas.android.com/apk/res/android"
+        android:fontProviderAuthority="com.google.android.gms.fonts"
+        android:fontProviderPackage="com.google.android.gms"
+        android:fontProviderQuery="Roboto Mono"
+        android:fontProviderCerts="@array/com_google_android_gms_fonts_certs">
 </font-family>


### PR DESCRIPTION
- Updated `roboto_mono.xml` and `roboto_flex.xml` to use the `android` namespace for font provider attributes, including `fontProviderAuthority`, `fontProviderPackage`, `fontProviderQuery`, and `fontProviderCerts`.
- Modified `google_sans_family.xml` to use `android:font`, `android:fontStyle`, and `android:fontWeight`.
- Replaced the `xmlns:app` namespace declaration with `xmlns:android` across all affected font resource files.