### PR TITLE
Merge deck selection into deletion undo entry in `DeckPickerViewModel`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -518,10 +518,17 @@ class DeckPickerViewModel : ViewModel(), OnErrorListener {
                 followUpEffect = DeckPickerComposeEffect.ShowSnackbar(R.string.something_wrong)
             } else {
                 val changes = undoableOp { decks.remove(listOf(did)) }
+                // Capture the undo step so we can merge any subsequent backend
+                // operations (e.g. deck selection) into this single undo entry.
+                val undoStep = withCol { undoStatus().lastStep }
                 // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
                 // to match and avoid unnecessary scrolls in `renderPage()`.
                 focusedDeck = Consts.DEFAULT_DECK_ID
                 updateDeckList()
+                // Merge any undo entries created by deck selection (triggered by
+                // focusedDeck assignment above) so that "Undo" restores the deleted
+                // deck, not an intermediate setCurrentDeck operation.
+                withCol { mergeUndoEntries(undoStep) }
 
                 val deletionResult =
                     DeckDeletionResult(deckName = deckName, cardsDeleted = changes.count)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -563,6 +563,45 @@ class DeckPickerViewModelTest : RobolectricTest() {
     }
 
     @Test
+    fun `deleteDeck - undo status targets deck removal after deletion`() = runTest {
+        val deckId = col.decks.id("Deck To Delete")
+
+        viewModel.deleteDeck(deckId).join()
+
+        // The undo status should reference the deck removal, not a subsequent
+        // setCurrentDeck or other intermediate operation.
+        val undoAction = col.undoStatus().undo
+        assertThat("undo should be available after deletion", undoAction != null, equalTo(true))
+        assertThat(
+            "undo action should reference deck removal, not an intermediate operation",
+            undoAction,
+            not(equalTo("Set Deck"))
+        )
+    }
+
+    @Test
+    fun `deleteDeck - undo restores the deleted deck`() = runTest {
+        val deckId = col.decks.id("Restorable Deck")
+        addBasicNote("Front", "Back").moveToDeck("Restorable Deck")
+
+        viewModel.deleteDeck(deckId).join()
+
+        assertThat(
+            "deck should not exist after deletion",
+            withCol { decks.getLegacy(deckId) },
+            equalTo(null)
+        )
+
+        // Undo the deletion
+        withCol { undo() }
+
+        assertThat(
+            "deck should be restored after undo",
+            withCol { decks.getLegacy(deckId) } != null,
+            equalTo(true))
+    }
+
+    @Test
     fun `effects - selecting deck with cards emits HasCardsToStudy`() = runTest {
         // Create a deck with a card
         addBasicNote("Front", "Back")


### PR DESCRIPTION
- Updated `deleteDeck` in `DeckPickerViewModel` to capture the undo step during deletion and merge subsequent backend operations, such as the automatic selection of the default deck, into a single undo entry.
- Added unit tests in `DeckPickerViewModelTest` to verify that the undo action correctly targets deck restoration rather than intermediate state changes.
- Verified that performing an undo after a deletion successfully restores the deleted deck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed undo behavior when deleting decks to correctly restore the deleted deck instead of reverting to an intermediate operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->