### PR TITLE
fix: prevent redraw on mark and add accessibility tooltips

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2243,7 +2243,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
         changes: OpChanges,
         handler: Any?,
     ) {
-        if (handler === this || handler == "ToggleMark") return
+        if (handler === this) return
         refreshRequired = ViewerRefresh.updateState(refreshRequired, changes)
         refreshIfRequired()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2243,7 +2243,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
         changes: OpChanges,
         handler: Any?,
     ) {
-        if (handler === this) return
+        if (handler === this || handler == "ToggleMark") return
         refreshRequired = ViewerRefresh.updateState(refreshRequired, changes)
         refreshIfRequired()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -755,7 +755,7 @@ class ReviewerViewModel(
             val note = withCol {
                 card.note(this)
             }
-            NoteService.toggleMark(note)
+            NoteService.toggleMark(note, handler = "ToggleMark")
             _state.update { it.copy(isMarked = !_state.value.isMarked) }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -757,7 +757,8 @@ class ReviewerViewModel(
             }
             try {
                 NoteService.toggleMark(note, handler = this@ReviewerViewModel)
-                _state.update { it.copy(isMarked = !it.isMarked) }
+                val isMarked = NoteService.isMarked(note)
+                _state.update { it.copy(isMarked = isMarked) }
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -755,8 +755,14 @@ class ReviewerViewModel(
             val note = withCol {
                 card.note(this)
             }
-            NoteService.toggleMark(note, handler = "ToggleMark")
-            _state.update { it.copy(isMarked = !_state.value.isMarked) }
+            try {
+                NoteService.toggleMark(note, handler = this@ReviewerViewModel)
+                _state.update { it.copy(isMarked = !it.isMarked) }
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Exception) {
+                Timber.w(exception, "Failed to toggle note mark")
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
@@ -30,8 +30,13 @@ import androidx.compose.material3.FilledIconToggleButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -96,29 +101,38 @@ fun ReviewerTopBar(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MarkIcon(isMarked: Boolean, onToggleMark: (Boolean) -> Unit) {
-    FilledIconToggleButton(
-        checked = isMarked,
-        onCheckedChange = onToggleMark,
-        shapes = IconButtonDefaults.toggleableShapes(),
-        colors = IconButtonDefaults.filledIconToggleButtonColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            checkedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            checkedContentColor = MaterialTheme.colorScheme.tertiary
-        )
+    val contentDescription = stringResource(if (isMarked) R.string.menu_unmark_note else R.string.menu_mark_note)
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+            positioning = TooltipAnchorPosition.Above,
+        ),
+        tooltip = { PlainTooltip { Text(contentDescription) } },
+        state = rememberTooltipState()
     ) {
-        Icon(
-            painter = if (isMarked) painterResource(R.drawable.star_shine_24px) else painterResource(
-                R.drawable.star_24px
-            ),
-            contentDescription = stringResource(if (isMarked) R.string.menu_unmark_note else R.string.menu_mark_note)
-        )
+        FilledIconToggleButton(
+            checked = isMarked,
+            onCheckedChange = onToggleMark,
+            shapes = IconButtonDefaults.toggleableShapes(),
+            colors = IconButtonDefaults.filledIconToggleButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                checkedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                checkedContentColor = MaterialTheme.colorScheme.tertiary
+            )
+        ) {
+            Icon(
+                painter = if (isMarked) painterResource(R.drawable.star_shine_24px) else painterResource(
+                    R.drawable.star_24px
+                ),
+                contentDescription = contentDescription
+            )
+        }
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FlagIcon(currentFlag: Int, onSetFlag: (Int) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
@@ -144,21 +158,30 @@ fun FlagIcon(currentFlag: Int, onSetFlag: (Int) -> Unit) {
     )
 
     Box {
-        FilledIconButton(
-            onClick = { expanded = true },
-            shapes = IconButtonDefaults.shapes(),
-            colors = if (currentFlag in flagColors.indices && currentFlag != 0) IconButtonDefaults.filledIconButtonColors(
-                contentColor = flagColors[currentFlag],
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            ) else IconButtonDefaults.filledIconButtonColors(
-                contentColor = IconButtonDefaults.filledIconToggleButtonColors().contentColor,
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-            )
+        val contentDescription = stringResource(R.string.menu_flag_card)
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                positioning = TooltipAnchorPosition.Above,
+            ),
+            tooltip = { PlainTooltip { Text(contentDescription) } },
+            state = rememberTooltipState()
         ) {
-            Icon(
-                painter = painterResource(R.drawable.flag_24px),
-                contentDescription = stringResource(R.string.menu_flag_card),
-            )
+            FilledIconButton(
+                onClick = { expanded = true },
+                shapes = IconButtonDefaults.shapes(),
+                colors = if (currentFlag in flagColors.indices && currentFlag != 0) IconButtonDefaults.filledIconButtonColors(
+                    contentColor = flagColors[currentFlag],
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ) else IconButtonDefaults.filledIconButtonColors(
+                    contentColor = IconButtonDefaults.filledIconToggleButtonColors().contentColor,
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                )
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.flag_24px),
+                    contentDescription = contentDescription,
+                )
+            }
         }
         DropdownMenu(
             expanded = expanded, onDismissRequest = { expanded = false },
@@ -189,26 +212,51 @@ fun FlagIcon(currentFlag: Int, onSetFlag: (Int) -> Unit) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Counts(newCount: Int, learnCount: Int, reviewCount: Int, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier, horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        MorphingCardCount(
-            newCount,
-            MaterialTheme.colorScheme.primaryContainer,
-            MaterialTheme.colorScheme.onPrimaryContainer
-        )
-        MorphingCardCount(
-            learnCount,
-            MaterialTheme.colorScheme.errorContainer,
-            MaterialTheme.colorScheme.onErrorContainer
-        )
-        MorphingCardCount(
-            reviewCount,
-            MaterialTheme.colorScheme.secondaryContainer,
-            MaterialTheme.colorScheme.onSecondaryContainer
-        )
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                positioning = TooltipAnchorPosition.Above,
+            ),
+            tooltip = { PlainTooltip { Text(stringResource(R.string.tags_dialog_option_new_cards)) } },
+            state = rememberTooltipState()
+        ) {
+            MorphingCardCount(
+                newCount,
+                MaterialTheme.colorScheme.primaryContainer,
+                MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                positioning = TooltipAnchorPosition.Above,
+            ),
+            tooltip = { PlainTooltip { Text(stringResource(R.string.learning)) } },
+            state = rememberTooltipState()
+        ) {
+            MorphingCardCount(
+                learnCount,
+                MaterialTheme.colorScheme.errorContainer,
+                MaterialTheme.colorScheme.onErrorContainer
+            )
+        }
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                positioning = TooltipAnchorPosition.Above,
+            ),
+            tooltip = { PlainTooltip { Text(stringResource(R.string.review)) } },
+            state = rememberTooltipState()
+        ) {
+            MorphingCardCount(
+                reviewCount,
+                MaterialTheme.colorScheme.secondaryContainer,
+                MaterialTheme.colorScheme.onSecondaryContainer
+            )
+        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.annotation.StringRes
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ichi2.anki.R
@@ -101,17 +102,25 @@ fun ReviewerTopBar(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MarkIcon(isMarked: Boolean, onToggleMark: (Boolean) -> Unit) {
-    val contentDescription = stringResource(if (isMarked) R.string.menu_unmark_note else R.string.menu_mark_note)
+private fun AboveTooltip(tooltipText: String, content: @Composable () -> Unit) {
     TooltipBox(
         positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
             positioning = TooltipAnchorPosition.Above,
         ),
-        tooltip = { PlainTooltip { Text(contentDescription) } },
+        tooltip = { PlainTooltip { Text(tooltipText) } },
         state = rememberTooltipState()
     ) {
+        content()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun MarkIcon(isMarked: Boolean, onToggleMark: (Boolean) -> Unit) {
+    val contentDescription = stringResource(if (isMarked) R.string.menu_unmark_note else R.string.menu_mark_note)
+    AboveTooltip(contentDescription) {
         FilledIconToggleButton(
             checked = isMarked,
             onCheckedChange = onToggleMark,
@@ -159,13 +168,7 @@ fun FlagIcon(currentFlag: Int, onSetFlag: (Int) -> Unit) {
 
     Box {
         val contentDescription = stringResource(R.string.menu_flag_card)
-        TooltipBox(
-            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                positioning = TooltipAnchorPosition.Above,
-            ),
-            tooltip = { PlainTooltip { Text(contentDescription) } },
-            state = rememberTooltipState()
-        ) {
+        AboveTooltip(contentDescription) {
             FilledIconButton(
                 onClick = { expanded = true },
                 shapes = IconButtonDefaults.shapes(),
@@ -214,49 +217,41 @@ fun FlagIcon(currentFlag: Int, onSetFlag: (Int) -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+private fun TooltipCardCount(
+    count: Int,
+    @StringRes tooltipResId: Int,
+    bgColor: Color,
+    contentColor: Color,
+) {
+    AboveTooltip(stringResource(tooltipResId)) {
+        MorphingCardCount(count, bgColor, contentColor)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 fun Counts(newCount: Int, learnCount: Int, reviewCount: Int, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier, horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        TooltipBox(
-            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                positioning = TooltipAnchorPosition.Above,
-            ),
-            tooltip = { PlainTooltip { Text(stringResource(R.string.tags_dialog_option_new_cards)) } },
-            state = rememberTooltipState()
-        ) {
-            MorphingCardCount(
-                newCount,
-                MaterialTheme.colorScheme.primaryContainer,
-                MaterialTheme.colorScheme.onPrimaryContainer
-            )
-        }
-        TooltipBox(
-            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                positioning = TooltipAnchorPosition.Above,
-            ),
-            tooltip = { PlainTooltip { Text(stringResource(R.string.learning)) } },
-            state = rememberTooltipState()
-        ) {
-            MorphingCardCount(
-                learnCount,
-                MaterialTheme.colorScheme.errorContainer,
-                MaterialTheme.colorScheme.onErrorContainer
-            )
-        }
-        TooltipBox(
-            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                positioning = TooltipAnchorPosition.Above,
-            ),
-            tooltip = { PlainTooltip { Text(stringResource(R.string.review)) } },
-            state = rememberTooltipState()
-        ) {
-            MorphingCardCount(
-                reviewCount,
-                MaterialTheme.colorScheme.secondaryContainer,
-                MaterialTheme.colorScheme.onSecondaryContainer
-            )
-        }
+        TooltipCardCount(
+            count = newCount,
+            tooltipResId = R.string.tags_dialog_option_new_cards,
+            bgColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        TooltipCardCount(
+            count = learnCount,
+            tooltipResId = R.string.learning,
+            bgColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        )
+        TooltipCardCount(
+            count = reviewCount,
+            tooltipResId = R.string.review,
+            bgColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
@@ -19,6 +19,10 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.servicelayer.NoteService
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -195,6 +199,46 @@ class ReviewerViewModelTest : RobolectricTest() {
 
         val state = viewModel.state.first()
         assertThat("Voice playback should be enabled", state.isVoicePlaybackEnabled, equalTo(true))
+    }
+
+    @Test
+    fun `toggleMark updates reviewer state after note is marked`() = runTest {
+        val note = addBasicNote("Front", "Back")
+        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+        advanceRobolectricLooper()
+
+        assertThat("Note should start unmarked", NoteService.isMarked(note), equalTo(false))
+        assertThat("State should start unmarked", viewModel.state.value.isMarked, equalTo(false))
+
+        viewModel.onEvent(ReviewerEvent.ToggleMark)
+        advanceRobolectricLooper()
+
+        val reloadedNote = col.getNote(note.id)
+        assertThat("Note should be marked after toggle", NoteService.isMarked(reloadedNote), equalTo(true))
+        assertThat("State should reflect marked note", viewModel.state.value.isMarked, equalTo(true))
+    }
+
+    @Test
+    fun `toggleMark leaves reviewer state unchanged when note toggle fails`() = runTest {
+        val note = addBasicNote("Front", "Back")
+        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+        advanceRobolectricLooper()
+
+        mockkObject(NoteService)
+        try {
+            coEvery {
+                NoteService.toggleMark(note = any(), handler = viewModel)
+            } throws IllegalStateException("toggle failed")
+
+            viewModel.onEvent(ReviewerEvent.ToggleMark)
+            advanceRobolectricLooper()
+
+            val reloadedNote = col.getNote(note.id)
+            assertThat("Note should remain unmarked after failure", NoteService.isMarked(reloadedNote), equalTo(false))
+            assertThat("State should remain unchanged after failure", viewModel.state.value.isMarked, equalTo(false))
+        } finally {
+            unmockkObject(NoteService)
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
@@ -219,6 +219,36 @@ class ReviewerViewModelTest : RobolectricTest() {
     }
 
     @Test
+    fun `toggleMark uses canonical mark state instead of flipping reviewer state`() = runTest {
+        val note = addBasicNote("Front", "Back")
+        NoteService.toggleMark(note)
+
+        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+        advanceRobolectricLooper()
+
+        assertThat("State should start marked", viewModel.state.value.isMarked, equalTo(true))
+
+        mockkObject(NoteService)
+        try {
+            coEvery {
+                NoteService.toggleMark(note = any(), handler = viewModel)
+            } answers { }
+            coEvery { NoteService.isMarked(note = any()) } returns true
+
+            viewModel.onEvent(ReviewerEvent.ToggleMark)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "State should follow the canonical note mark state",
+                viewModel.state.value.isMarked,
+                equalTo(true)
+            )
+        } finally {
+            unmockkObject(NoteService)
+        }
+    }
+
+    @Test
     fun `toggleMark leaves reviewer state unchanged when note toggle fails`() = runTest {
         val note = addBasicNote("Front", "Back")
         val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())


### PR DESCRIPTION
* Added tooltips to ReviewerTopBar components (MarkIcon, FlagIcon, Counts) for better accessibility
* Modified `toggleMark` to prevent it from redrawing the entire webview and flipping the card back to the question side
* Updated AbstractFlashcardViewer to properly filter out the updated `toggleMark` handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltips to mark, flag, and card count indicators for better clarity.

* **Bug Fixes**
  * Improved error handling when toggling note marks to prevent unexpected app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->