### PR TITLE
Fix "Capitalize sentences" option not working in Compose Note Editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -819,6 +819,7 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                     onDismissNoClozeDialog = {
                         noteEditorViewModel.dismissNoClozeDialog()
                     },
+                    capitalizeSentences = capitalizeChecked,
                 )
 
                 // Toolbar Item Dialog (Add/Edit)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditor.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -76,6 +77,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -164,6 +166,7 @@ fun NoteEditorScreen(
     noClozeDialogMessage: String?,
     onSaveAnywayClick: () -> Unit,
     onDismissNoClozeDialog: () -> Unit,
+    capitalizeSentences: Boolean = true,
 ) {
     // Observe keyboard state for auto-scrolling
     val imeState = rememberImeState()
@@ -304,6 +307,7 @@ fun NoteEditorScreen(
                             showStickyButton = state.isAddingNote,
                             onFocus = { onFieldFocus(field.index) },
                             isFocused = state.focusedFieldIndex == field.index,
+                            capitalizeSentences = capitalizeSentences,
                         )
                     }
                 }
@@ -583,6 +587,7 @@ fun NoteFieldEditor(
     showStickyButton: Boolean,
     onFocus: () -> Unit,
     isFocused: Boolean,
+    capitalizeSentences: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -630,6 +635,7 @@ fun NoteFieldEditor(
         OutlinedTextField(
             value = field.value,
             onValueChange = onValueChange,
+            keyboardOptions = if (capitalizeSentences) KeyboardOptions(capitalization = KeyboardCapitalization.Sentences) else KeyboardOptions.Default,
             modifier = Modifier
                 .fillMaxWidth()
                 .onFocusChanged { focusState ->
@@ -754,6 +760,7 @@ fun NoteEditorScreenPreview() {
             noClozeDialogMessage = null,
             onSaveAnywayClick = {},
             onDismissNoClozeDialog = {},
+            capitalizeSentences = true,
         )
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows sentence capitalization to be toggled in the note editor's text fields. The main change is the addition of a `capitalizeSentences` parameter that controls whether sentences are automatically capitalized during note entry. This parameter is threaded through the note editor components and used to set the appropriate keyboard options.

**Feature: Sentence Capitalization Toggle**

* Added a `capitalizeSentences` parameter to the `NoteEditorScreen` and `NoteFieldEditor` composables, allowing sentence capitalization to be enabled or disabled for note input fields. [[1]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR169) [[2]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR590)
* Passed the `capitalizeSentences` flag through the note editor UI hierarchy, including from the fragment (`NoteEditorFragment`) to the Compose UI, ensuring consistent behavior throughout the note editing experience. [[1]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064R822) [[2]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR310)
* Updated the `OutlinedTextField` in `NoteFieldEditor` to use `KeyboardOptions(capitalization = KeyboardCapitalization.Sentences)` when `capitalizeSentences` is true, otherwise using the default keyboard options.
* Updated the preview function to include the new `capitalizeSentences` parameter for testing and demonstration purposes.

**Dependencies and Imports**

* Added necessary imports for `KeyboardOptions` and `KeyboardCapitalization` to support the new feature. [[1]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR29) [[2]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR80)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capitalization control in the note editor. Users can now toggle automatic sentence capitalization on or off via the toolbar, allowing keyboard behavior to match their preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->