### PR TITLE
Animate DeckItem expand/collapse icon rotation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckItem.kt
@@ -189,6 +189,7 @@ fun DeckItem(
                 ) {
                     val rotation by animateFloatAsState(
                         targetValue = if (deck.collapsed) -90f else 0f,
+                        animationSpec = motionScheme.defaultSpatialSpec(),
                         label = "ExpandCollapseIconRotation"
                     )
                     Icon(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckItem.kt
@@ -55,7 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
@@ -197,7 +197,7 @@ fun DeckItem(
                             R.string.collapse
                         ),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.rotate(rotation)
+                        modifier = Modifier.graphicsLayer { rotationZ = rotation }
                     )
                 }
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckItem.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki.deckpicker.compose
 
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
@@ -54,6 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
@@ -185,14 +187,17 @@ fun DeckItem(
                         .padding(start = 6.dp)
                         .size(36.dp)
                 ) {
+                    val rotation by animateFloatAsState(
+                        targetValue = if (deck.collapsed) -90f else 0f,
+                        label = "ExpandCollapseIconRotation"
+                    )
                     Icon(
-                        painter = painterResource(
-                            if (deck.collapsed) R.drawable.keyboard_arrow_right_24px else R.drawable.keyboard_arrow_down_24px,
-                        ),
+                        painter = painterResource(R.drawable.keyboard_arrow_down_24px),
                         contentDescription = if (deck.collapsed) stringResource(R.string.expand) else stringResource(
                             R.string.collapse
                         ),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.rotate(rotation)
                     )
                 }
             } else {


### PR DESCRIPTION
Added a rotation animation to the DeckItem expand/collapse icon in DeckPickerScreen. This is a small UI enhancement that improves the transition when expanding/collapsing decks.

---
*PR created automatically by Jules for task [869652641659227015](https://jules.google.com/task/869652641659227015) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved expand/collapse indicator in the deck picker: a single icon now rotates smoothly to show state changes.
* **Accessibility**
  * Preserved dynamic descriptive labels for the expand/collapse control so screen readers reflect the current state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->