### PR TITLE
Enable R8 Configuration Analyzer and refine ProGuard rules

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -24,11 +24,16 @@
 # -dontobfuscate
 
 # Used through Reflection
--keep class com.ichi2.anki.**.*Fragment { *; }
--keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
--keep class androidx.core.app.ActivityCompat$* { *; }
--keep class androidx.concurrent.futures.** { *; }
--keep class androidx.appcompat.view.menu.MenuItemImpl { *; } # .utils.ext.MenuItemImpl
+-keep class com.ichi2.anki.**.*Fragment { <init>(); }
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+-keepclassmembers class androidx.appcompat.view.menu.MenuItemImpl {
+    *** mMenu;
+    *** mSubMenu;
+}
+# AndroidX libraries bundle their own consumer Proguard rules. These custom rules are redundant/unused.
+# -keep class androidx.core.app.ActivityCompat$* { *; }
+# -keep class androidx.concurrent.futures.** { *; }
+-dontwarn androidx.concurrent.futures.**
 
 # Ignore unused packages
 -dontwarn javax.naming.**

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,5 +34,9 @@ android.uniquePackageNames=false
 # Avoids strict full-mode keep-rule validation for R8 during AGP 9 migration.
 android.r8.strictFullModeForKeepRules=false
 
+# Enable the R8 Configuration Analyzer to identify broad keep rules and improve optimization scores.
+# (Enabled by default in AGP 9.3.0-alpha05+)
+android.experimental.r8.enableR8ConfigurationAnalyzer=true
+
 # Disables AGP's new Kotlin DSL migration to keep existing build configuration.
 android.newDsl=false


### PR DESCRIPTION
- Enabled `android.experimental.r8.enableR8ConfigurationAnalyzer` in `gradle.properties` to identify over-broad keep rules and improve optimization.
- Refined ProGuard rules in `AnkiDroid/proguard-rules.pro` to reduce code bloat:
    - Narrowed Fragment keep rules to only preserve constructors.
    - Updated `GeneratedMessageLite` and `MenuItemImpl` rules to target specific members instead of entire classes.
    - Removed redundant rules for `ActivityCompat` and `androidx.concurrent.futures` which are already provided by AndroidX consumer rules.
    - Added `dontwarn` for `androidx.concurrent.futures` to suppress unnecessary build warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build optimization rules for improved precision
  * Enabled R8 Configuration Analyzer for enhanced build-time code optimization analysis

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->