### PR TITLE
feat: Add responsive side-by-side layout for SharedDecksDownloadScreen

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -348,7 +348,7 @@ dependencies {
     implementation libs.androidx.compose.ui.text
     implementation libs.androidx.compose.animation
     implementation libs.androidx.compose.ui.unit
-    implementation libs.compose.material3.windowSizeClass
+    implementation libs.androidx.compose.material3.windowsize
     implementation libs.androidx.navigation3.ui
     testImplementation libs.androidx.compose.ui.test.junit4
     implementation libs.androidx.glance.appwidget

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -348,7 +348,7 @@ dependencies {
     implementation libs.androidx.compose.ui.text
     implementation libs.androidx.compose.animation
     implementation libs.androidx.compose.ui.unit
-    implementation libs.androidx.compose.material3.window.size.class1
+    implementation libs.compose.material3.windowSizeClass
     implementation libs.androidx.navigation3.ui
     testImplementation libs.androidx.compose.ui.test.junit4
     implementation libs.androidx.glance.appwidget

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -16,12 +16,9 @@
 package com.ichi2.anki.ui.compose.shareddecks
 
 import android.app.Activity
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -385,79 +382,72 @@ private fun DownloadProgressSection(
 private fun DownloadActions(
     state: DownloadUiState, onIntent: (DownloadIntent) -> Unit, modifier: Modifier = Modifier
 ) {
-
     Column(
-        modifier = modifier, verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        AnimatedVisibility(
-            visible = state.status == DownloadStatus.Complete, enter = fadeIn(), exit = fadeOut()
-        ) {
-            Button(
-                onClick = { onIntent(DownloadIntent.ImportClicked) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(64.dp),
-                shape = MaterialTheme.shapes.extraLarge
-            ) {
-                Text(
-                    text = stringResource(R.string.import_deck),
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
-        }
-
-        AnimatedVisibility(
-            visible = state.status == DownloadStatus.Failed, enter = fadeIn(), exit = fadeOut()
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        when (state.status) {
+            DownloadStatus.Complete -> {
                 Button(
-                    onClick = { onIntent(DownloadIntent.RetryClicked) },
+                    onClick = { onIntent(DownloadIntent.ImportClicked) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(64.dp),
                     shape = MaterialTheme.shapes.extraLarge
                 ) {
                     Text(
-                        text = stringResource(R.string.try_again),
-                        style = MaterialTheme.typography.labelLarge
-                    )
-                }
-
-                FilledTonalButton(
-                    onClick = { onIntent(DownloadIntent.OpenInBrowserClicked) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(64.dp),
-                    shape = MaterialTheme.shapes.extraLarge
-                ) {
-                    Text(
-                        text = stringResource(R.string.open_in_browser),
+                        text = stringResource(R.string.import_deck),
                         style = MaterialTheme.typography.labelLarge
                     )
                 }
             }
-        }
 
-        AnimatedVisibility(
-            visible = state.status != DownloadStatus.Complete && state.status != DownloadStatus.Failed,
-            enter = fadeIn(),
-            exit = fadeOut()
-        ) {
-            Button(
-                onClick = { onIntent(DownloadIntent.CancelClicked) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                shape = MaterialTheme.shapes.extraLarge,
-                colors = ButtonDefaults.buttonColors(
-                    contentColor = MaterialTheme.colorScheme.onError,
-                    containerColor = MaterialTheme.colorScheme.error
-                )
-            ) {
-                Text(
-                    text = stringResource(R.string.cancel_download),
-                    style = MaterialTheme.typography.labelLarge
-                )
+            DownloadStatus.Failed -> {
+                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Button(
+                        onClick = { onIntent(DownloadIntent.RetryClicked) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(64.dp),
+                        shape = MaterialTheme.shapes.extraLarge
+                    ) {
+                        Text(
+                            text = stringResource(R.string.try_again),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+
+                    FilledTonalButton(
+                        onClick = { onIntent(DownloadIntent.OpenInBrowserClicked) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(64.dp),
+                        shape = MaterialTheme.shapes.extraLarge
+                    ) {
+                        Text(
+                            text = stringResource(R.string.open_in_browser),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+                }
+            }
+
+            else -> {
+                Button(
+                    onClick = { onIntent(DownloadIntent.CancelClicked) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(64.dp),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    colors = ButtonDefaults.buttonColors(
+                        contentColor = MaterialTheme.colorScheme.onError,
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.cancel_download),
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -94,14 +95,22 @@ fun SharedDecksDownloadScreen(
     state: DownloadUiState,
     onNavigateUp: () -> Unit,
     onIntent: (DownloadIntent) -> Unit,
+    windowWidthSizeClass: WindowWidthSizeClass? = null,
 ) {
 
     val context = LocalContext.current
-    val activity = context.findActivity()
-    val isExpanded = activity?.let {
-        val windowSizeClass = calculateWindowSizeClass(it)
-        windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded || windowSizeClass.widthSizeClass == WindowWidthSizeClass.Medium
-    } ?: false
+    val windowInfo = LocalWindowInfo.current
+
+    val widthSizeClass = windowWidthSizeClass ?: context.findActivity()?.let {
+        calculateWindowSizeClass(it).widthSizeClass
+    } ?: when {
+        windowInfo.containerDpSize.width >= 840.dp -> WindowWidthSizeClass.Expanded
+        windowInfo.containerDpSize.width >= 600.dp -> WindowWidthSizeClass.Medium
+        else -> WindowWidthSizeClass.Compact
+    }
+
+    val isExpanded =
+        widthSizeClass == WindowWidthSizeClass.Expanded || widthSizeClass == WindowWidthSizeClass.Medium
 
     if (state.showCancelDialog) {
         AlertDialog(onDismissRequest = { onIntent(DownloadIntent.DismissCancelDialog) }, title = {
@@ -145,11 +154,15 @@ fun SharedDecksDownloadScreen(
                             .weight(1f),
                         contentAlignment = Alignment.Center
                     ) {
-                        DownloadProgressSection(state = state)
+                        DownloadProgressSection(
+                            state = state, modifier = Modifier
+                                .aspectRatio(1f)
+                                .padding(20.dp)
+                        )
                     }
 
                     DownloadActions(
-                        state = state, onIntent = onIntent
+                        state = state, onIntent = onIntent, modifier = Modifier.fillMaxWidth()
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))
@@ -171,11 +184,15 @@ fun SharedDecksDownloadScreen(
                         .weight(1f),
                     contentAlignment = Alignment.Center
                 ) {
-                    DownloadProgressSection(state = state)
+                    DownloadProgressSection(
+                        state = state, modifier = Modifier
+                            .aspectRatio(1f)
+                            .padding(20.dp)
+                    )
                 }
 
                 DownloadActions(
-                    state = state, onIntent = onIntent
+                    state = state, onIntent = onIntent, modifier = Modifier.fillMaxWidth()
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -196,7 +213,9 @@ private fun DownloadStatusContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        DownloadHero(status = state.status)
+        DownloadHero(
+            status = state.status, modifier = Modifier.size(120.dp)
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -233,7 +252,9 @@ private fun DownloadStatusContent(
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun DownloadHero(status: DownloadStatus) {
+private fun DownloadHero(
+    status: DownloadStatus, modifier: Modifier = Modifier
+) {
 
     val containerColor = when (status) {
         DownloadStatus.Failed -> MaterialTheme.colorScheme.errorContainer
@@ -259,7 +280,7 @@ private fun DownloadHero(status: DownloadStatus) {
     }
 
     Box(
-        modifier = Modifier.size(120.dp), contentAlignment = Alignment.Center
+        modifier = modifier, contentAlignment = Alignment.Center
     ) {
 
         Surface(
@@ -282,7 +303,9 @@ private fun DownloadHero(status: DownloadStatus) {
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun DownloadProgressSection(state: DownloadUiState) {
+private fun DownloadProgressSection(
+    state: DownloadUiState, modifier: Modifier = Modifier
+) {
 
     val animatedProgress by animateFloatAsState(
         targetValue = state.progress / 100f, animationSpec = spring(
@@ -290,9 +313,7 @@ private fun DownloadProgressSection(state: DownloadUiState) {
         ), label = "DownloadProgress"
     )
     Box(
-        modifier = Modifier
-            .aspectRatio(1f)
-            .padding(20.dp), contentAlignment = Alignment.Center
+        modifier = modifier, contentAlignment = Alignment.Center
     ) {
         Box(
             modifier = Modifier
@@ -363,11 +384,11 @@ private fun DownloadProgressSection(state: DownloadUiState) {
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun DownloadActions(
-    state: DownloadUiState, onIntent: (DownloadIntent) -> Unit
+    state: DownloadUiState, onIntent: (DownloadIntent) -> Unit, modifier: Modifier = Modifier
 ) {
 
     Column(
-        modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = modifier, verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         AnimatedVisibility(
             visible = state.status == DownloadStatus.Complete, enter = fadeIn(), exit = fadeOut()
@@ -456,6 +477,20 @@ fun SharedDecksDownloadScreenPreview() {
     }
 }
 
+@Preview(device = "spec:width=411dp,height=891dp,orientation=landscape", showBackground = true)
+@Composable
+fun SharedDecksDownloadScreenLandscapePreview() {
+    AnkiDroidTheme {
+        SharedDecksDownloadScreen(
+            state = DownloadUiState(
+            fileName = "Medical Terminology.apkg",
+            progress = 45f,
+            status = DownloadStatus.Downloading
+        ), onNavigateUp = {}, onIntent = {}, windowWidthSizeClass = WindowWidthSizeClass.Medium
+        )
+    }
+}
+
 @Preview
 @Composable
 fun SharedDecksDownloadScreenFailedPreview() {
@@ -487,7 +522,9 @@ fun DownloadProgressSectionPreview() {
         DownloadProgressSection(
             state = DownloadUiState(
                 progress = 75f, status = DownloadStatus.Downloading
-            )
+            ), modifier = Modifier
+                .aspectRatio(1f)
+                .padding(20.dp)
         )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.ui.compose.shareddecks
 
+import android.app.Activity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -26,11 +27,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
-import androidx.compose.ui.platform.LocalContext
-import android.app.Activity
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,6 +34,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -52,12 +49,16 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -83,7 +84,11 @@ import java.util.Locale
  * @param onNavigateUp Callback for when the user clicks the back navigation button.
  * @param onIntent Callback for processing user actions (intents) on this screen.
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi::class)
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalMaterial3ExpressiveApi::class,
+    ExperimentalMaterial3WindowSizeClassApi::class
+)
 @Composable
 fun SharedDecksDownloadScreen(
     state: DownloadUiState,
@@ -92,18 +97,11 @@ fun SharedDecksDownloadScreen(
 ) {
 
     val context = LocalContext.current
-    var isExpanded = false
-    var currentContext = context
-    while (currentContext is android.content.ContextWrapper) {
-        if (currentContext is Activity) break
-        currentContext = currentContext.baseContext
-    }
-
-    val activity = currentContext as? Activity
-    if (activity != null) {
-        val windowSizeClass = calculateWindowSizeClass(activity)
-        isExpanded = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded || windowSizeClass.widthSizeClass == WindowWidthSizeClass.Medium
-    }
+    val activity = context.findActivity()
+    val isExpanded = activity?.let {
+        val windowSizeClass = calculateWindowSizeClass(it)
+        windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded || windowSizeClass.widthSizeClass == WindowWidthSizeClass.Medium
+    } ?: false
 
     if (state.showCancelDialog) {
         AlertDialog(onDismissRequest = { onIntent(DownloadIntent.DismissCancelDialog) }, title = {
@@ -133,39 +131,8 @@ fun SharedDecksDownloadScreen(
                     .padding(horizontal = 24.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Column(
-                    modifier = Modifier.weight(1f),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    DownloadHero(status = state.status)
+                DownloadStatusContent(state = state, modifier = Modifier.weight(1f))
 
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Text(
-                        text = when (state.status) {
-                            DownloadStatus.Failed -> stringResource(R.string.download_failed)
-                            DownloadStatus.Complete -> stringResource(R.string.import_deck)
-                            else -> stringResource(R.string.downloading_file, state.fileName)
-                        },
-                        style = MaterialTheme.typography.displayMediumEmphasized,
-                        textAlign = TextAlign.Center,
-                        color = if (state.status == DownloadStatus.Failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
-                    )
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Text(
-                        text = when (state.status) {
-                            DownloadStatus.Failed -> stringResource(R.string.deck_download_failed_message)
-                            DownloadStatus.Complete -> stringResource(R.string.deck_download_complete_message)
-                            else -> stringResource(R.string.deck_download_progress_message)
-                        },
-                        style = MaterialTheme.typography.bodyLarge,
-                        textAlign = TextAlign.Center,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
                 Spacer(modifier = Modifier.width(32.dp))
                 Column(
                     modifier = Modifier.weight(1f),
@@ -175,7 +142,8 @@ fun SharedDecksDownloadScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .weight(1f), contentAlignment = Alignment.Center
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
                     ) {
                         DownloadProgressSection(state = state)
                     }
@@ -195,40 +163,13 @@ fun SharedDecksDownloadScreen(
                     .padding(horizontal = 24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    DownloadHero(status = state.status)
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    Text(
-                        text = when (state.status) {
-                            DownloadStatus.Failed -> stringResource(R.string.download_failed)
-                            DownloadStatus.Complete -> stringResource(R.string.import_deck)
-                            else -> stringResource(R.string.downloading_file, state.fileName)
-                        },
-                        style = MaterialTheme.typography.displayMediumEmphasized,
-                        textAlign = TextAlign.Center,
-                        color = if (state.status == DownloadStatus.Failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
-                    )
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Text(
-                        text = when (state.status) {
-                            DownloadStatus.Failed -> stringResource(R.string.deck_download_failed_message)
-                            DownloadStatus.Complete -> stringResource(R.string.deck_download_complete_message)
-                            else -> stringResource(R.string.deck_download_progress_message)
-                        },
-                        style = MaterialTheme.typography.bodyLarge,
-                        textAlign = TextAlign.Center,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                DownloadStatusContent(state = state)
 
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f), contentAlignment = Alignment.Center
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
                 ) {
                     DownloadProgressSection(state = state)
                 }
@@ -240,6 +181,48 @@ fun SharedDecksDownloadScreen(
                 Spacer(modifier = Modifier.height(24.dp))
             }
         }
+    }
+}
+
+/**
+ * Displays the hero icon and status text for the download.
+ */
+@Composable
+private fun DownloadStatusContent(
+    state: DownloadUiState, modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        DownloadHero(status = state.status)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = when (state.status) {
+                DownloadStatus.Failed -> stringResource(R.string.download_failed)
+                DownloadStatus.Complete -> stringResource(R.string.import_deck)
+                else -> stringResource(R.string.downloading_file, state.fileName)
+            },
+            style = MaterialTheme.typography.displayMediumEmphasized,
+            textAlign = TextAlign.Center,
+            color = if (state.status == DownloadStatus.Failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = when (state.status) {
+                DownloadStatus.Failed -> stringResource(R.string.deck_download_failed_message)
+                DownloadStatus.Complete -> stringResource(R.string.deck_download_complete_message)
+                else -> stringResource(R.string.deck_download_progress_message)
+            },
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 
@@ -509,14 +492,14 @@ fun DownloadProgressSectionPreview() {
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-fun DownloadProgressSectionWaitingPreview() {
-    AnkiDroidTheme {
-        DownloadProgressSection(
-            state = DownloadUiState(
-                progress = 0f, status = DownloadStatus.WaitingForNetwork
-            )
-        )
+/**
+ * Extension function to find the underlying Activity from a Context.
+ */
+private fun android.content.Context.findActivity(): Activity? {
+    var context = this
+    while (context is android.content.ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
     }
+    return null
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -154,11 +154,11 @@ fun SharedDecksDownloadScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         DownloadProgressSection(
-                            state = state, modifier = Modifier
-                                .aspectRatio(1f)
-                                .padding(20.dp)
+                            state = state, modifier = Modifier.aspectRatio(1f)
                         )
                     }
+
+                    Spacer(modifier = Modifier.height(24.dp))
 
                     DownloadActions(
                         state = state, onIntent = onIntent, modifier = Modifier.fillMaxWidth()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -25,6 +25,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.platform.LocalContext
+import android.app.Activity
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -77,13 +83,28 @@ import java.util.Locale
  * @param onNavigateUp Callback for when the user clicks the back navigation button.
  * @param onIntent Callback for processing user actions (intents) on this screen.
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun SharedDecksDownloadScreen(
     state: DownloadUiState,
     onNavigateUp: () -> Unit,
     onIntent: (DownloadIntent) -> Unit,
 ) {
+
+    val context = LocalContext.current
+    var isExpanded = false
+    var currentContext = context
+    while (currentContext is android.content.ContextWrapper) {
+        if (currentContext is Activity) break
+        currentContext = currentContext.baseContext
+    }
+
+    val activity = currentContext as? Activity
+    if (activity != null) {
+        val windowSizeClass = calculateWindowSizeClass(activity)
+        isExpanded = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded || windowSizeClass.widthSizeClass == WindowWidthSizeClass.Medium
+    }
+
     if (state.showCancelDialog) {
         AlertDialog(onDismissRequest = { onIntent(DownloadIntent.DismissCancelDialog) }, title = {
             Text(text = stringResource(R.string.cancel_download_question_title))
@@ -104,56 +125,120 @@ fun SharedDecksDownloadScreen(
         topBar = {
             AnkiTopAppBar(onNavigateUp = onNavigateUp)
         }) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                DownloadHero(status = state.status)
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Text(
-                    text = when (state.status) {
-                        DownloadStatus.Failed -> stringResource(R.string.download_failed)
-                        DownloadStatus.Complete -> stringResource(R.string.import_deck)
-                        else -> stringResource(R.string.downloading_file, state.fileName)
-                    },
-                    style = MaterialTheme.typography.displayMediumEmphasized,
-                    textAlign = TextAlign.Center,
-                    color = if (state.status == DownloadStatus.Failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = when (state.status) {
-                        DownloadStatus.Failed -> stringResource(R.string.deck_download_failed_message)
-                        DownloadStatus.Complete -> stringResource(R.string.deck_download_complete_message)
-                        else -> stringResource(R.string.deck_download_progress_message)
-                    },
-                    style = MaterialTheme.typography.bodyLarge,
-                    textAlign = TextAlign.Center,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            Box(
+        if (isExpanded) {
+            Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f), contentAlignment = Alignment.Center
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                DownloadProgressSection(state = state)
+                Column(
+                    modifier = Modifier.weight(1f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    DownloadHero(status = state.status)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = when (state.status) {
+                            DownloadStatus.Failed -> stringResource(R.string.download_failed)
+                            DownloadStatus.Complete -> stringResource(R.string.import_deck)
+                            else -> stringResource(R.string.downloading_file, state.fileName)
+                        },
+                        style = MaterialTheme.typography.displayMediumEmphasized,
+                        textAlign = TextAlign.Center,
+                        color = if (state.status == DownloadStatus.Failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = when (state.status) {
+                            DownloadStatus.Failed -> stringResource(R.string.deck_download_failed_message)
+                            DownloadStatus.Complete -> stringResource(R.string.deck_download_complete_message)
+                            else -> stringResource(R.string.deck_download_progress_message)
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(modifier = Modifier.width(32.dp))
+                Column(
+                    modifier = Modifier.weight(1f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f), contentAlignment = Alignment.Center
+                    ) {
+                        DownloadProgressSection(state = state)
+                    }
+
+                    DownloadActions(
+                        state = state, onIntent = onIntent
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
             }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    DownloadHero(status = state.status)
 
-            DownloadActions(
-                state = state, onIntent = onIntent
-            )
+                    Spacer(modifier = Modifier.height(8.dp))
 
-            Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = when (state.status) {
+                            DownloadStatus.Failed -> stringResource(R.string.download_failed)
+                            DownloadStatus.Complete -> stringResource(R.string.import_deck)
+                            else -> stringResource(R.string.downloading_file, state.fileName)
+                        },
+                        style = MaterialTheme.typography.displayMediumEmphasized,
+                        textAlign = TextAlign.Center,
+                        color = if (state.status == DownloadStatus.Failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = when (state.status) {
+                            DownloadStatus.Failed -> stringResource(R.string.deck_download_failed_message)
+                            DownloadStatus.Complete -> stringResource(R.string.deck_download_complete_message)
+                            else -> stringResource(R.string.deck_download_progress_message)
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f), contentAlignment = Alignment.Center
+                ) {
+                    DownloadProgressSection(state = state)
+                }
+
+                DownloadActions(
+                    state = state, onIntent = onIntent
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -137,8 +137,7 @@ fun SharedDecksDownloadScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(horizontal = 24.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .padding(horizontal = 24.dp)
             ) {
                 DownloadStatusContent(state = state, modifier = Modifier.weight(1f))
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/shareddecks/SharedDecksDownloadScreen.kt
@@ -383,6 +383,7 @@ private fun DownloadActions(
     state: DownloadUiState, onIntent: (DownloadIntent) -> Unit, modifier: Modifier = Modifier
 ) {
     Column(
+        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         when (state.status) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -230,7 +230,7 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-compose-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-ui-unit = { group = "androidx.compose.ui", name = "ui-unit" }
-compose-material3-windowSizeClass = { group = "androidx.compose.material3", name = "material3-window-size-class" }
+androidx-compose-material3-windowsize = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "material3" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glanceAppWidget" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -230,7 +230,7 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-compose-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-ui-unit = { group = "androidx.compose.ui", name = "ui-unit" }
-androidx-compose-material3-window-size-class1 = { group = "androidx.compose.material3", name = "material3-window-size-class" }
+compose-material3-windowSizeClass = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glanceAppWidget" }


### PR DESCRIPTION
- Use `WindowWidthSizeClass` to detect medium/expanded window widths (e.g., landscape phones).
- Refactor `SharedDecksDownloadScreen` to use a `Row` layout, placing the progress indicator side-by-side with text/actions when space permits.
- Safely unwrap Compose context to resolve `Activity` to compute the size class.
- Add `androidx.compose.material3:material3-window-size-class` to project dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The shared decks download screen adapts to window width: stacked layout on narrow screens and a two-column layout on wider displays for better use of space and clearer progress/actions.

* **Chores**
  * Project configuration updated (build/catalog alignment) with no user-facing behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->