### PR TITLE
Add preference to control Hirameki CSS styling in reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -40,6 +40,11 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.viewinterop.AndroidView
+import android.content.SharedPreferences
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.ViewerResourceHandler
 import com.ichi2.anki.previewer.stdHtml
 import com.ichi2.anki.reviewer.ReviewerJavascriptCommand
@@ -70,6 +75,23 @@ fun Flashcard(
     val currentOnTap by rememberUpdatedState(onTap)
 
     val context = LocalContext.current
+    val sharedPrefs = remember(context) { context.sharedPrefs() }
+    var applyHiramekiCssMode by remember {
+        mutableStateOf(sharedPrefs.getString("applyHiramekiCss", "all") ?: "all")
+    }
+
+    DisposableEffect(sharedPrefs) {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == "applyHiramekiCss") {
+                applyHiramekiCssMode = sharedPrefs.getString("applyHiramekiCss", "all") ?: "all"
+            }
+        }
+        sharedPrefs.registerOnSharedPreferenceChangeListener(listener)
+        onDispose {
+            sharedPrefs.unregisterOnSharedPreferenceChangeListener(listener)
+        }
+    }
+
     val isNightMode = Themes.currentTheme.isNightMode
     val surfaceColor = MaterialTheme.colorScheme.surface
     val surfaceColorHex = surfaceColor.toArgb().toRGBHex()
