### PR TITLE
Improve field migration logic when switching note types

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -769,19 +769,7 @@ class NoteEditorViewModel(
                         // continues to reference the same database row.
                         newNote.id = currentNote.id
 
-                        // Build a name→index lookup for the *new* note type's fields
-                        // so we can match old fields to new fields by their display
-                        // name, regardless of position or total count.
-                        val newFieldIndexByName =
-                            freshNotetype.fields.withIndex().associate { it.value.name to it.index }
-
-                        currentNote.notetype.fields.zip(currentNote.fields)
-                            .forEach { (oldField, oldValue) ->
-                                val newIndex = newFieldIndexByName[oldField.name] ?: -1
-                                if (newIndex in newNote.fields.indices) {
-                                    newNote.fields[newIndex] = oldValue
-                                }
-                            }
+                        migrateFieldsForNoteTypeSwitch(currentNote, newNote, freshNotetype)
 
                         // Carry over any tags the user has set during this session.
                         newNote.setTagsFromStr(col, noteEditorState.tags.joinToString(" "))
@@ -1072,6 +1060,56 @@ class NoteEditorViewModel(
             hint = "",
             index = index,
         )
+    }
+
+    /**
+     * Migrate field content during a note type switch.
+     *
+     * The first pass keeps the existing name-based mapping so reordered fields with
+     * matching names land in the correct destination slots. A second pass falls back
+     * to index-to-index migration only for source fields that had no name match.
+     */
+    private fun migrateFieldsForNoteTypeSwitch(
+        oldNote: Note,
+        newNote: Note,
+        newNotetype: NotetypeJson,
+    ) {
+        val oldNotetype = oldNote.notetype
+        val newFieldIndexByName =
+            newNotetype.fields.withIndex().associate { it.value.name to it.index }
+        val sourceIndexesMappedByName = mutableSetOf<Int>()
+        val destinationIndexesMappedByName = mutableSetOf<Int>()
+
+        (0 until oldNotetype.fields.length()).forEach { oldIndex ->
+            val oldValue = oldNote.fields.getOrNull(oldIndex) ?: return@forEach
+            val oldFieldName = oldNotetype.fields[oldIndex].name
+            val newIndex = newFieldIndexByName[oldFieldName] ?: return@forEach
+
+            if (newIndex !in newNote.fields.indices) {
+                return@forEach
+            }
+
+            newNote.fields[newIndex] = oldValue
+            sourceIndexesMappedByName += oldIndex
+            destinationIndexesMappedByName += newIndex
+        }
+
+        (0 until oldNotetype.fields.length()).forEach { oldIndex ->
+            if (oldIndex in sourceIndexesMappedByName) {
+                return@forEach
+            }
+
+            val oldValue = oldNote.fields.getOrNull(oldIndex) ?: return@forEach
+            if (oldIndex !in newNote.fields.indices) {
+                return@forEach
+            }
+
+            if (oldIndex in destinationIndexesMappedByName) {
+                return@forEach
+            }
+
+            newNote.fields[oldIndex] = oldValue
+        }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -691,6 +691,94 @@ class NoteEditorTest : RobolectricTest() {
     }
 
     @Test
+    fun `fields fall back to index when names do not match`() {
+        addStandardNoteType(
+            "Prompt Answer", arrayOf("Prompt", "Answer"), "{{Prompt}}", "{{Answer}}"
+        )
+        val editor = getNoteEditorAdding(NoteType.BASIC).build()
+        idleMainLooper()
+
+        editor.setFieldValueFromUi(0, "hello")
+        editor.setFieldValueFromUi(1, "world")
+        idleMainLooper()
+
+        editor.viewModel.selectNoteType("Prompt Answer")
+        idleMainLooper()
+
+        val fields = editor.viewModel.noteEditorState.value.fields
+        assertThat("Prompt field keeps index 0 value", fields[0].value.text, equalTo("hello"))
+        assertThat("Answer field keeps index 1 value", fields[1].value.text, equalTo("world"))
+    }
+
+    @Test
+    fun `fields use name matches before index fallback`() {
+        addStandardNoteType(
+            "Front Response", arrayOf("Front", "Response"), "{{Front}}", "{{Response}}"
+        )
+        val editor = getNoteEditorAdding(NoteType.BASIC).build()
+        idleMainLooper()
+
+        editor.setFieldValueFromUi(0, "front-val")
+        editor.setFieldValueFromUi(1, "back-val")
+        idleMainLooper()
+
+        editor.viewModel.selectNoteType("Front Response")
+        idleMainLooper()
+
+        val fields = editor.viewModel.noteEditorState.value.fields
+        assertThat("Front field keeps name-based match", fields[0].value.text, equalTo("front-val"))
+        assertThat(
+            "Response field receives unmatched back field by index",
+            fields[1].value.text,
+            equalTo("back-val")
+        )
+    }
+
+    @Test
+    fun `name matching takes precedence over conflicting index fallback`() {
+        addStandardNoteType("Back Prompt", arrayOf("Back", "Prompt"), "{{Back}}", "{{Prompt}}")
+        val editor = getNoteEditorAdding(NoteType.BASIC).build()
+        idleMainLooper()
+
+        editor.setFieldValueFromUi(0, "front-val")
+        editor.setFieldValueFromUi(1, "back-val")
+        idleMainLooper()
+
+        editor.viewModel.selectNoteType("Back Prompt")
+        idleMainLooper()
+
+        val fields = editor.viewModel.noteEditorState.value.fields
+        assertThat("Back field keeps the name-based match", fields[0].value.text, equalTo("back-val"))
+        assertThat("Prompt field stays blank", fields[1].value.text, equalTo(""))
+    }
+
+    @Test
+    fun `index fallback skips fields past destination size`() {
+        createThreeFieldNoteType()
+        addStandardNoteType(
+            "Prompt Pair", arrayOf("Prompt", "Response"), "{{Prompt}}", "{{Response}}"
+        )
+        val editor = getNoteEditorAdding(NoteType.BASIC).build()
+        idleMainLooper()
+
+        editor.viewModel.selectNoteType("ThreeField")
+        idleMainLooper()
+
+        editor.setFieldValueFromUi(0, "front-val")
+        editor.setFieldValueFromUi(1, "back-val")
+        editor.setFieldValueFromUi(2, "extra-val")
+        idleMainLooper()
+
+        editor.viewModel.selectNoteType("Prompt Pair")
+        idleMainLooper()
+
+        val fields = editor.viewModel.noteEditorState.value.fields
+        assertThat("destination has only 2 fields", fields.size, equalTo(2))
+        assertThat("Prompt gets index 0 value", fields[0].value.text, equalTo("front-val"))
+        assertThat("Response gets index 1 value", fields[1].value.text, equalTo("back-val"))
+    }
+
+    @Test
     fun `field content with newlines survives note type round-trip`() {
         createBasic2NoteType()
         val editor = getNoteEditorAdding(NoteType.BASIC).build()


### PR DESCRIPTION
- Extracted field migration logic into a new `migrateFieldsForNoteTypeSwitch` method in `NoteEditorViewModel`.
- Implemented a two-pass migration strategy: first matching fields by name to handle reordering, then falling back to index-based mapping for any remaining unmatched fields.
- Added logic to ensure name-based matches take precedence and prevent index-based fallback from overwriting destination fields that were already populated.
- Added unit tests in `NoteEditorTest.kt` to verify name-based matching, index fallback behavior, and boundary conditions during note type transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field migration during note type switching with enhanced mapping logic that matches fields by name first, then by index as a fallback, reducing risk of data loss.
  * Added validation to properly handle edge cases when converting between note types with different field counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->