### PR TITLE
Refactor SoundTagPlayer and CardMediaPlayer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1066,7 +1066,6 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
             Timber.w("media is not played as cardMediaPlayer is not initialized")
             return
         }
-        if (!cardMediaPlayer.config.autoplay && !doMediaReplay) return
         // Use TTS if TTS preference enabled and no other media source
         val useTTS = tts.enabled && !cardMediaPlayer.hasMedia(displayAnswer)
         // We need to play the media from the proper side of the card
@@ -1075,7 +1074,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ViewerComma
                 val side = if (displayAnswer) SingleCardSide.BACK else SingleCardSide.FRONT
                 when (doMediaReplay) {
                     true -> cardMediaPlayer.replayAll(side)
-                    false -> cardMediaPlayer.playAllForSide(side.toCardSide())
+                    false -> cardMediaPlayer.autoplayAllForSide(side.toCardSide())
                 }
             }
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -164,19 +164,21 @@ class CardMediaPlayer : Closeable {
     }
 
     suspend fun autoplayAllForSide(cardSide: CardSide) {
-        if (config.autoplay) {
-            playAllForSide(cardSide)
-        }
+        playAllForSide(cardSide, isAutomaticPlayback = true)
     }
 
-    suspend fun playAllForSide(cardSide: CardSide) {
+    suspend fun playAllForSide(cardSide: CardSide, isAutomaticPlayback: Boolean) {
         if (!isEnabled) return
+        if (isAutomaticPlayback && !config.autoplay) {
+            onMediaGroupCompleted?.invoke()
+            return
+        }
         playAvTagsJob =
             playbackMutex.withLock {
                 playAvTagsJob?.cancelAndJoin()
                 scope.launch {
                     Timber.i("playing sounds for %s", cardSide)
-                    playAllAvTagsInternal(cardSide, isAutomaticPlayback = true)
+                    playAllAvTagsInternal(cardSide, isAutomaticPlayback)
                     playAvTagsJob = null
                 }
             }
@@ -326,8 +328,8 @@ class CardMediaPlayer : Closeable {
      */
     suspend fun replayAll(side: SingleCardSide) =
         when (side) {
-            SingleCardSide.BACK -> if (config.replayQuestion) playAllForSide(CardSide.BOTH) else playAllForSide(CardSide.ANSWER)
-            SingleCardSide.FRONT -> playAllForSide(CardSide.QUESTION)
+            SingleCardSide.BACK -> if (config.replayQuestion) playAllForSide(CardSide.BOTH, isAutomaticPlayback = false) else playAllForSide(CardSide.ANSWER, isAutomaticPlayback = false)
+            SingleCardSide.FRONT -> playAllForSide(CardSide.QUESTION, isAutomaticPlayback = false)
         }
 
     private suspend fun awaitTtsPlayer(isAutomaticPlayback: Boolean): TtsPlayer? {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -30,7 +30,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.ensureActive
 import com.ichi2.anki.libanki.SoundOrVideoTag
 import com.ichi2.anki.multimedia.getTagType
@@ -42,7 +41,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /** Player for (`[sound:...]`): [SoundOrVideoTag]  */
-@NeedsTest("CardSoundConfig.autoplay should mean that video also isn't played automatically")
 class SoundTagPlayer(
     private val soundUriBase: String,
     val videoPlayer: VideoPlayer,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -320,7 +320,11 @@ class SoundTagPlayer(
             return
         }
 
-        completionLatch.await()
+        try {
+            completionLatch.await()
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
         failure?.let { throw it }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -22,6 +22,9 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
@@ -34,6 +37,7 @@ import com.ichi2.anki.multimedia.getTagType
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
+import java.util.concurrent.CountDownLatch
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -45,8 +49,19 @@ class SoundTagPlayer(
 ) {
     private var mediaPlayer: MediaPlayer? = null
 
-    private val music =
-        AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_MUSIC).build()
+    @Volatile
+    private var isReleased = false
+    private val releaseLock = Any()
+
+    // MediaPlayer callbacks require a looper-backed thread, and MediaPlayer access must stay
+    // on the same thread that created the instance.
+    private val mediaPlayerThread = HandlerThread("SoundTagPlayer").apply {
+        start()
+    }
+    private val mediaPlayerHandler = Handler(mediaPlayerThread.looper)
+
+    private val music = AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+        .setUsage(AudioAttributes.USAGE_MEDIA).build()
 
     /**
      * AudioManager to request/release audio focus
@@ -57,7 +72,7 @@ class SoundTagPlayer(
     // the same instance of an AudioFocusRequest must be used to cancel focus
     private val audioFocusRequest: AudioFocusRequest by lazy {
         AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-            .setAudioAttributes(music).setOnAudioFocusChangeListener { }.build()
+            .setAudioAttributes(music).build()
     }
 
     /**
@@ -72,7 +87,10 @@ class SoundTagPlayer(
         suspendCancellableCoroutine { continuation ->
             Timber.d("Playing SoundOrVideoTag")
             when (tagType) {
-                SoundOrVideoTag.Type.AUDIO -> playSound(continuation, tag, mediaErrorListener)
+                SoundOrVideoTag.Type.AUDIO -> postToMediaPlayerThread(continuation) {
+                    playSound(continuation, tag, mediaErrorListener)
+                }
+
                 SoundOrVideoTag.Type.VIDEO -> playVideo(continuation, tag)
             }
         }
@@ -150,24 +168,35 @@ class SoundTagPlayer(
      * Releases the media players.
      */
     fun release() {
-        Timber.d("Releasing sounds and abandoning audio focus")
-        mediaPlayer?.let {
-            // Required to remove warning: "mediaplayer went away with unhandled events"
-            // https://stackoverflow.com/questions/9609479/android-mediaplayer-went-away-with-unhandled-events
-            it.reset()
-            it.release()
-            mediaPlayer = null
+        runOnMediaPlayerThreadBlocking {
+            Timber.d("Releasing sounds and abandoning audio focus")
+            mediaPlayer?.let {
+                // Required to remove warning: "mediaplayer went away with unhandled events"
+                // https://stackoverflow.com/questions/9609479/android-mediaplayer-went-away-with-unhandled-events
+                it.reset()
+                it.release()
+                mediaPlayer = null
+            }
+            abandonAudioFocus()
+            isReleased = true
         }
-        abandonAudioFocus()
+
+        synchronized(releaseLock) {
+            if (mediaPlayerThread.isAlive) {
+                mediaPlayerThread.quitSafely()
+            }
+        }
     }
 
     fun stop() {
-        try {
-            mediaPlayer?.stop()
-        } catch (e: Exception) {
-            Timber.w(e, "stopSounds()")
+        runOnMediaPlayerThreadBlocking {
+            try {
+                mediaPlayer?.stop()
+            } catch (e: Exception) {
+                Timber.w(e, "stopSounds()")
+            }
+            abandonAudioFocus()
         }
-        abandonAudioFocus()
     }
 
     /**
@@ -205,6 +234,96 @@ class SoundTagPlayer(
     private fun abandonAudioFocus(): Int {
         Timber.d("Abandoning audio focus")
         return audioManager.abandonAudioFocusRequest(audioFocusRequest)
+    }
+
+    private fun postToMediaPlayerThread(
+        continuation: CancellableContinuation<Unit>,
+        action: () -> Unit,
+    ) {
+        if (Looper.myLooper() == mediaPlayerHandler.looper) {
+            if (isReleased) {
+                if (!continuation.isCompleted) {
+                    continuation.resumeWithException(IllegalStateException("SoundTagPlayer released"))
+                }
+                return
+            }
+
+            action()
+            return
+        }
+
+        val isPosted = synchronized(releaseLock) {
+            if (isReleased) {
+                false
+            } else {
+                mediaPlayerHandler.post {
+                    if (isReleased) {
+                        if (!continuation.isCompleted) {
+                            continuation.resumeWithException(IllegalStateException("SoundTagPlayer released"))
+                        }
+                        return@post
+                    }
+
+                    action()
+                }
+            }
+        }
+
+        if (!isPosted) {
+            if (!continuation.isCompleted) {
+                val exception = if (isReleased) {
+                    IllegalStateException("SoundTagPlayer released")
+                } else {
+                    IllegalStateException("SoundTagPlayer thread unavailable")
+                }
+                continuation.resumeWithException(exception)
+            }
+        }
+    }
+
+    private fun runOnMediaPlayerThreadBlocking(action: () -> Unit) {
+        if (isReleased) {
+            return
+        }
+
+        if (Looper.myLooper() == mediaPlayerHandler.looper) {
+            if (isReleased) {
+                return
+            }
+
+            action()
+            return
+        }
+
+        val completionLatch = CountDownLatch(1)
+        var failure: Throwable? = null
+        val isPosted = synchronized(releaseLock) {
+            if (isReleased) {
+                false
+            } else {
+                mediaPlayerHandler.post {
+                    try {
+                        if (isReleased) {
+                            return@post
+                        }
+
+                        action()
+                    } catch (e: Throwable) {
+                        failure = e
+                    } finally {
+                        completionLatch.countDown()
+                    }
+                }
+            }
+        }
+
+        if (!isPosted) {
+            check(isReleased) { "SoundTagPlayer thread unavailable" }
+            return
+        }
+
+        completionLatch.await()
+        failure?.let { throw it }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -320,9 +320,16 @@ class SoundTagPlayer(
             return
         }
 
-        try {
-            completionLatch.await()
-        } catch (_: InterruptedException) {
+        var interrupted = false
+        while (true) {
+            try {
+                completionLatch.await()
+                break
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+        if (interrupted) {
             Thread.currentThread().interrupt()
         }
         failure?.let { throw it }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -682,9 +682,7 @@ class ReviewerViewModel(
                 )
             }
         }
-        if (cardMediaPlayer.config.autoplay) {
-            cardMediaPlayer.playAllForSide(SingleCardSide.FRONT.toCardSide())
-        }
+        cardMediaPlayer.autoplayAllForSide(SingleCardSide.FRONT.toCardSide())
     }
 
     private fun showAnswer() {
@@ -711,9 +709,7 @@ class ReviewerViewModel(
                     )
                 }
             }
-            if (cardMediaPlayer.config.autoplay) {
-                cardMediaPlayer.playAllForSide(SingleCardSide.BACK.toCardSide())
-            }
+            cardMediaPlayer.autoplayAllForSide(SingleCardSide.BACK.toCardSide())
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardMediaPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardMediaPlayerTest.kt
@@ -196,6 +196,52 @@ class CardMediaPlayerTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `video respects autoplay off`() = runSoundPlayerTest(
+        questions = listOf(SoundOrVideoTag("video.mp4")),
+        autoplay = false,
+    ) {
+        autoplayAllForSide(SingleCardSide.FRONT.toCardSide())
+        playAvTagsJob?.join()
+
+        coVerify(exactly = 0) { tagPlayer.play(any(), any()) }
+        ensureOnMediaGroupCompletedCalled()
+    }
+
+    @Test
+    fun `video respects autoplay on`() = runSoundPlayerTest(
+        questions = listOf(SoundOrVideoTag("video.mp4")),
+        autoplay = true,
+    ) {
+        autoplayAllForSide(SingleCardSide.FRONT.toCardSide())
+        playAvTagsJob?.join()
+
+        coVerify(exactly = 1) { tagPlayer.play(SoundOrVideoTag("video.mp4"), any()) }
+        ensureOnMediaGroupCompletedCalled()
+    }
+
+    @Test
+    fun `manual replay plays video even if autoplay is off`() = runSoundPlayerTest(
+        questions = listOf(SoundOrVideoTag("video.mp4")),
+        autoplay = false,
+    ) {
+        replayAllAndWait(SingleCardSide.FRONT)
+
+        coVerify(exactly = 1) { tagPlayer.play(SoundOrVideoTag("video.mp4"), any()) }
+        ensureOnMediaGroupCompletedCalled()
+    }
+
+    @Test
+    fun `playAllForSide manual plays video even if autoplay is off`() = runSoundPlayerTest(
+        questions = listOf(SoundOrVideoTag("video.mp4")),
+        autoplay = false,
+    ) {
+        playAllAndWait(SingleCardSide.FRONT, isAutomaticPlayback = false)
+
+        coVerify(exactly = 1) { tagPlayer.play(SoundOrVideoTag("video.mp4"), any()) }
+        ensureOnMediaGroupCompletedCalled()
+    }
+
     private fun verifyNoSoundsPlayed() {
         coVerify(exactly = 0) { tagPlayer.play(any(), any()) }
         coVerify(exactly = 0) { ttsPlayer.play(any()) }
@@ -206,8 +252,11 @@ class CardMediaPlayerTest : JvmTest() {
         verify(exactly = 1) { onMediaGroupCompleted.invoke() }
     }
 
-    private suspend fun CardMediaPlayer.playAllAndWait(side: SingleCardSide = SingleCardSide.FRONT) {
-        this.playAllForSide(side.toCardSide())
+    private suspend fun CardMediaPlayer.playAllAndWait(
+        side: SingleCardSide = SingleCardSide.FRONT,
+        isAutomaticPlayback: Boolean = false,
+    ) {
+        this.playAllForSide(side.toCardSide(), isAutomaticPlayback)
         playAvTagsJob?.join()
     }
 


### PR DESCRIPTION
This pull request refactors the card media playback logic to ensure that video playback correctly respects the "autoplay" configuration, and introduces a dedicated thread for handling `MediaPlayer` operations to improve thread safety and reliability. It also adds comprehensive tests to verify the new behavior for both audio and video playback scenarios.

**Media playback logic and configuration:**

* Changed `autoplayAllForSide` and `playAllForSide` in `CardMediaPlayer` to ensure that video (and audio) playback only occurs automatically if the `autoplay` config is enabled; manual playback (e.g., replay) always plays media regardless of the `autoplay` setting. [[1]](diffhunk://#diff-64cde60f078f7e8ab4f533b63ea9ac6c1b920d3c644fb4e1774794a216d7b890L167-R181) [[2]](diffhunk://#diff-64cde60f078f7e8ab4f533b63ea9ac6c1b920d3c644fb4e1774794a216d7b890L329-R332) [[3]](diffhunk://#diff-46244be82dea8313e396e21e64be261bfbb20403d8228897536f20222d2b14c8L685-R685) [[4]](diffhunk://#diff-46244be82dea8313e396e21e64be261bfbb20403d8228897536f20222d2b14c8L714-R712) [[5]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6L1069) [[6]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6L1078-R1077)

**Threading and reliability improvements:**

* Refactored `SoundTagPlayer` to use a dedicated `HandlerThread` for all `MediaPlayer` operations, ensuring all access is on a single thread and improving thread safety. Added helper methods to post actions to this thread and to run actions synchronously. [[1]](diffhunk://#diff-4778082b925af1ec479870b26daf8a1a22292e6b696bbf812c9998b1e754a82eR25-R62) [[2]](diffhunk://#diff-4778082b925af1ec479870b26daf8a1a22292e6b696bbf812c9998b1e754a82eL75-R91) [[3]](diffhunk://#diff-4778082b925af1ec479870b26daf8a1a22292e6b696bbf812c9998b1e754a82eR169) [[4]](diffhunk://#diff-4778082b925af1ec479870b26daf8a1a22292e6b696bbf812c9998b1e754a82eR179-R198) [[5]](diffhunk://#diff-4778082b925af1ec479870b26daf8a1a22292e6b696bbf812c9998b1e754a82eR236-R325)

**Testing enhancements:**

* Added new tests in `CardMediaPlayerTest` to verify that video playback respects the `autoplay` setting, and that manual playback works regardless of autoplay. Also refactored test helpers to support the new method signatures. [[1]](diffhunk://#diff-5e26a08892ba1057698ac63fbefd9778eceacaaa6f7ca4fd7ffed5bd6b4f1c73R199-R244) [[2]](diffhunk://#diff-5e26a08892ba1057698ac63fbefd9778eceacaaa6f7ca4fd7ffed5bd6b4f1c73L209-R259)

These changes make media playback behavior more predictable and robust, especially regarding the interplay between user settings and manual playback actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when media playback is triggered without a ready player.
  * Ensured autoplay and manual replay behave reliably for video/audio.

* **Improvements**
  * Increased thread-safety and stability of media playback and audio-focus handling.
  * Better handling of automatic vs. manual media playback to match user expectations.

* **Tests**
  * Added video autoplay tests to verify automatic and manual playback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->