### PR TITLE
Fix StudyOptionsComposeActivity layout scaling and theming

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -29,9 +29,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.ichi2.anki.CollectionManager.withCol
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
 import com.ichi2.anki.deckpicker.compose.StudyOptionsData
 import com.ichi2.anki.deckpicker.compose.StudyOptionsScreen
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.utils.ext.showDialogFragment
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -83,15 +88,20 @@ class StudyOptionsComposeActivity : AnkiActivity() {
                 }
             }
 
-            StudyOptionsScreen(
-                studyOptionsData = studyOptionsData,
-                onStartStudy = {
-                    startActivity(Reviewer.getIntent(this))
-                },
-                onCustomStudy = { deckId ->
-                    showDialogFragment(CustomStudyDialog.createInstance(deckId))
-                },
-            )
+            AnkiDroidTheme {
+                Scaffold { innerPadding ->
+                    StudyOptionsScreen(
+                        modifier = Modifier.padding(innerPadding).fillMaxSize(),
+                        studyOptionsData = studyOptionsData,
+                        onStartStudy = {
+                            startActivity(Reviewer.getIntent(this))
+                        },
+                        onCustomStudy = { deckId ->
+                            showDialogFragment(CustomStudyDialog.createInstance(deckId))
+                        },
+                    )
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerScreen.kt
@@ -663,6 +663,7 @@ fun DeckPickerScreen(
                     }
                     Box(modifier = Modifier.weight(1f)) {
                         StudyOptionsScreen(
+                            modifier = Modifier.padding(start = 4.dp, end = 12.dp, bottom = 12.dp),
                             studyOptionsData = studyOptionsData,
                             onStartStudy = onStartStudy,
                             onCustomStudy = onCustomStudy,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/StudyOptionsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/StudyOptionsScreen.kt
@@ -108,22 +108,22 @@ fun StudyOptionsScreen(
     ) {
         if (studyOptionsData == null) {
             // Show a loading indicator or an empty state
-            Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
 
         } else {
             when {
                 studyOptionsData.totalCards == 0 && !studyOptionsData.isFiltered -> {
-                    EmptyDeckView(studyOptionsData, modifier)
+                    EmptyDeckView(studyOptionsData, modifier = Modifier)
                 }
 
                 studyOptionsData.newCount + studyOptionsData.lrnCount + studyOptionsData.revCount == 0 -> {
-                    CongratsView(studyOptionsData, onCustomStudy, modifier)
+                    CongratsView(studyOptionsData, onCustomStudy, modifier = Modifier)
                 }
 
                 else -> {
-                    StudyOptionsView(studyOptionsData, onStartStudy, modifier)
+                    StudyOptionsView(studyOptionsData, onStartStudy, modifier = Modifier)
                 }
             }
         }
@@ -168,8 +168,10 @@ fun StudyOptionsView(
                         val start = spanned.getSpanStart(span)
                         val end = spanned.getSpanEnd(span)
                         val url = span.url
-                        if (url.startsWith("http://", ignoreCase = true) ||
-                            url.startsWith("https://", ignoreCase = true)
+                        if (url.startsWith(
+                                "http://",
+                                ignoreCase = true
+                            ) || url.startsWith("https://", ignoreCase = true)
                         ) {
                             addLink(LinkAnnotation.Url(url), start, end)
                             addStyle(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/StudyOptionsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/StudyOptionsScreen.kt
@@ -102,7 +102,7 @@ fun StudyOptionsScreen(
     onCustomStudy: (Long) -> Unit,
 ) {
     Surface(
-        modifier.padding(start = 4.dp, end = 12.dp, bottom = 12.dp),
+        modifier = modifier,
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceContainerLowest
     ) {


### PR DESCRIPTION
Resolves an issue where `StudyOptionsComposeActivity` does not stretch full width and lacks proper theming and window inset handling. 

- Wrapped root screen inside `AnkiDroidTheme`
- Wrapped content inside a `Scaffold` and applied `innerPadding` and `fillMaxSize()` so it can respect window insets natively.
- Extracted hard-coded padding away from the shared `StudyOptionsScreen` to allow consumers to dictate sizing/padding, placing the original padding back into the tablet-side layout (`DeckPickerScreen`).

---
*PR created automatically by Jules for task [9598906547713706357](https://jules.google.com/task/9598906547713706357) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified theming and scaffolded layout for the study screen for more consistent visuals.
  * Adjusted padding and spacing in split/tablet views for improved layout and alignment.

* **Bug Fixes**
  * Fixed layout sizing so the study screen respects parent padding and fills available space more predictably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->