### PR TITLE
Fix share image to image occlusion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -527,13 +527,23 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                     } ?: 0L
 
                     if (caller == NoteEditorCaller.IMG_OCCLUSION) {
+                        val imageOcclusionLoadFailedMessage =
+                            getString(R.string.image_occlusion_load_failed)
                         val imageUri = BundleCompat.getParcelable(
-                            requireArguments(),
-                            EXTRA_IMG_OCCLUSION,
-                            Uri::class.java
+                            requireArguments(), EXTRA_IMG_OCCLUSION, Uri::class.java
                         )
-                        if (imageUri != null) {
-                            ImportUtils.getFileCachedCopy(requireContext(), imageUri)?.let { path ->
+                        if (imageUri == null) {
+                            Timber.w("Could not load image for image occlusion: missing URI")
+                            noteEditorViewModel.showSnackbar(imageOcclusionLoadFailedMessage)
+                        } else {
+                            val path = ImportUtils.getFileCachedCopy(requireContext(), imageUri)
+                            if (path == null) {
+                                Timber.w(
+                                    "Could not load image for image occlusion: failed to cache %s",
+                                    imageUri,
+                                )
+                                noteEditorViewModel.showSnackbar(imageOcclusionLoadFailedMessage)
+                            } else {
                                 setupImageOcclusionEditor(path)
                             }
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -507,7 +507,7 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
             deckId = requireArguments().getLong(EXTRA_DID, 0L),
             isAddingNote = addNote,
             initialFieldText = initialFieldText,
-        ) { success, _ ->
+        ) { success, error ->
             if (success) {
                 // Sync Fragment's deckId with ViewModel's deckId after initialization
                 // This ensures the hasUnsavedChanges() deck comparison works correctly
@@ -535,6 +535,7 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                         if (imageUri == null) {
                             Timber.w("Could not load image for image occlusion: missing URI")
                             noteEditorViewModel.showSnackbar(imageOcclusionLoadFailedMessage)
+                            closeNoteEditor()
                         } else {
                             val path = ImportUtils.getFileCachedCopy(requireContext(), imageUri)
                             if (path == null) {
@@ -543,6 +544,7 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                                     imageUri,
                                 )
                                 noteEditorViewModel.showSnackbar(imageOcclusionLoadFailedMessage)
+                                closeNoteEditor()
                             } else {
                                 setupImageOcclusionEditor(path)
                             }
@@ -574,6 +576,15 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                         noteEditorViewModel.updateTags(tags.toSet())
                     }
                 }
+            } else {
+                Timber.e("NoteEditorFragment init failed: %s", error)
+                val message = if (error == "image_occlusion_notetype_missing") {
+                    getString(R.string.image_occlusion_notetype_missing)
+                } else {
+                    getString(R.string.something_wrong)
+                }
+                noteEditorViewModel.showSnackbar(message)
+                closeNoteEditor()
             }
         }
         return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -92,6 +92,7 @@ import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.noteeditor.ClozeInsertionMode
 import com.ichi2.anki.noteeditor.CustomToolbarButton
+import com.ichi2.anki.noteeditor.ImageOcclusionNotetypeMissingException
 import com.ichi2.anki.noteeditor.NoteEditorCaller
 import com.ichi2.anki.noteeditor.NoteEditorCaller.Companion.fromValue
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
@@ -578,10 +579,9 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                 }
             } else {
                 Timber.e("NoteEditorFragment init failed: %s", error)
-                val message = if (error == "image_occlusion_notetype_missing") {
-                    getString(R.string.image_occlusion_notetype_missing)
-                } else {
-                    getString(R.string.something_wrong)
+                val message = when (error) {
+                    is ImageOcclusionNotetypeMissingException -> getString(R.string.image_occlusion_notetype_missing)
+                    else -> getString(R.string.something_wrong)
                 }
                 noteEditorViewModel.showSnackbar(message)
                 closeNoteEditor()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -289,6 +289,12 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                 if (!addNote) {
                     reloadRequired = true
                     closeNoteEditor(RESULT_UPDATED_IO_NOTE, null)
+                } else if (caller == NoteEditorCaller.IMG_OCCLUSION) {
+                    closeNoteEditor()
+                }
+            } else {
+                if (caller == NoteEditorCaller.IMG_OCCLUSION) {
+                    closeNoteEditor()
                 }
             }
         },
@@ -519,6 +525,19 @@ class NoteEditorFragment : Fragment(R.layout.note_editor_fragment), DeckSelectio
                             currentEditedCard?.currentDeckId() ?: 0L
                         }
                     } ?: 0L
