### PR TITLE
Fix: Restore haptic feedback when answering in compose reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -53,8 +53,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import android.view.HapticFeedbackConstants
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -131,6 +133,7 @@ fun AnswerButtons(
                 Box(
                     modifier = Modifier.animateContentSize(motionScheme.fastSpatialSpec())
                 ) {
+                    val view = LocalView.current
                     if (!isAnswerShown) {
                         val interactionSource = remember { MutableInteractionSource() }
                         val isPressed by interactionSource.collectIsPressedAsState()
@@ -143,7 +146,10 @@ fun AnswerButtons(
                             motionScheme.fastSpatialSpec()
                         )
                         Button(
-                            onClick = onShowAnswer,
+                            onClick = {
+                                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                onShowAnswer()
+                            },
                             modifier = Modifier.height(56.dp),
                             interactionSource = interactionSource,
                             contentPadding = PaddingValues(horizontal = horizontalPadding),
@@ -173,7 +179,10 @@ fun AnswerButtons(
                                             contentAlignment = Alignment.BottomCenter
                                         ) {
                                             Button(
-                                                onClick = { onRateCard(rating) },
+                                                onClick = {
+                                                    view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                                    onRateCard(rating)
+                                                },
                                                 modifier = Modifier
                                                     .height(56.dp)
                                                     .fillMaxWidth()


### PR DESCRIPTION
The compose reviewer (`AnswerButtons.kt`) lacked haptic feedback when showing the answer and selecting rating values. This commit restores the original legacy reviewer haptic behavior (`HapticFeedbackConstants.KEYBOARD_TAP`) using `LocalView.current` inside Jetpack Compose `onClick` handlers.

---
*PR created automatically by Jules for task [3711070737902257691](https://jules.google.com/task/3711070737902257691) started by @ColbyCabrera*