### PR TITLE
Replace Material switches with AnkiToggleView for XML interoperability

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
@@ -25,7 +25,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.materialswitch.MaterialSwitch
+import com.ichi2.anki.ui.compose.components.AnkiToggleView
 import com.ichi2.anki.R
 
 class ScheduleRemindersAdapter(
@@ -40,7 +40,7 @@ class ScheduleRemindersAdapter(
         val context: Context = holder.context
         val deckTextView: TextView = holder.findViewById(R.id.reminders_list_deck_text)
         val timeTextView: TextView = holder.findViewById(R.id.reminders_list_time_text)
-        val switchView: MaterialSwitch = holder.findViewById(R.id.reminders_list_switch)
+        val switchView: AnkiToggleView = holder.findViewById(R.id.reminders_list_switch)
     }
 
     override fun onCreateViewHolder(
@@ -68,7 +68,7 @@ class ScheduleRemindersAdapter(
         holder.itemView.setOnClickListener { editReminder(reminder) }
 
         holder.switchView.isChecked = reminder.enabled
-        holder.switchView.setOnClickListener { toggleReminderEnabled(reminder.id, reminder.scope) }
+        holder.switchView.setOnCheckedChangeListener { _, _ -> toggleReminderEnabled(reminder.id, reminder.scope) }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
@@ -16,6 +16,8 @@
 package com.ichi2.anki.ui.compose.components
 
 import android.content.Context
+import android.os.Parcel
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.Checkable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -62,6 +64,26 @@ class AnkiToggleView @JvmOverloads constructor(
         isEnabledState = enabled
     }
 
+    override fun onSaveInstanceState(): Parcelable {
+        val superState = super.onSaveInstanceState()
+        return SavedState(superState).also {
+            it.isChecked = isCheckedState
+            it.isEnabled = isEnabledState
+        }
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        if (state !is SavedState) {
+            super.onRestoreInstanceState(state)
+            return
+        }
+
+        super.onRestoreInstanceState(state.superState)
+        isCheckedState = state.isChecked
+        isEnabledState = state.isEnabled
+        super.setEnabled(state.isEnabled)
+    }
+
     fun setOnCheckedChangeListener(listener: ((AnkiToggleView, Boolean) -> Unit)?) {
         onCheckedChangeListener = listener
     }
@@ -76,6 +98,34 @@ class AnkiToggleView @JvmOverloads constructor(
                     performClick()
                 }, interactionSource = interactionSource, enabled = isEnabledState
             )
+        }
+    }
+
+    private class SavedState : BaseSavedState {
+        var isChecked = false
+        var isEnabled = true
+
+        constructor(superState: Parcelable?) : super(superState)
+
+        private constructor(source: Parcel) : super(source) {
+            isChecked = source.readInt() != 0
+            isEnabled = source.readInt() != 0
+        }
+
+        override fun writeToParcel(out: Parcel, flags: Int) {
+            super.writeToParcel(out, flags)
+            out.writeInt(if (isChecked) 1 else 0)
+            out.writeInt(if (isEnabled) 1 else 0)
+        }
+
+        companion object {
+            @JvmField
+            @Suppress("unused")
+            val CREATOR: Parcelable.Creator<SavedState> = object : Parcelable.Creator<SavedState> {
+                override fun createFromParcel(source: Parcel): SavedState = SavedState(source)
+
+                override fun newArray(size: Int): Array<SavedState?> = arrayOfNulls(size)
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
@@ -1,0 +1,88 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Colby Cabrera <colbycabrera@gmail.com>                            *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.ui.compose.components
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.Checkable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
+
+/**
+ * A Checkable View that wraps the Compose [AnkiToggle].
+ * This is used to interop with XML-based layouts and Preferences.
+ */
+class AnkiToggleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AbstractComposeView(context, attrs, defStyleAttr), Checkable {
+
+    private var isCheckedState by mutableStateOf(false)
+    private var isEnabledState by mutableStateOf(true)
+    private var onCheckedChangeListener: ((AnkiToggleView, Boolean) -> Unit)? = null
+
+    init {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    }
+
+    override fun setChecked(checked: Boolean) {
+        if (isCheckedState != checked) {
+            isCheckedState = checked
+        }
+    }
+
+    override fun isChecked(): Boolean = isCheckedState
+
+    override fun toggle() {
+        setChecked(!isCheckedState)
+        onCheckedChangeListener?.invoke(this, isCheckedState)
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        isEnabledState = enabled
+    }
+
+    fun setOnCheckedChangeListener(listener: ((AnkiToggleView, Boolean) -> Unit)?) {
+        onCheckedChangeListener = listener
+    }
+
+    @Composable
+    override fun Content() {
+        AnkiDroidTheme {
+            val interactionSource = remember { MutableInteractionSource() }
+            AnkiToggle(
+                checked = isCheckedState,
+                onCheckedChange = { newChecked ->
+                    setChecked(newChecked)
+                    onCheckedChangeListener?.invoke(this, newChecked)
+                    // Trigger standard click listeners registered via setOnClickListener
+                    performClick()
+                },
+                interactionSource = interactionSource,
+                enabled = isEnabledState
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
@@ -33,9 +33,7 @@ import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
  * This is used to interop with XML-based layouts and Preferences.
  */
 class AnkiToggleView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : AbstractComposeView(context, attrs, defStyleAttr), Checkable {
 
     private var isCheckedState by mutableStateOf(false)
@@ -49,14 +47,14 @@ class AnkiToggleView @JvmOverloads constructor(
     override fun setChecked(checked: Boolean) {
         if (isCheckedState != checked) {
             isCheckedState = checked
+            onCheckedChangeListener?.invoke(this, checked)
         }
     }
 
     override fun isChecked(): Boolean = isCheckedState
 
     override fun toggle() {
-        setChecked(!isCheckedState)
-        onCheckedChangeListener?.invoke(this, isCheckedState)
+        isChecked = !isCheckedState
     }
 
     override fun setEnabled(enabled: Boolean) {
@@ -73,15 +71,10 @@ class AnkiToggleView @JvmOverloads constructor(
         AnkiDroidTheme {
             val interactionSource = remember { MutableInteractionSource() }
             AnkiToggle(
-                checked = isCheckedState,
-                onCheckedChange = { newChecked ->
-                    setChecked(newChecked)
-                    onCheckedChangeListener?.invoke(this, newChecked)
-                    // Trigger standard click listeners registered via setOnClickListener
+                checked = isCheckedState, onCheckedChange = { newChecked ->
+                    isChecked = newChecked
                     performClick()
-                },
-                interactionSource = interactionSource,
-                enabled = isEnabledState
+                }, interactionSource = interactionSource, enabled = isEnabledState
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsItem.kt
@@ -21,7 +21,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.ImageView
-import androidx.appcompat.widget.SwitchCompat
+import com.ichi2.anki.ui.compose.components.AnkiToggleView
 import androidx.core.content.withStyledAttributes
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.R
@@ -56,7 +56,7 @@ class PermissionsItem(
     context: Context,
     attrs: AttributeSet,
 ) : FrameLayout(context, attrs) {
-    private val switch: SwitchCompat
+    private val switch: AnkiToggleView
 
     /**
      * The value of either app:permissions or app:permission.
@@ -68,7 +68,7 @@ class PermissionsItem(
         LayoutInflater.from(context).inflate(R.layout.permissions_item, this, true)
 
         switch =
-            findViewById<SwitchCompat>(R.id.switch_widget).apply {
+            findViewById<AnkiToggleView>(R.id.switch_widget).apply {
                 isEnabled = true
                 setOnCheckedChangeListener { button, _ ->
                     button.isChecked = areGranted

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextWithASwitchPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextWithASwitchPreference.kt
@@ -19,7 +19,7 @@ import android.util.AttributeSet
 import androidx.core.content.edit
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceViewHolder
-import com.google.android.material.materialswitch.MaterialSwitch
+import com.ichi2.anki.ui.compose.components.AnkiToggleView
 import com.ichi2.anki.R
 
 /**
@@ -63,7 +63,7 @@ class VersatileTextWithASwitchPreference(
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
 
-        with(holder.findViewById(R.id.switch_widget) as MaterialSwitch) {
+        with(holder.findViewById(R.id.switch_widget) as AnkiToggleView) {
             isFocusable = canBeSwitchedOn
             isClickable = canBeSwitchedOn
             isChecked = preferences.getBoolean(switchKey, false)

--- a/AnkiDroid/src/main/res/layout/permissions_item.xml
+++ b/AnkiDroid/src/main/res/layout/permissions_item.xml
@@ -49,7 +49,7 @@
         tools:maxLines="4"
         tools:text="A summary about why the permission should be given" />
 
-    <com.google.android.material.materialswitch.MaterialSwitch
+    <com.ichi2.anki.ui.compose.components.AnkiToggleView
         android:id="@+id/switch_widget"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/preference_material_switch_widget.xml
+++ b/AnkiDroid/src/main/res/layout/preference_material_switch_widget.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.materialswitch.MaterialSwitch
+<com.ichi2.anki.ui.compose.components.AnkiToggleView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/switchWidget"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    app:thumbIcon="@drawable/thumb_icon_selector" />
+    android:layout_height="wrap_content" />

--- a/AnkiDroid/src/main/res/layout/preference_widget_switch_with_separator.xml
+++ b/AnkiDroid/src/main/res/layout/preference_widget_switch_with_separator.xml
@@ -13,12 +13,11 @@
         android:layout_marginVertical="16dp"
         />
 
-    <com.google.android.material.materialswitch.MaterialSwitch
+    <com.ichi2.anki.ui.compose.components.AnkiToggleView
         android:id="@+id/switch_widget"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:paddingStart="16dp"
         android:background="@null"
-        app:thumbIcon="@drawable/thumb_icon_selector"
         />
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/schedule_reminders_list_item.xml
+++ b/AnkiDroid/src/main/res/layout/schedule_reminders_list_item.xml
@@ -38,7 +38,7 @@
 
     </LinearLayout>
 
-    <com.google.android.material.materialswitch.MaterialSwitch
+    <com.ichi2.anki.ui.compose.components.AnkiToggleView
         android:id="@+id/reminders_list_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />


### PR DESCRIPTION
This pull request replaces the usage of `MaterialSwitch` (from the Material Components library) with a new custom Compose-based component, `AnkiToggleView`, throughout the codebase. This change affects both the code and XML layouts, ensuring consistent toggle switch behavior and appearance across the app. The new `AnkiToggleView` is designed to be compatible with both Compose and traditional XML layouts, and brings a unified implementation for toggle switches.

**Component Replacement and Integration:**

* Introduced a new custom toggle switch component, `AnkiToggleView`, implemented as a Compose wrapper for interoperability with XML layouts and preferences. (`AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt`)
* Replaced all instances of `MaterialSwitch` with `AnkiToggleView` in code files, including adapters and custom views:
  - `ScheduleRemindersAdapter.kt` [[1]](diffhunk://#diff-d948c9fb49e1a71b13af6769c838e32639f1ec437e58e7cad12c5b66deac3cb2L28-R28) [[2]](diffhunk://#diff-d948c9fb49e1a71b13af6769c838e32639f1ec437e58e7cad12c5b66deac3cb2L43-R43) [[3]](diffhunk://#diff-d948c9fb49e1a71b13af6769c838e32639f1ec437e58e7cad12c5b66deac3cb2L71-R71)
  - `PermissionsItem.kt` [[1]](diffhunk://#diff-4417e156954e86458517ca806dfcf9b628380330a67e73c5a578082697549928L24-R24) [[2]](diffhunk://#diff-4417e156954e86458517ca806dfcf9b628380330a67e73c5a578082697549928L59-R59) [[3]](diffhunk://#diff-4417e156954e86458517ca806dfcf9b628380330a67e73c5a578082697549928L71-R71)
  - `VersatileTextWithASwitchPreference.kt` [[1]](diffhunk://#diff-d92abfe6d03b2aeef7e1088a7021050a7b33fb612628494ef08d58f1a14d18c4L22-R22) [[2]](diffhunk://#diff-d92abfe6d03b2aeef7e1088a7021050a7b33fb612628494ef08d58f1a14d18c4L66-R66)

**Layout Updates:**

* Updated all relevant XML layout files to use `AnkiToggleView` instead of `MaterialSwitch`:
  - `permissions_item.xml`
  - `preference_material_switch_widget.xml`
  - `preference_widget_switch_with_separator.xml`
  - `schedule_reminders_list_item.xml`

**Event Handling Improvements:**

* Updated event handling to use `setOnCheckedChangeListener` (instead of `setOnClickListener`) for the new toggle view, ensuring proper toggle state management and listener invocation. (`ScheduleRemindersAdapter.kt`)

These changes modernize the toggle switch implementation, improve code consistency, and prepare the codebase for future Compose-based UI enhancements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toggle controls in reminder settings, permissions screens, and preference sections for improved visual consistency across the app.
  * Modernized switch components throughout the interface for a more unified user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->