### PR TITLE
Fix Compose lint warning for Locale in CongratsScreen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
@@ -54,10 +54,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ichi2.anki.R
+import androidx.compose.ui.text.intl.Locale
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.ui.compose.theme.RobotoMono
 import kotlinx.coroutines.delay
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -168,7 +168,7 @@ fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUnti
                     ) {
                         Text(
                             text = String.format(
-                                Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds
+                                Locale.current.platformLocale, "%02d:%02d:%02d", hours, minutes, seconds
                             ),
                             fontFamily = RobotoMono,
                             fontSize = 70.sp,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
@@ -167,12 +167,8 @@ fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUnti
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = String.format(
-                                Locale.current.platformLocale,
-                                "%02d:%02d:%02d",
-                                hours,
-                                minutes,
-                                seconds
+                            text = "%02d:%02d:%02d".format(
+                                Locale.current.platformLocale, hours, minutes, seconds
                             ),
                             fontFamily = RobotoMono,
                             fontSize = 70.sp,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
@@ -50,11 +50,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ichi2.anki.R
-import androidx.compose.ui.text.intl.Locale
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.ui.compose.theme.RobotoMono
 import kotlinx.coroutines.delay
@@ -168,7 +168,11 @@ fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUnti
                     ) {
                         Text(
                             text = String.format(
-                                Locale.current.platformLocale, "%02d:%02d:%02d", hours, minutes, seconds
+                                Locale.current.platformLocale,
+                                "%02d:%02d:%02d",
+                                hours,
+                                minutes,
+                                seconds
                             ),
                             fontFamily = RobotoMono,
                             fontSize = 70.sp,
@@ -188,8 +192,6 @@ fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUnti
 @Composable
 fun CongratsScreenPreview() {
     CongratsScreen(
-        onNavigateUp = {},
-        onDeckOptions = {},
-        timeUntilNextDay = 1000 * 60 * 60 * 4
+        onNavigateUp = {}, onDeckOptions = {}, timeUntilNextDay = 1000 * 60 * 60 * 4
     )
 }


### PR DESCRIPTION
This pull request updates the way locale information is handled in the `CongratsScreen` Compose UI. The main change is switching from the standard Java `Locale` to the Compose-specific `Locale` for formatting time strings, ensuring better compatibility and consistency within Compose-based code.

**Locale handling improvements:**

* Changed import from Java's `java.util.Locale` to Compose's `androidx.compose.ui.text.intl.Locale` in `CongratsScreen.kt` to align with Compose best practices.
* Updated time formatting to use `Locale.current.platformLocale` instead of `Locale.getDefault()`, ensuring the locale used matches the current Compose context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time display formatting to respect the app's locale settings properly on the results screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->