@@ -106,9 +128,23 @@ fun Flashcard(
             outlineColorHex,
             currentStyle,
             currentPadding,
-            toolbarHeight
+            toolbarHeight,
+            applyHiramekiCssMode
         ) {
-            """
+            if (applyHiramekiCssMode == "disabled") {
+                """<style id="compose-styles"></style>"""
+            } else {
+                val fontSizeStyles = if (applyHiramekiCssMode == "no_font_size") {
+                    ""
+                } else {
+                    """
+                        font-size: ${currentStyle.fontSize.value}px;
+                        line-height: ${currentStyle.lineHeight.value}px;
+                        letter-spacing: ${currentStyle.letterSpacing.value}px;
+                    """.trimIndent()
+                }
+
+                """
                 <style id="compose-styles">
                     @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
                     html {
@@ -118,10 +154,8 @@ fun Flashcard(
                     body.card {
                         text-align: center;
                         font-family: "Roboto", sans-serif;
-                        font-size: ${currentStyle.fontSize.value}px;
+                        $fontSizeStyles
                         font-weight: ${currentStyle.fontWeight?.weight ?: 400};
-                        line-height: ${currentStyle.lineHeight.value}px;
-                        letter-spacing: ${currentStyle.letterSpacing.value}px;
                         text-wrap: pretty;
                         padding-top: ${currentPadding}px;
                         padding-bottom: ${toolbarHeight}px;
@@ -217,7 +251,8 @@ fun Flashcard(
                         fill: currentColor;
                     }
                 </style>
-            """.trimIndent()
+                """.trimIndent()
+            }
         }
         val styledHtml = remember(context, isNightMode, composeStyle) {
             buildStyledHtml(context, isNightMode, composeStyle)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -45,6 +45,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.R
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ViewerResourceHandler
 import com.ichi2.anki.previewer.stdHtml
 import com.ichi2.anki.reviewer.ReviewerJavascriptCommand
@@ -76,16 +78,20 @@ fun Flashcard(
 
     val context = LocalContext.current
     val sharedPrefs = remember(context) { context.sharedPrefs() }
+    val prefKey = remember(context) { context.getString(R.string.apply_hirameki_css_preference) }
     var applyHiramekiCssMode by remember {
-        mutableStateOf(sharedPrefs.getString("applyHiramekiCss", "all") ?: "all")
+        mutableStateOf(sharedPrefs.getString(prefKey, Prefs.HIRAMEKI_CSS_ALL) ?: Prefs.HIRAMEKI_CSS_ALL)
     }
 
-    DisposableEffect(sharedPrefs) {
-        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key == "applyHiramekiCss") {
-                applyHiramekiCssMode = sharedPrefs.getString("applyHiramekiCss", "all") ?: "all"
+    val listener = remember {
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == prefKey) {
+                applyHiramekiCssMode = sharedPrefs.getString(prefKey, Prefs.HIRAMEKI_CSS_ALL) ?: Prefs.HIRAMEKI_CSS_ALL
             }
         }
+    }
+
+    DisposableEffect(sharedPrefs, listener) {
         sharedPrefs.registerOnSharedPreferenceChangeListener(listener)
         onDispose {
             sharedPrefs.unregisterOnSharedPreferenceChangeListener(listener)
@@ -131,10 +137,10 @@ fun Flashcard(
             toolbarHeight,
             applyHiramekiCssMode
         ) {
-            if (applyHiramekiCssMode == "disabled") {
+            if (applyHiramekiCssMode == Prefs.HIRAMEKI_CSS_DISABLED) {
                 """<style id="compose-styles"></style>"""
             } else {
-                val fontSizeStyles = if (applyHiramekiCssMode == "no_font_size") {
+                val fontSizeStyles = if (applyHiramekiCssMode == Prefs.HIRAMEKI_CSS_NO_FONT_SIZE) {
                     ""
                 } else {
                     """

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.reviewer.compose
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.SharedPreferences
 import android.graphics.Color
 import android.view.GestureDetector
 import android.view.MotionEvent
@@ -32,24 +33,24 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.viewinterop.AndroidView
-import android.content.SharedPreferences
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.R
-import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ViewerResourceHandler
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.stdHtml
 import com.ichi2.anki.reviewer.ReviewerJavascriptCommand
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.themes.Themes
 import com.ichi2.utils.toRGBHex
 import kotlinx.serialization.json.Json
@@ -78,15 +79,18 @@ fun Flashcard(
 
     val context = LocalContext.current
     val sharedPrefs = remember(context) { context.sharedPrefs() }
-    val prefKey = remember(context) { context.getString(R.string.apply_hirameki_css_preference) }
+    val prefKey = stringResource(R.string.apply_hirameki_css_preference)
     var applyHiramekiCssMode by remember {
-        mutableStateOf(sharedPrefs.getString(prefKey, Prefs.HIRAMEKI_CSS_ALL) ?: Prefs.HIRAMEKI_CSS_ALL)
+        mutableStateOf(
+            sharedPrefs.getString(prefKey, Prefs.HIRAMEKI_CSS_ALL) ?: Prefs.HIRAMEKI_CSS_ALL
+        )
     }
 
-    val listener = remember {
+    val listener = remember(sharedPrefs, prefKey) {
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key == prefKey) {
-                applyHiramekiCssMode = sharedPrefs.getString(prefKey, Prefs.HIRAMEKI_CSS_ALL) ?: Prefs.HIRAMEKI_CSS_ALL
+                applyHiramekiCssMode =
+                    sharedPrefs.getString(prefKey, Prefs.HIRAMEKI_CSS_ALL) ?: Prefs.HIRAMEKI_CSS_ALL
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -34,6 +34,10 @@ import kotlin.reflect.KProperty
 // TODO move this to `com.ichi2.anki.preferences`
 //  after the UI classes of that package are moved to `com.ichi2.anki.ui.preferences`
 object Prefs {
+    const val HIRAMEKI_CSS_ALL = "all"
+    const val HIRAMEKI_CSS_NO_FONT_SIZE = "no_font_size"
+    const val HIRAMEKI_CSS_DISABLED = "disabled"
+
     private val sharedPrefs get() = AnkiDroidApp.sharedPrefs()
 
     @VisibleForTesting
@@ -239,7 +243,7 @@ object Prefs {
     val showAnswerFeedback by booleanPref(R.string.show_answer_feedback_key, defaultValue = true)
     val showAnswerButtonBadges by booleanPref(R.string.show_answer_button_badges_key, defaultValue = true)
     val showAnswerButtons by booleanPref(R.string.show_answer_buttons_key, true)
-    val applyHiramekiCss by stringPref(R.string.apply_hirameki_css_preference, defaultValue = "all")
+    val applyHiramekiCss by stringPref(R.string.apply_hirameki_css_preference, defaultValue = HIRAMEKI_CSS_ALL)
 
     val doubleTapInterval by intPref(R.string.double_tap_timeout_pref_key, defaultValue = 200)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -239,6 +239,7 @@ object Prefs {
     val showAnswerFeedback by booleanPref(R.string.show_answer_feedback_key, defaultValue = true)
     val showAnswerButtonBadges by booleanPref(R.string.show_answer_button_badges_key, defaultValue = true)
     val showAnswerButtons by booleanPref(R.string.show_answer_buttons_key, true)
+    val applyHiramekiCss by stringPref(R.string.apply_hirameki_css_preference, defaultValue = "all")
 
     val doubleTapInterval by intPref(R.string.double_tap_timeout_pref_key, defaultValue = 200)
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -472,4 +472,9 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
 
     <!--Keyboard shortcuts dialog-->
     <string name="open_settings" comment="Description of the shortcut that opens the app settings">Open settings</string>
+
+    <string name="apply_hirameki_css">Apply Hirameki CSS in the reviewer</string>
+    <string name="apply_hirameki_css_all">Apply all custom CSS</string>
+    <string name="apply_hirameki_css_no_font_size">Disable font size changes</string>
+    <string name="apply_hirameki_css_disabled">Disable all custom CSS</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -473,6 +473,7 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
     <!--Keyboard shortcuts dialog-->
     <string name="open_settings" comment="Description of the shortcut that opens the app settings">Open settings</string>
 
+    <string name="reviewer_css_styling">Reviewer CSS styling</string>
     <string name="apply_hirameki_css">Apply Hirameki CSS in the reviewer</string>
     <string name="apply_hirameki_css_all">Apply all custom CSS</string>
     <string name="apply_hirameki_css_no_font_size">Disable font size changes</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -323,4 +323,14 @@
     <string name="post_notification_permission">android.permission.POST_NOTIFICATIONS</string>
     <string name="record_audio_permission">android.permission.RECORD_AUDIO</string>
 
+    <string-array name="apply_hirameki_css_labels">
+        <item>@string/apply_hirameki_css_all</item>
+        <item>@string/apply_hirameki_css_no_font_size</item>
+        <item>@string/apply_hirameki_css_disabled</item>
+    </string-array>
+    <string-array name="apply_hirameki_css_values">
+        <item>all</item>
+        <item>no_font_size</item>
+        <item>disabled</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -246,4 +246,5 @@
     <string name="reviewer_frame_style_key">reviewerFrameStyle</string>
     <string name="reviewer_toolbar_position_key">reviewerToolbarPosition</string>
     <string name="apply_hirameki_css_preference">applyHiramekiCss</string>
+    <string name="reviewer_css_category">reviewer_css_category</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -245,5 +245,5 @@
     <string name="reviewer_menu_settings_key">reviewerMenuSettings</string>
     <string name="reviewer_frame_style_key">reviewerFrameStyle</string>
     <string name="reviewer_toolbar_position_key">reviewerToolbarPosition</string>
-
+    <string name="apply_hirameki_css_preference">applyHiramekiCss</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -61,7 +61,7 @@
             android:title="@string/show_answer_button_badges"
             android:summary="@string/show_answer_button_badges_summ" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="Reviewer CSS styling" android:key="reviewer_css_category">
+    <PreferenceCategory android:title="@string/reviewer_css_styling" android:key="reviewer_css_category">
         <ListPreference
             android:defaultValue="all"
             android:entries="@array/apply_hirameki_css_labels"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -61,7 +61,7 @@
             android:title="@string/show_answer_button_badges"
             android:summary="@string/show_answer_button_badges_summ" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/reviewer_css_styling" android:key="reviewer_css_category">
+    <PreferenceCategory android:title="@string/reviewer_css_styling" android:key="@string/reviewer_css_category">
         <ListPreference
             android:defaultValue="all"
             android:entries="@array/apply_hirameki_css_labels"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -61,4 +61,13 @@
             android:title="@string/show_answer_button_badges"
             android:summary="@string/show_answer_button_badges_summ" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="Reviewer CSS styling" android:key="reviewer_css_category">
+        <ListPreference
+            android:defaultValue="all"
+            android:entries="@array/apply_hirameki_css_labels"
+            android:entryValues="@array/apply_hirameki_css_values"
+            android:key="@string/apply_hirameki_css_preference"
+            android:title="@string/apply_hirameki_css"
+            app1:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -67,6 +67,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             R.string.pref_cat_plugins_key, // category_plugins
             R.string.pref_cat_workarounds_key, // category_workarounds
             R.string.pref_controls_tab_layout_key, // controlsTabLayout
+            R.string.reviewer_css_category, // reviewer_css_category
             // Preferences that only click: don't have a value
             R.string.tts_key, // tts
             R.string.pref_reset_languages_key, // resetLanguages
@@ -89,6 +90,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             R.string.custom_sync_server_collection_url_key, // syncBaseUrl
             R.string.pref_language_key, // language
             R.string.custom_sync_certificate_key, // customSyncCertificate
+            R.string.apply_hirameki_css_preference, // applyHiramekiCss
         ).toStringResourceSet()
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
@@ -71,12 +71,27 @@ class PrefsRobolectricTest : RobolectricTest() {
             callOriginal()
         }
 
+        val allowedNonPreferenceProperties = setOf(
+            "resources", "HIRAMEKI_CSS_ALL", "HIRAMEKI_CSS_NO_FONT_SIZE", "HIRAMEKI_CSS_DISABLED"
+        )
+        val unexpectedExceptions = mutableListOf<Throwable>()
         for (property in Prefs::class.memberProperties) {
             if (property.visibility != KVisibility.PUBLIC) continue
             try {
                 property.getter.call(Prefs)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                val unwrapped =
+                    if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
+                if (property.name !in allowedNonPreferenceProperties) {
+                    unexpectedExceptions.add(unwrapped)
+                }
             }
+        }
+        if (unexpectedExceptions.isNotEmpty()) {
+            throw AssertionError(
+                "Unexpected exceptions thrown during Prefs property inspection: $unexpectedExceptions",
+                unexpectedExceptions.first()
+            )
         }
         unmockkObject(Prefs)
         AnkiDroidApp.sharedPreferencesTestingOverride = null
@@ -133,6 +148,10 @@ class PrefsRobolectricTest : RobolectricTest() {
             callOriginal()
         }
         val propertyNamesAndKeys = mutableMapOf<String, String>()
+        val allowedNonPreferenceProperties = setOf(
+            "resources", "HIRAMEKI_CSS_ALL", "HIRAMEKI_CSS_NO_FONT_SIZE", "HIRAMEKI_CSS_DISABLED"
+        )
+        val unexpectedExceptions = mutableListOf<Throwable>()
         for (property in Prefs::class.memberProperties) {
             if (property.visibility != KVisibility.PUBLIC) continue
             val keysSizeBefore = keys.size
@@ -141,8 +160,19 @@ class PrefsRobolectricTest : RobolectricTest() {
                 if (keys.size > keysSizeBefore) {
                     propertyNamesAndKeys[property.name] = keys.last()
                 }
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                val unwrapped =
+                    if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
+                if (property.name !in allowedNonPreferenceProperties) {
+                    unexpectedExceptions.add(unwrapped)
+                }
             }
+        }
+        if (unexpectedExceptions.isNotEmpty()) {
+            throw AssertionError(
+                "Unexpected exceptions thrown during Prefs property key mapping: $unexpectedExceptions",
+                unexpectedExceptions.first()
+            )
         }
         unmockkObject(Prefs)
         AnkiDroidApp.sharedPreferencesTestingOverride = null

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
@@ -73,7 +73,10 @@ class PrefsRobolectricTest : RobolectricTest() {
 
         for (property in Prefs::class.memberProperties) {
             if (property.visibility != KVisibility.PUBLIC) continue
-            property.getter.call(Prefs)
+            try {
+                property.getter.call(Prefs)
+            } catch (_: Exception) {
+            }
         }
         unmockkObject(Prefs)
         AnkiDroidApp.sharedPreferencesTestingOverride = null
@@ -132,8 +135,14 @@ class PrefsRobolectricTest : RobolectricTest() {
         val propertyNamesAndKeys = mutableMapOf<String, String>()
         for (property in Prefs::class.memberProperties) {
             if (property.visibility != KVisibility.PUBLIC) continue
-            property.getter.call(Prefs)
-            propertyNamesAndKeys[property.name] = keys.last()
+            val keysSizeBefore = keys.size
+            try {
+                property.getter.call(Prefs)
+                if (keys.size > keysSizeBefore) {
+                    propertyNamesAndKeys[property.name] = keys.last()
+                }
+            } catch (_: Exception) {
+            }
         }
         unmockkObject(Prefs)
         AnkiDroidApp.sharedPreferencesTestingOverride = null

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.settings
 import android.content.res.Resources
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -58,6 +59,27 @@ class PrefsTest {
 
             assertThat("The getter and setter of '${property.name}' use the same key", getterKey, equalTo(setterKey))
         }
+        unmockkObject(Prefs)
+        AnkiDroidApp.sharedPreferencesTestingOverride = null
+    }
+
+    @Test
+    fun `applyHiramekiCss setting reads from shared preferences`() {
+        val sharedPrefs = SPMockBuilder().createSharedPreferences()
+        AnkiDroidApp.sharedPreferencesTestingOverride = sharedPrefs
+        val mockResources = mockk<Resources>()
+        every { mockResources.getString(R.string.apply_hirameki_css_preference) } returns "applyHiramekiCss"
+        mockkObject(Prefs)
+        every { Prefs.resources } returns mockResources
+
+        assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_ALL))
+
+        sharedPrefs.edit().putString("applyHiramekiCss", Prefs.HIRAMEKI_CSS_NO_FONT_SIZE).commit()
+        assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_NO_FONT_SIZE))
+
+        sharedPrefs.edit().putString("applyHiramekiCss", Prefs.HIRAMEKI_CSS_DISABLED).commit()
+        assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_DISABLED))
+
         unmockkObject(Prefs)
         AnkiDroidApp.sharedPreferencesTestingOverride = null
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.settings
 
 import android.content.res.Resources
+import androidx.core.content.edit
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
@@ -57,7 +58,11 @@ class PrefsTest {
             }
             val setterKey = lastKey
 
-            assertThat("The getter and setter of '${property.name}' use the same key", getterKey, equalTo(setterKey))
+            assertThat(
+                "The getter and setter of '${property.name}' use the same key",
+                getterKey,
+                equalTo(setterKey)
+            )
         }
         unmockkObject(Prefs)
         AnkiDroidApp.sharedPreferencesTestingOverride = null
@@ -67,20 +72,30 @@ class PrefsTest {
     fun `applyHiramekiCss setting reads from shared preferences`() {
         val sharedPrefs = SPMockBuilder().createSharedPreferences()
         AnkiDroidApp.sharedPreferencesTestingOverride = sharedPrefs
-        val mockResources = mockk<Resources>()
-        every { mockResources.getString(R.string.apply_hirameki_css_preference) } returns "applyHiramekiCss"
-        mockkObject(Prefs)
-        every { Prefs.resources } returns mockResources
+        try {
+            val mockResources = mockk<Resources>()
+            every { mockResources.getString(R.string.apply_hirameki_css_preference) } returns "applyHiramekiCss"
+            mockkObject(Prefs)
+            every { Prefs.resources } returns mockResources
 
-        assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_ALL))
+            assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_ALL))
 
-        sharedPrefs.edit().putString("applyHiramekiCss", Prefs.HIRAMEKI_CSS_NO_FONT_SIZE).commit()
-        assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_NO_FONT_SIZE))
+            sharedPrefs.edit(commit = true) {
+                putString(
+                    "applyHiramekiCss", Prefs.HIRAMEKI_CSS_NO_FONT_SIZE
+                )
+            }
+            assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_NO_FONT_SIZE))
 
-        sharedPrefs.edit().putString("applyHiramekiCss", Prefs.HIRAMEKI_CSS_DISABLED).commit()
-        assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_DISABLED))
-
-        unmockkObject(Prefs)
-        AnkiDroidApp.sharedPreferencesTestingOverride = null
+            sharedPrefs.edit(commit = true) {
+                putString(
+                    "applyHiramekiCss", Prefs.HIRAMEKI_CSS_DISABLED
+                )
+            }
+            assertThat(Prefs.applyHiramekiCss, equalTo(Prefs.HIRAMEKI_CSS_DISABLED))
+        } finally {
+            unmockkObject(Prefs)
+            AnkiDroidApp.sharedPreferencesTestingOverride = null
+        }
     }
 }


### PR DESCRIPTION
This pull request adds a new user preference that controls the application of custom Hirameki CSS styles in the flashcard reviewer. It introduces a setting allowing users to choose whether all custom CSS, only partial CSS (disabling font size changes), or no custom CSS is applied to flashcards. The implementation includes updates to the UI, preferences system, and the Compose flashcard rendering logic to respect this new setting.

**User Preference Integration:**

* Added a new string preference `applyHiramekiCss` with options for "all", "no_font_size", and "disabled", and exposed it in the `Prefs` object for easy access. [[1]](diffhunk://#diff-683e37ec895f487c77006168489a240dfaa5b379b18d80ddd7e8fcefdc05bfddR242) [[2]](diffhunk://#diff-346a9ba80302bde8b517da97319d761ed9ebf3d6441da4683c7adcf1af2374d2L248-R248)
* Updated the reviewing preferences UI (`preferences_reviewing.xml`) to include a new list preference for controlling the Hirameki CSS application mode, with user-friendly labels and values. [[1]](diffhunk://#diff-b5f90e8cab429136c3208f9d7241efcc100a2be07270611ca2d6c042b1c8ffd6R64-R72) [[2]](diffhunk://#diff-90245b3aabb697f90a867f2dfd56e526ff1167b17b9c66b414e4ac044a55259aR326-R335) [[3]](diffhunk://#diff-019694600ddf48c04a96ea5326a284af3b523cb16e8dc07af2120e791ec232fcR475-R479)

**Flashcard Rendering Logic:**

* Modified the `Flashcard` composable to:
  - Read the new preference and update reactively when it changes.
  - Conditionally apply custom CSS to the flashcard HTML based on the selected mode:
    - "all": Apply all custom CSS (including font size).
    - "no_font_size": Apply custom CSS but omit font size, line height, and letter spacing.
    - "disabled": Omit all custom CSS. [[1]](diffhunk://#diff-14a601f9506e05a368449c0673d9d35522909e58f87f14583d69e52e9b2e211bR43-R47) [[2]](diffhunk://#diff-14a601f9506e05a368449c0673d9d35522909e58f87f14583d69e52e9b2e211bR78-R94) [[3]](diffhunk://#diff-14a601f9506e05a368449c0673d9d35522909e58f87f14583d69e52e9b2e211bL109-R146) [[4]](diffhunk://#diff-14a601f9506e05a368449c0673d9d35522909e58f87f14583d69e52e9b2e211bL121-L124) [[5]](diffhunk://#diff-14a601f9506e05a368449c0673d9d35522909e58f87f14583d69e52e9b2e211bR256)

These changes give users fine-grained control over flashcard CSS styling, improving customization and accessibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Reviewer CSS styling" preference section in the reviewing settings
  * Users can now choose between three CSS styling modes: apply all Hirameki CSS, disable font size changes only, or disable all custom CSS
  * The flashcard viewer now dynamically responds to the selected CSS styling preference

* **Tests**
  * Added comprehensive test coverage for the new CSS preference functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->