### PR TITLE
Fix custom study redirect on phones

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -22,18 +22,19 @@ package com.ichi2.anki
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableIntStateOf
-import com.ichi2.anki.CollectionManager.withCol
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.deckpicker.compose.StudyOptionsData
 import com.ichi2.anki.deckpicker.compose.StudyOptionsScreen
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
@@ -47,6 +48,15 @@ import kotlinx.coroutines.withContext
 class StudyOptionsComposeActivity : AnkiActivity() {
     @VisibleForTesting
     internal var collectionDispatcher: CoroutineDispatcher = ioDispatcher
+
+    private val reviewerLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS || result.resultCode == DeckPicker.RESULT_DB_ERROR || result.resultCode == DeckPicker.RESULT_MEDIA_EJECTED) {
+            setResult(result.resultCode)
+            finish()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -106,10 +116,12 @@ class StudyOptionsComposeActivity : AnkiActivity() {
             AnkiDroidTheme {
                 Scaffold { innerPadding ->
                     StudyOptionsScreen(
-                        modifier = Modifier.padding(innerPadding).fillMaxSize(),
+                        modifier = Modifier
+                            .padding(innerPadding)
+                            .fillMaxSize(),
                         studyOptionsData = studyOptionsData,
                         onStartStudy = {
-                            startActivity(Reviewer.getIntent(this))
+                            reviewerLauncher.launch(Reviewer.getIntent(this))
                         },
                         onCustomStudy = { deckId ->
                             showDialogFragment(CustomStudyDialog.createInstance(deckId))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableIntStateOf
 import com.ichi2.anki.CollectionManager.withCol
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -36,7 +37,9 @@ import androidx.compose.ui.Modifier
 import com.ichi2.anki.deckpicker.compose.StudyOptionsData
 import com.ichi2.anki.deckpicker.compose.StudyOptionsScreen
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -50,10 +53,21 @@ class StudyOptionsComposeActivity : AnkiActivity() {
             return
         }
         super.onCreate(savedInstanceState)
+
         setContent {
             var studyOptionsData by remember { mutableStateOf<StudyOptionsData?>(null) }
+            var refreshCounter by remember { mutableIntStateOf(0) }
 
-            LaunchedEffect(Unit) {
+            setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
+                when (CustomStudyAction.fromBundle(bundle)) {
+                    CustomStudyAction.CUSTOM_STUDY_SESSION -> finish()
+                    CustomStudyAction.EXTEND_STUDY_LIMITS -> {
+                        refreshCounter++
+                    }
+                }
+            }
+
+            LaunchedEffect(refreshCounter) {
                 studyOptionsData = withContext(collectionDispatcher) {
                     withCol {
                         val deckId = intent.getLongExtra(DECK_ID, decks.current().id)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -49,12 +49,16 @@ class StudyOptionsComposeActivity : AnkiActivity() {
     @VisibleForTesting
     internal var collectionDispatcher: CoroutineDispatcher = ioDispatcher
 
+    private var refreshCounter by mutableIntStateOf(0)
+
     private val reviewerLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (result.resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS || result.resultCode == DeckPicker.RESULT_DB_ERROR || result.resultCode == DeckPicker.RESULT_MEDIA_EJECTED) {
             setResult(result.resultCode)
             finish()
+        } else {
+            refreshCounter++
         }
     }
 
@@ -63,8 +67,6 @@ class StudyOptionsComposeActivity : AnkiActivity() {
             return
         }
         super.onCreate(savedInstanceState)
-
-        var refreshCounter by mutableIntStateOf(0)
 
         setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -54,18 +54,19 @@ class StudyOptionsComposeActivity : AnkiActivity() {
         }
         super.onCreate(savedInstanceState)
 
-        setContent {
-            var studyOptionsData by remember { mutableStateOf<StudyOptionsData?>(null) }
-            var refreshCounter by remember { mutableIntStateOf(0) }
+        var refreshCounter by mutableIntStateOf(0)
 
-            setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
-                when (CustomStudyAction.fromBundle(bundle)) {
-                    CustomStudyAction.CUSTOM_STUDY_SESSION -> finish()
-                    CustomStudyAction.EXTEND_STUDY_LIMITS -> {
-                        refreshCounter++
-                    }
+        setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
+            when (CustomStudyAction.fromBundle(bundle)) {
+                CustomStudyAction.CUSTOM_STUDY_SESSION -> finish()
+                CustomStudyAction.EXTEND_STUDY_LIMITS -> {
+                    refreshCounter++
                 }
             }
+        }
+
+        setContent {
+            var studyOptionsData by remember { mutableStateOf<StudyOptionsData?>(null) }
 
             LaunchedEffect(refreshCounter) {
                 studyOptionsData = withContext(collectionDispatcher) {


### PR DESCRIPTION
Fixed an issue where finishing a custom study session from the phone study options screen would not correctly redirect the user to the DeckPicker screen.

This introduces a listener for `CustomStudyAction.REQUEST_KEY` in `StudyOptionsComposeActivity.kt` using `setFragmentResultListener`. When `CUSTOM_STUDY_SESSION` is received, the activity calls `finish()` returning the user to the underlying DeckPicker. It handles `EXTEND_STUDY_LIMITS` by updating a counter that forces a refresh of the deck data block.

---
*PR created automatically by Jules for task [14775402294901371918](https://jules.google.com/task/14775402294901371918) started by @ColbyCabrera*