+
+                    if (caller == NoteEditorCaller.IMG_OCCLUSION) {
+                        val imageUri = BundleCompat.getParcelable(
+                            requireArguments(),
+                            EXTRA_IMG_OCCLUSION,
+                            Uri::class.java
+                        )
+                        if (imageUri != null) {
+                            ImportUtils.getFileCachedCopy(requireContext(), imageUri)?.let { path ->
+                                setupImageOcclusionEditor(path)
+                            }
+                        }
+                    }
                 }
                 // Update cards info for the selected note type
                 if (editorNote != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -54,7 +54,8 @@ import timber.log.Timber
 import kotlin.math.max
 import kotlin.math.min
 
-class ImageOcclusionNotetypeMissingException : IllegalStateException()
+class ImageOcclusionNotetypeMissingException :
+    IllegalStateException("Image occlusion notetype is missing")
 
 enum class ClozeInsertionMode {
     SAME_NUMBER, INCREMENT_NUMBER,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -384,7 +384,11 @@ class NoteEditorViewModel(
                         _deckId.value = card.currentDeckId()
                     } else {
                         // Adding a new note - use the provided deckId or calculate it
-                        val notetype = col.notetypes.current()
+                        val notetype = if (_caller.value == NoteEditorCaller.IMG_OCCLUSION) {
+                            col.notetypes.all().find { it.isImageOcclusion } ?: col.notetypes.current()
+                        } else {
+                            col.notetypes.current()
+                        }
                         ensureActive() // Check cancellation after DB access
                         val newNote = Note.fromNotetypeId(col, notetype.id)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -385,7 +385,8 @@ class NoteEditorViewModel(
                     } else {
                         // Adding a new note - use the provided deckId or calculate it
                         val notetype = if (_caller.value == NoteEditorCaller.IMG_OCCLUSION) {
-                            col.notetypes.all().find { it.isImageOcclusion } ?: col.notetypes.current()
+                            col.notetypes.all().find { it.isImageOcclusion }
+                                ?: throw IllegalStateException("image_occlusion_notetype_missing")
                         } else {
                             col.notetypes.current()
                         }
@@ -668,8 +669,8 @@ class NoteEditorViewModel(
      *
      * 1. **Resolve & validate** – Look up the target note type by [noteTypeName] and
      *    short-circuit if it is already active.
-    * 2. **Persist to collection** – Set the new note type as current, associate it
-    *    with the deck the editor will use after the switch (`mid` key), and invalidate the notetype cache so
+     * 2. **Persist to collection** – Set the new note type as current, associate it
+     *    with the deck the editor will use after the switch (`mid` key), and invalidate the notetype cache so
      *    subsequent reads return up-to-date JSON.
      * 3. **Determine target deck** – Honor the user's
      *    [ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK] preference: either keep the
@@ -696,7 +697,7 @@ class NoteEditorViewModel(
             try {
                 val col = collectionProvider()
                 ensureActive()
-                
+
                 val currentNote = _currentNote.value
                 val currentDeckId = _deckId.value
                 val noteEditorState = _noteEditorState.value
@@ -739,14 +740,13 @@ class NoteEditorViewModel(
 
                     // Associate the note type with the deck the editor is actually using
                     // after this switch so deck-specific model memory stays in sync.
-                    val targetDeck =
-                        col.decks.getLegacy(newDeckId) ?: run {
-                            Timber.w(
-                                "Deck %d missing while updating note type preference; falling back to current deck",
-                                newDeckId,
-                            )
-                            col.decks.current()
-                        }
+                    val targetDeck = col.decks.getLegacy(newDeckId) ?: run {
+                        Timber.w(
+                            "Deck %d missing while updating note type preference; falling back to current deck",
+                            newDeckId,
+                        )
+                        col.decks.current()
+                    }
                     targetDeck.put("mid", freshNotetype.id)
                     col.decks.save(targetDeck)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -54,6 +54,8 @@ import timber.log.Timber
 import kotlin.math.max
 import kotlin.math.min
 
+class ImageOcclusionNotetypeMissingException : IllegalStateException()
+
 enum class ClozeInsertionMode {
     SAME_NUMBER, INCREMENT_NUMBER,
 }
@@ -325,9 +327,9 @@ class NoteEditorViewModel(
 
     private var isInitialized = false
     private var initializeJob: Job? = null
-    private val pendingInitCallbacks = mutableListOf<(Boolean, String?) -> Unit>()
+    private val pendingInitCallbacks = mutableListOf<(Boolean, Throwable?) -> Unit>()
 
-    private fun flushInitCallbacks(success: Boolean, error: String?) {
+    private fun flushInitCallbacks(success: Boolean, error: Throwable?) {
         val callbacks = pendingInitCallbacks.toList()
         pendingInitCallbacks.clear()
         callbacks.forEach { callback ->
@@ -348,7 +350,7 @@ class NoteEditorViewModel(
         deckId: Long? = null,
         isAddingNote: Boolean = true,
         initialFieldText: String? = null,
-        onComplete: ((success: Boolean, error: String?) -> Unit)? = null,
+        onComplete: ((success: Boolean, error: Throwable?) -> Unit)? = null,
     ) {
         onComplete?.let { pendingInitCallbacks += it }
 
@@ -386,7 +388,7 @@ class NoteEditorViewModel(
                         // Adding a new note - use the provided deckId or calculate it
                         val notetype = if (_caller.value == NoteEditorCaller.IMG_OCCLUSION) {
                             col.notetypes.all().find { it.isImageOcclusion }
-                                ?: throw IllegalStateException("image_occlusion_notetype_missing")
+                                ?: throw ImageOcclusionNotetypeMissingException()
                         } else {
                             col.notetypes.current()
                         }
@@ -464,7 +466,7 @@ class NoteEditorViewModel(
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Error initializing note editor")
-                flushInitCallbacks(false, e.message)
+                flushInitCallbacks(false, e)
             } finally {
                 initializeJob = null
             }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -318,6 +318,7 @@
     <string name="downloading_file">Downloading %s</string>
     <string name="import_deck">Import Deck</string>
     <string name="something_wrong">Something went wrong, please try again</string>
+    <string name="image_occlusion_load_failed">Could not load image for image occlusion</string>
     <string name="download_failed">Download failed</string>
     <string name="deck_download_failed_message">Check your internet connection and try again</string>
     <string name="deck_download_progress_message">You can use other apps while the download is running</string>

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -109,4 +109,5 @@
         <item>https://ankiweb.net/decks</item>
         <item>https://ankiweb.net/account/verify-email</item>
     </string-array>
+    <string name="image_occlusion_notetype_missing">No Image Occlusion note type found</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
@@ -512,6 +513,25 @@ class NoteEditorTest : RobolectricTest() {
         idleMainLooper()
 
         assertThat(editor.viewModel.noteEditorState.value.selectedNoteTypeName, equalTo(type1Name))
+    }
+
+    @Test
+    fun `starts with image occlusion note type when caller is IMG_OCCLUSION`() {
+        val ioNotetype = col.notetypes.all().find { it.isImageOcclusion }
+        org.junit.Assume.assumeTrue("Image Occlusion note type required", ioNotetype != null)
+
+        // Set another note type as current, to prove it switches to Image Occlusion
+        val basicType = col.notetypes.byName("Basic")!!
+        col.notetypes.setCurrent(basicType)
+
+        val bundle = NoteEditorLauncher.ImageOcclusion(Uri.parse("content://media/external/images/media/1")).toBundle()
+        val editor = openNoteEditorWithArgs(bundle)
+        idleMainLooper()
+
+        assertThat(
+            editor.viewModel.noteEditorState.value.selectedNoteTypeName,
+            equalTo(ioNotetype!!.name)
+        )
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -524,14 +524,72 @@ class NoteEditorTest : RobolectricTest() {
         val basicType = col.notetypes.byName("Basic")!!
         col.notetypes.setCurrent(basicType)
 
-        val bundle = NoteEditorLauncher.ImageOcclusion(Uri.parse("content://media/external/images/media/1")).toBundle()
+        val bundle =
+            NoteEditorLauncher.ImageOcclusion(Uri.parse("content://media/external/images/media/1"))
+                .toBundle()
         val editor = openNoteEditorWithArgs(bundle)
         idleMainLooper()
 
         assertThat(
-            editor.viewModel.noteEditorState.value.selectedNoteTypeName,
-            equalTo(ioNotetype!!.name)
+            editor.viewModel.noteEditorState.value.selectedNoteTypeName, equalTo(ioNotetype!!.name)
         )
+    }
+
+    @Test
+    fun `launching with IMG_OCCLUSION and missing imageUri closes the editor`() {
+        val bundle = NoteEditorLauncher.ImageOcclusion(imageUri = null).toBundle()
+        ActivityScenario.launchActivityForResult<NoteEditorActivity>(
+            NoteEditorLauncher.PassArguments(bundle).toIntent(targetContext)
+        ).use { scenario ->
+            idleMainLooper()
+            scenario.onNoteEditor { noteEditor ->
+                assertThat(
+                    "Missing image URI should cause the activity to finish",
+                    noteEditor.requireActivity().isFinishing
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `launching with IMG_OCCLUSION when image cached copy path is null closes the editor`() {
+        val bundle =
+            NoteEditorLauncher.ImageOcclusion(imageUri = Uri.parse("content://invalid-provider/image"))
+                .toBundle()
+        ActivityScenario.launchActivityForResult<NoteEditorActivity>(
+            NoteEditorLauncher.PassArguments(bundle).toIntent(targetContext)
+        ).use { scenario ->
+            idleMainLooper()
+            scenario.onNoteEditor { noteEditor ->
+                assertThat(
+                    "Null image cached copy path should cause the activity to finish",
+                    noteEditor.requireActivity().isFinishing
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `launching with IMG_OCCLUSION when no image occlusion note type is found closes the editor`() {
+        val ioNotetype = col.notetypes.all().find { it.isImageOcclusion }
+        if (ioNotetype != null) {
+            col.notetypes.remove(ioNotetype.id)
+        }
+
+        val bundle =
+            NoteEditorLauncher.ImageOcclusion(Uri.parse("content://media/external/images/media/1"))
+                .toBundle()
+        ActivityScenario.launchActivityForResult<NoteEditorActivity>(
+            NoteEditorLauncher.PassArguments(bundle).toIntent(targetContext)
+        ).use { scenario ->
+            idleMainLooper()
+            scenario.onNoteEditor { noteEditor ->
+                assertThat(
+                    "Missing image occlusion note type should cause the activity to finish",
+                    noteEditor.requireActivity().isFinishing
+                )
+            }
+        }
     }
 
     @Test
@@ -768,7 +826,11 @@ class NoteEditorTest : RobolectricTest() {
         idleMainLooper()
 
         val fields = editor.viewModel.noteEditorState.value.fields
-        assertThat("Back field keeps the name-based match", fields[0].value.text, equalTo("back-val"))
+        assertThat(
+            "Back field keeps the name-based match",
+            fields[0].value.text,
+            equalTo("back-val")
+        )
         assertThat("Prompt field stays blank", fields[1].value.text, equalTo(""))
     }
 
@@ -1053,11 +1115,11 @@ class NoteEditorTest : RobolectricTest() {
         col.notetypes.save(alternateNoteType)
 
         addBasicNote("Initial Front", "Initial Back").update {
-                setTagsFromStr(col, "initial-only-tag")
-            }.updateCards { did = initialDeckId }
+            setTagsFromStr(col, "initial-only-tag")
+        }.updateCards { did = initialDeckId }
         addBasicNote("Preferred Front", "Preferred Back").update {
-                setTagsFromStr(col, "preferred-only-tag")
-            }.updateCards { did = preferredDeckId }
+            setTagsFromStr(col, "preferred-only-tag")
+        }.updateCards { did = preferredDeckId }
 
         val editor = getNoteEditorAdding(NoteType.BASIC).build()
         idleMainLooper()


### PR DESCRIPTION
This pull request enhances the image occlusion feature in the note editor by improving how image occlusion notes are initialized and handled, adding error handling and user feedback, and introducing a new test to ensure correct behavior. The main focus is on ensuring that when the note editor is opened for image occlusion, it automatically selects the appropriate note type and gracefully handles potential image loading failures.

**Image Occlusion Handling Improvements:**

- The note editor now automatically selects the image occlusion note type when launched for image occlusion, falling back to the current note type if none is found.
- Improved error handling for image occlusion: if the image URI is missing or the image cannot be cached, a user-friendly snackbar message is shown, and appropriate warnings are logged. [[1]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064R528-R550) [[2]](diffhunk://#diff-55582f3477f88d22e8e7acfbac5e2fdea81e4f8f298e0b1b91ec60093e6e3a04R321)

**Editor Closing Logic:**

- Adjusted the editor closing logic to ensure the note editor is closed correctly in image occlusion scenarios, both when adding and editing notes.

**Testing:**

- Added a test to verify that the note editor starts with the image occlusion note type when the caller is `IMG_OCCLUSION`, even if another note type is currently selected.
- Updated test imports to support image occlusion testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image occlusion launches now auto-select the Image Occlusion note type and initialize the occlusion editor when applicable.
  * New user-facing messages for missing note type and image load failures; editor closes when required resources are absent.

* **Bug Fixes**
  * Improved editor close behavior for canceled or failed image-occlusion flows and for add vs. edit launch scenarios.

* **Tests**
  * Added tests covering image occlusion launch, missing image URI, caching failures, and missing note type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->