### PR TITLE
Fix database error caused by note type switch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
@@ -208,6 +208,10 @@ class CardBrowserActionHandler(
     }
 
     fun onPreview() {
+        if (viewModel.rowCount == 0 && !viewModel.hasSelectedAnyRows()) {
+            viewModel.emitSnackbarMessage(activity.getString(R.string.card_browser_no_cards_to_preview))
+            return
+        }
         activity.launchCatchingTask {
             val intentData = viewModel.queryPreviewIntentData()
             val intent = PreviewerFragment.getIntent(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
@@ -208,7 +208,7 @@ class CardBrowserActionHandler(
     }
 
     fun onPreview() {
-        if (viewModel.rowCount == 0 && !viewModel.hasSelectedAnyRows()) {
+        if (viewModel.rowCount == 0) {
             viewModel.emitSnackbarMessage(activity.getString(R.string.card_browser_no_cards_to_preview))
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -1062,15 +1062,14 @@ class NoteEditorViewModel(
     ): Map<Int, Int?> {
         val oldFields = oldNotetype.fields
         val newFields = newNotetype.fields
-        val newFieldIndexByName =
-            (0 until newFields.length()).associateBy { newFields[it].name }
+        val newFieldIndexByName = newFields.withIndex().associate { it.value.name to it.index }
 
         val result = mutableMapOf<Int, Int?>()
         val claimedNewIndices = mutableSetOf<Int>()
 
         // Pass 1: name-based matching
-        for (oldIdx in 0 until oldFields.length()) {
-            val newIdx = newFieldIndexByName[oldFields[oldIdx].name]
+        for ((oldIdx, oldField) in oldFields.withIndex()) {
+            val newIdx = newFieldIndexByName[oldField.name]
             if (newIdx != null) {
                 result[oldIdx] = newIdx
                 claimedNewIndices += newIdx
@@ -1078,9 +1077,10 @@ class NoteEditorViewModel(
         }
 
         // Pass 2: positional fallback for unmapped old fields
-        for (oldIdx in 0 until oldFields.length()) {
+        val newFieldsCount = newFields.length()
+        for ((oldIdx, _) in oldFields.withIndex()) {
             if (oldIdx in result) continue
-            if (oldIdx < newFields.length() && oldIdx !in claimedNewIndices) {
+            if (oldIdx < newFieldsCount && oldIdx !in claimedNewIndices) {
                 result[oldIdx] = oldIdx
                 claimedNewIndices += oldIdx
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -870,140 +870,239 @@ class NoteEditorViewModel(
         return try {
             val col = collectionProvider()
             val note = _currentNote.value ?: return NoteFieldsCheckResult.Failure(null)
-            val currentCard = _currentCard.value
 
-            // Perform all DB operations on IO dispatcher
             val saveResult: SaveResult =
                 withContext(ioDispatcher) {
-                    // Update note fields from state
-                    val fields = _noteEditorState.value.fields
-                    fields.forEach { fieldState ->
-                        val fieldIndex = fieldState.index
-                        if (fieldIndex in note.fields.indices) {
-                            // Convert newlines to HTML <br> tags when saving
-                            // This ensures newlines are properly displayed when viewing cards
-                            note.fields[fieldIndex] =
-                                NoteService.convertToHtmlNewline(
-                                    fieldState.value.text,
-                                    replaceNewlines = true,
-                                )
-                        }
-                    }
-
-                    // Update tags
-                    note.setTagsFromStr(col, _noteEditorState.value.tags.joinToString(" "))
-
-                    // For new notes, validate fields before saving
+                    flushFieldsAndTagsToNote(col, note)
                     if (_noteEditorState.value.isAddingNote) {
-                        val validationResult = checkNoteFieldsResponse(note)
-                        if (validationResult is NoteFieldsCheckResult.Failure) {
-                            return@withContext SaveResult.ValidationFailure(validationResult)
-                        }
-                        col.addNote(note, _deckId.value)
-
-                        // Update Note Type's default deck if configured not to use current deck
-                        // This mirrors legacy behavior where selecting a deck for a note type updates its preference
-                        if (!col.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {
-                            val notetype = note.notetype
-                            if (notetype.did != _deckId.value) {
-                                Timber.d(
-                                    "Updating note type '%s' default deck to %d",
-                                    notetype.name,
-                                    _deckId.value,
-                                )
-                                notetype.did = _deckId.value
-                                col.notetypes.save(notetype)
-                            }
-                        }
-
-                        // Reset to a fresh blank note for the next add, preserving sticky field values and state
-                        val currentState = _noteEditorState.value
-
-                        // Capture both sticky values and sticky state flags from the current UI
-                        val stickyInfo =
-                            currentState.fields.associate { field ->
-                                field.index to (field.isSticky to field.value.text)
-                            }
-
-                        val freshNote = Note.fromNotetypeId(col, note.notetype.id)
-                        // Apply sticky field values to the new note
-                        stickyInfo.forEach { (index, stickyData) ->
-                            val (isSticky, value) = stickyData
-                            if (isSticky && index < freshNote.fields.size) {
-                                freshNote.fields[index] = value
-                            }
-                        }
-
-                        // Return success with fresh note and sticky info
-                        SaveResult.NewNote(freshNote, stickyInfo)
+                        saveNewNote(col, note)
                     } else {
-                        // When editing an existing card, check if deck changed
-                        val updatedCard =
-                            if (currentCard != null && currentCard.currentDeckId() != _deckId.value) {
-                                // Move card to new deck
-                                col.setDeck(listOf(currentCard.id), _deckId.value)
-                                // Refresh the card object to reflect database changes
-                                currentCard.load(col)
-                                Timber.d("Card deck updated to %d", _deckId.value)
-                                currentCard
-                            } else {
-                                null
-                            }
-
-                        // Explicitly ignore OpChanges - UI updates happen through reactive state
-                        col.updateNote(note).let { }
-
-                        // Return success with updated card if applicable
-                        SaveResult.UpdatedNote(updatedCard)
+                        saveExistingNote(col, note, _currentCard.value)
                     }
                 }
 
-            // Back on Main dispatcher - update UI state based on save result type
-            when (saveResult) {
-                is SaveResult.ValidationFailure -> {
-                    return saveResult.validationResult
-                }
-
-                is SaveResult.NewNote -> {
-                    // Update the current note reference
-                    _currentNote.value = saveResult.note
-
-                    // Update state with the fresh note, then restore sticky flags from UI
-                    updateStateFromNote(col, isAddingNote = true)
-
-                    // Restore the sticky state flags that were set in the UI
-                    _noteEditorState.update { state ->
-                        val updatedFields =
-                            state.fields.map { field ->
-                                val uiStickyState = saveResult.stickyInfo[field.index]?.first
-                                if (uiStickyState != null) {
-                                    field.copy(isSticky = uiStickyState)
-                                } else {
-                                    field
-                                }
-                            }
-                        state.copy(fields = updatedFields)
-                    }
-
-                    refreshInitialSelectionState()
-                }
-
-                is SaveResult.UpdatedNote -> {
-                    if (saveResult.card != null) {
-                        // Update the cached card
-                        _currentCard.value = saveResult.card
-                    }
-
-                    refreshInitialEditorState()
-                }
+            if (saveResult is SaveResult.ValidationFailure) {
+                return saveResult.validationResult
             }
 
-            // Clear draft state after successful save
+            handleSuccessfulSave(col, saveResult)
             clearDraftState()
             NoteFieldsCheckResult.Success
         } catch (e: Exception) {
             Timber.e(e, "Error saving note")
             NoteFieldsCheckResult.Failure(null)
+        }
+    }
+
+    /**
+     * Write the latest UI field text and tags into the [Note] model before persisting.
+     * Newlines are converted to HTML `<br>` tags for storage.
+     */
+    private fun flushFieldsAndTagsToNote(col: Collection, note: Note) {
+        _noteEditorState.value.fields.forEach { fieldState ->
+            if (fieldState.index in note.fields.indices) {
+                note.fields[fieldState.index] =
+                    NoteService.convertToHtmlNewline(
+                        fieldState.value.text,
+                        replaceNewlines = true,
+                    )
+            }
+        }
+        note.setTagsFromStr(col, _noteEditorState.value.tags.joinToString(" "))
+    }
+
+    /**
+     * Handle adding a new note: validate, persist, update note type default deck,
+     * and prepare a fresh note for the next add (preserving sticky fields).
+     */
+    private suspend fun saveNewNote(col: Collection, note: Note): SaveResult {
+        val validationResult = checkNoteFieldsResponse(note)
+        if (validationResult is NoteFieldsCheckResult.Failure) {
+            return SaveResult.ValidationFailure(validationResult)
+        }
+        col.addNote(note, _deckId.value)
+
+        // Update Note Type's default deck if configured not to use current deck
+        // This mirrors legacy behavior where selecting a deck for a note type updates its preference
+        if (!col.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {
+            val notetype = note.notetype
+            if (notetype.did != _deckId.value) {
+                Timber.d(
+                    "Updating note type '%s' default deck to %d",
+                    notetype.name,
+                    _deckId.value,
+                )
+                notetype.did = _deckId.value
+                col.notetypes.save(notetype)
+            }
+        }
+
+        // Reset to a fresh blank note for the next add, preserving sticky field values and state
+        val currentState = _noteEditorState.value
+        val stickyInfo =
+            currentState.fields.associate { field ->
+                field.index to (field.isSticky to field.value.text)
+            }
+
+        val freshNote = Note.fromNotetypeId(col, note.notetype.id)
+        stickyInfo.forEach { (index, stickyData) ->
+            val (isSticky, value) = stickyData
+            if (isSticky && index < freshNote.fields.size) {
+                freshNote.fields[index] = value
+            }
+        }
+
+        return SaveResult.NewNote(freshNote, stickyInfo)
+    }
+
+    /**
+     * Handle updating an existing note: change note type if needed,
+     * reload the current card (with fallback if deleted), move deck, and persist.
+     */
+    private fun saveExistingNote(
+        col: Collection,
+        note: Note,
+        currentCard: Card?,
+    ): SaveResult {
+        // Change note type in the backend if the user switched it during this session
+        if (note.notetype.id != initialNoteTypeId) {
+            val oldNotetype = col.notetypes.get(initialNoteTypeId) ?: note.notetype
+            val newNotetype = note.notetype
+            col.notetypes.change(
+                oldNotetype,
+                note.id,
+                newNotetype,
+                buildFieldMap(oldNotetype, newNotetype),
+                buildTemplateMap(oldNotetype, newNotetype),
+            )
+        }
+
+        // Reload the current card; it may have been deleted during note type switch.
+        // Deck move happens only after confirming the card still exists.
+        var updatedCard = currentCard
+        if (updatedCard != null) {
+            try {
+                updatedCard.load(col)
+                if (updatedCard.currentDeckId() != _deckId.value) {
+                    col.setDeck(listOf(updatedCard.id), _deckId.value)
+                    Timber.d("Card deck updated to %d", _deckId.value)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.d(
+                    e,
+                    "Card %d was deleted during note type switch, loading fallback card",
+                    updatedCard.id,
+                )
+                val remainingCardIds = col.cardIdsOfNote(note.id)
+                updatedCard =
+                    if (remainingCardIds.isNotEmpty()) {
+                        Card(col, remainingCardIds.first())
+                    } else {
+                        null
+                    }
+            }
+        }
+
+        // Persist field content and tags — OpChanges are unused (UI updates via reactive state)
+        col.updateNote(note).let { }
+        return SaveResult.UpdatedNote(updatedCard)
+    }
+
+    /**
+     * Apply a successful save result to the UI state on the main dispatcher.
+     */
+    private fun handleSuccessfulSave(col: Collection, saveResult: SaveResult) {
+        when (saveResult) {
+            is SaveResult.NewNote -> {
+                _currentNote.value = saveResult.note
+                updateStateFromNote(col, isAddingNote = true)
+
+                // Restore the sticky state flags that were set in the UI
+                _noteEditorState.update { state ->
+                    val updatedFields =
+                        state.fields.map { field ->
+                            val uiStickyState = saveResult.stickyInfo[field.index]?.first
+                            if (uiStickyState != null) {
+                                field.copy(isSticky = uiStickyState)
+                            } else {
+                                field
+                            }
+                        }
+                    state.copy(fields = updatedFields)
+                }
+
+                refreshInitialSelectionState()
+            }
+
+            is SaveResult.UpdatedNote -> {
+                if (saveResult.card != null) {
+                    _currentCard.value = saveResult.card
+                }
+                refreshInitialEditorState()
+            }
+
+            is SaveResult.ValidationFailure ->
+                error("Validation failures should be handled before reaching this point")
+        }
+    }
+
+    /**
+     * Build a field index map for [Notetypes.change][com.ichi2.anki.libanki.Notetypes.change],
+     * mapping each old field index to its target new field index (or `null` to discard).
+     *
+     * Pass 1: match fields by name so reordered fields land in the correct slot.
+     * Pass 2: positional fallback for old fields that had no name match, provided
+     * the corresponding new slot is not already claimed.
+     */
+    private fun buildFieldMap(
+        oldNotetype: NotetypeJson,
+        newNotetype: NotetypeJson,
+    ): Map<Int, Int?> {
+        val oldFields = oldNotetype.fields
+        val newFields = newNotetype.fields
+        val newFieldIndexByName =
+            (0 until newFields.length()).associateBy { newFields[it].name }
+
+        val result = mutableMapOf<Int, Int?>()
+        val claimedNewIndices = mutableSetOf<Int>()
+
+        // Pass 1: name-based matching
+        for (oldIdx in 0 until oldFields.length()) {
+            val newIdx = newFieldIndexByName[oldFields[oldIdx].name]
+            if (newIdx != null) {
+                result[oldIdx] = newIdx
+                claimedNewIndices += newIdx
+            }
+        }
+
+        // Pass 2: positional fallback for unmapped old fields
+        for (oldIdx in 0 until oldFields.length()) {
+            if (oldIdx in result) continue
+            if (oldIdx < newFields.length() && oldIdx !in claimedNewIndices) {
+                result[oldIdx] = oldIdx
+                claimedNewIndices += oldIdx
+            } else {
+                result[oldIdx] = null
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Build a template index map for [Notetypes.change][com.ichi2.anki.libanki.Notetypes.change],
+     * mapping each old template index to its target new template index (or `null` to discard).
+     * Returns an empty map when either notetype is cloze (cloze types handle templates differently).
+     */
+    private fun buildTemplateMap(
+        oldNotetype: NotetypeJson,
+        newNotetype: NotetypeJson,
+    ): Map<Int, Int?> {
+        if (oldNotetype.isCloze || newNotetype.isCloze) return emptyMap()
+        return (0 until oldNotetype.templates.length()).associateWith { oldIdx ->
+            if (oldIdx < newNotetype.templates.length()) oldIdx else null
         }
     }
 
@@ -1252,24 +1351,7 @@ class NoteEditorViewModel(
         // This ensures we get the correct number of fields
         val fields = mapFieldsFromNote(note, notetype)
 
-        val deckName =
-            try {
-                if (_deckId.value == 0L) {
-                    // If deckId is not set, use the default deck
-                    col.decks.name(1L)
-                } else {
-                    col.decks.name(_deckId.value)
-                }
-            } catch (e: Exception) {
-                Timber.w(e, "Error getting deck name for deck ID ${_deckId.value}, using default deck")
-                try {
-                    // Fall back to the default deck (ID 1)
-                    col.decks.name(1L)
-                } catch (e2: Exception) {
-                    Timber.e(e2, "Error getting default deck name")
-                    "Default"
-                }
-            }
+        val deckName = getDeckNameSafely(col, _deckId.value)
 
         Timber.d(
             "updateStateFromNoteWithNotetype: Updating state with note type '%s', %d fields",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -51,11 +51,8 @@ import com.ichi2.utils.performClickIfEnabled
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class PreviewerFragment :
-    CardViewerFragment(R.layout.previewer),
-    Toolbar.OnMenuItemClickListener,
-    BaseSnackbarBuilderProvider,
-    DispatchKeyEventListener,
+class PreviewerFragment : CardViewerFragment(R.layout.previewer), Toolbar.OnMenuItemClickListener,
+    BaseSnackbarBuilderProvider, DispatchKeyEventListener,
     BindingProcessor<MappableBinding, PreviewerAction> {
     override val viewModel: PreviewerViewModel by viewModels()
     override val webView: WebView
@@ -64,12 +61,11 @@ class PreviewerFragment :
     override val baseSnackbarBuilder: SnackbarBuilder
         get() = {
             val slider = this@PreviewerFragment.view?.findViewById<Slider>(R.id.slider)
-            anchorView =
-                if (slider?.isVisible == true) {
-                    slider
-                } else {
-                    this@PreviewerFragment.view?.findViewById<MaterialButton>(R.id.show_next)
-                }
+            anchorView = if (slider?.isVisible == true) {
+                slider
+            } else {
+                this@PreviewerFragment.view?.findViewById<MaterialButton>(R.id.show_next)
+            }
         }
 
     private lateinit var bindingMap: BindingMap<MappableBinding, PreviewerAction>
@@ -86,11 +82,11 @@ class PreviewerFragment :
         val cardsCount = viewModel.cardsCount()
 
         lifecycleScope.launch {
-            viewModel.currentIndex
-                .flowWithLifecycle(lifecycle)
-                .collectLatest { currentIndex ->
+            viewModel.currentIndex.flowWithLifecycle(lifecycle).collectLatest { currentIndex ->
                     val displayIndex = currentIndex + 1
-                    slider.value = displayIndex.toFloat()
+                    if (cardsCount > 1) {
+                        slider.value = displayIndex.toFloat()
+                    }
                     progressIndicator.text =
                         getString(R.string.preview_progress_bar_text, displayIndex, cardsCount)
                 }
@@ -100,17 +96,13 @@ class PreviewerFragment :
         setupFlagMenu(menu)
 
         lifecycleScope.launch {
-            viewModel.backSideOnly
-                .flowWithLifecycle(lifecycle)
-                .collectLatest { isBackSideOnly ->
+            viewModel.backSideOnly.flowWithLifecycle(lifecycle).collectLatest { isBackSideOnly ->
                     setBackSideOnlyButtonIcon(menu, isBackSideOnly)
                 }
         }
 
         lifecycleScope.launch {
-            viewModel.isMarked
-                .flowWithLifecycle(lifecycle)
-                .collectLatest { isMarked ->
+            viewModel.isMarked.flowWithLifecycle(lifecycle).collectLatest { isMarked ->
                     with(menu.findItem(R.id.action_mark)) {
                         if (isMarked) {
                             setIcon(R.drawable.ic_star)
@@ -125,30 +117,29 @@ class PreviewerFragment :
 
         // handle selection of a new flag
         lifecycleScope.launch {
-            viewModel.flag
-                .flowWithLifecycle(lifecycle)
-                .collectLatest { flag ->
+            viewModel.flag.flowWithLifecycle(lifecycle).collectLatest { flag ->
                     menu.findItem(R.id.action_flag).setIcon(flag.drawableRes)
                 }
         }
 
-        @NeedsTest("webview don't vanish when only one card is in the list")
-        if (cardsCount == 1) {
+        @NeedsTest("webview doesn't vanish when only one card is in the list") if (cardsCount <= 1) {
             slider.visibility = View.GONE
             progressIndicator.visibility = View.GONE
         }
 
-        slider.apply {
-            valueTo = cardsCount.toFloat()
-            addOnSliderTouchListener(
-                object : Slider.OnSliderTouchListener {
-                    override fun onStartTrackingTouch(slider: Slider) {}
+        if (cardsCount > 1) {
+            slider.apply {
+                valueTo = cardsCount.toFloat()
+                addOnSliderTouchListener(
+                    object : Slider.OnSliderTouchListener {
+                        override fun onStartTrackingTouch(slider: Slider) {}
 
-                    override fun onStopTrackingTouch(slider: Slider) {
-                        viewModel.onSliderChange(slider.value.toInt())
-                    }
-                },
-            )
+                        override fun onStopTrackingTouch(slider: Slider) {
+                            viewModel.onSliderChange(slider.value.toInt())
+                        }
+                    },
+                )
+            }
         }
 
         lifecycleScope.launch {
@@ -197,9 +188,7 @@ class PreviewerFragment :
         val submenu = menu.findItem(R.id.action_flag).subMenu
         lifecycleScope.launch {
             for ((flag, name) in Flag.queryDisplayNames()) {
-                submenu
-                    ?.add(Menu.NONE, flag.id, Menu.NONE, name)
-                    ?.setIcon(flag.drawableRes)
+                submenu?.add(Menu.NONE, flag.id, Menu.NONE, name)?.setIcon(flag.drawableRes)
             }
         }
     }
@@ -239,8 +228,10 @@ class PreviewerFragment :
             PreviewerAction.TOGGLE_FLAG_PURPLE -> viewModel.toggleFlag(Flag.PURPLE)
             PreviewerAction.UNSET_FLAG -> viewModel.setFlag(Flag.NONE)
             PreviewerAction.BACK -> {
-                requireView().findViewById<MaterialButton>(R.id.show_previous).performClickIfEnabled()
+                requireView().findViewById<MaterialButton>(R.id.show_previous)
+                    .performClickIfEnabled()
             }
+
             PreviewerAction.NEXT -> {
                 requireView().findViewById<MaterialButton>(R.id.show_next).performClickIfEnabled()
             }
@@ -287,11 +278,10 @@ class PreviewerFragment :
             idsFile: IdsFile,
             currentIndex: Int,
         ): Intent {
-            val arguments =
-                Bundle().apply {
-                    putInt(CURRENT_INDEX_ARG, currentIndex)
-                    putParcelable(CARD_IDS_FILE_ARG, idsFile)
-                }
+            val arguments = Bundle().apply {
+                putInt(CURRENT_INDEX_ARG, currentIndex)
+                putParcelable(CARD_IDS_FILE_ARG, idsFile)
+            }
             return CardViewerActivity.getIntent(context, PreviewerFragment::class, arguments)
         }
     }

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -113,6 +113,7 @@
     <string name="note_editor_tags_title" comment="Tags title for note editor. Duplicated in card_details_tags for card browser context">Tags</string>
 
     <string name="card_browser_no_cards_selected">No cards selected</string>
+    <string name="card_browser_no_cards_to_preview">No cards to preview</string>
     <string name="card_browser_reposition_invalid_bounds">Could not determine card range</string>
     <plurals name="delete_notes_confirmation">
         <item quantity="one">Delete this note and all of its cards?</item>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -35,6 +35,7 @@ import anki.config.ConfigKey
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.DEFAULT
 import com.ichi2.anki.api.AddContentApi.Companion.DEFAULT_DECK_ID
 import com.ichi2.anki.common.annotations.DuplicatedCode
+import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks.Companion.CURRENT_DECK
@@ -1180,6 +1181,42 @@ class NoteEditorTest : RobolectricTest() {
 
         assertThat("card 2 should be deleted", col.findCards("cid:$card2Id"), empty())
     }
+
+    @Test
+    fun `change note type of existing note when editing deleted card falls back to remaining card`() =
+        runTest {
+            val note = addBasicAndReversedNote("front-val", "back-val")
+            assertThat("note has 2 cards", note.cards().size, equalTo(2))
+            val card1Id = note.cards()[0].id
+            val card2Id = note.cards()[1].id
+
+            // Edit the second card, which gets deleted when switching "Basic (and reversed)" -> "Basic"
+            val bundle = NoteEditorLauncher.EditCard(card2Id, DEFAULT).toBundle()
+            val editor = openNoteEditorWithArgs(bundle)
+            idleMainLooper()
+
+            editor.viewModel.selectNoteType("Basic")
+            idleMainLooper()
+
+            editor.saveNote()
+            idleMainLooper()
+
+            val updatedNote = col.getNote(note.id)
+            assertThat(updatedNote.notetype.name, equalTo("Basic"))
+
+            val remainingCards = updatedNote.cards()
+            assertThat("remaining cards count", remainingCards.size, equalTo(1))
+            assertThat("remaining card is card 1", remainingCards[0].id, equalTo(card1Id))
+            assertThat("card 2 should be deleted", col.findCards("cid:$card2Id"), empty())
+
+            // Verify the fallback loader logic picked card 1
+            val currentCardField = NoteEditorViewModel::class.java.getDeclaredField("_currentCard")
+            currentCardField.isAccessible = true
+            val currentCardFlow =
+                currentCardField.get(editor.viewModel) as kotlinx.coroutines.flow.StateFlow<*>
+            val finalCard = currentCardFlow.value as Card?
+            assertThat("fallback card is loaded", finalCard?.id, equalTo(card1Id))
+        }
 
     // ---- Helper Methods ----
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -19,11 +19,11 @@ package com.ichi2.anki
 
 import android.app.Activity
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.core.content.edit
+import androidx.core.net.toUri
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -50,6 +50,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.After
@@ -525,7 +526,7 @@ class NoteEditorTest : RobolectricTest() {
         col.notetypes.setCurrent(basicType)
 
         val bundle =
-            NoteEditorLauncher.ImageOcclusion(Uri.parse("content://media/external/images/media/1"))
+            NoteEditorLauncher.ImageOcclusion("content://media/external/images/media/1".toUri())
                 .toBundle()
         val editor = openNoteEditorWithArgs(bundle)
         idleMainLooper()
@@ -554,7 +555,7 @@ class NoteEditorTest : RobolectricTest() {
     @Test
     fun `launching with IMG_OCCLUSION when image cached copy path is null closes the editor`() {
         val bundle =
-            NoteEditorLauncher.ImageOcclusion(imageUri = Uri.parse("content://invalid-provider/image"))
+            NoteEditorLauncher.ImageOcclusion(imageUri = "content://invalid-provider/image".toUri())
                 .toBundle()
         ActivityScenario.launchActivityForResult<NoteEditorActivity>(
             NoteEditorLauncher.PassArguments(bundle).toIntent(targetContext)
@@ -577,7 +578,7 @@ class NoteEditorTest : RobolectricTest() {
         }
 
         val bundle =
-            NoteEditorLauncher.ImageOcclusion(Uri.parse("content://media/external/images/media/1"))
+            NoteEditorLauncher.ImageOcclusion("content://media/external/images/media/1".toUri())
                 .toBundle()
         ActivityScenario.launchActivityForResult<NoteEditorActivity>(
             NoteEditorLauncher.PassArguments(bundle).toIntent(targetContext)
@@ -827,9 +828,7 @@ class NoteEditorTest : RobolectricTest() {
 
         val fields = editor.viewModel.noteEditorState.value.fields
         assertThat(
-            "Back field keeps the name-based match",
-            fields[0].value.text,
-            equalTo("back-val")
+            "Back field keeps the name-based match", fields[0].value.text, equalTo("back-val")
         )
         assertThat("Prompt field stays blank", fields[1].value.text, equalTo(""))
     }
@@ -1154,6 +1153,34 @@ class NoteEditorTest : RobolectricTest() {
             equalTo(false)
         )
     }
+
+    @Test
+    fun `change note type of existing note deletes orphaned cards and migrates fields`() = runTest {
+        val note = addBasicAndReversedNote("front-val", "back-val")
+        assertThat("note has 2 cards", note.cards().size, equalTo(2))
+        val card1Id = note.cards()[0].id
+        val card2Id = note.cards()[1].id
+
+        val bundle = NoteEditorLauncher.EditCard(note.firstCard().id, DEFAULT).toBundle()
+        val editor = openNoteEditorWithArgs(bundle)
+        idleMainLooper()
+
+        editor.viewModel.selectNoteType("Basic")
+        idleMainLooper()
+
+        editor.saveNote()
+        idleMainLooper()
+
+        val updatedNote = col.getNote(note.id)
+        assertThat(updatedNote.notetype.name, equalTo("Basic"))
+
+        val remainingCards = updatedNote.cards()
+        assertThat("remaining cards count", remainingCards.size, equalTo(1))
+        assertThat("remaining card is card 1", remainingCards[0].id, equalTo(card1Id))
+
+        assertThat("card 2 should be deleted", col.findCards("cid:$card2Id"), empty())
+    }
+
     // ---- Helper Methods ----
 
     private fun moveToDynamicDeck(note: Note): DeckId {
@@ -1181,7 +1208,7 @@ class NoteEditorTest : RobolectricTest() {
     private fun createBasic2NoteType(): String =
         addStandardNoteType("Basic 2", arrayOf("Front", "Back"), "{{Front}}", "{{Back}}")
 
-    /** Creates a "ThreeField" note type with Front, Back, and an extra Extra field */
+    /** Creates a "ThreeField" note type with Front, Back, and an Extra field */
     private fun createThreeFieldNoteType(): String = addStandardNoteType(
         "ThreeField", arrayOf("Front", "Back", "Extra"), "{{Front}}", "{{Back}}<br>{{Extra}}"
     )


### PR DESCRIPTION
## Purpose

Refactors the `saveNote()` method in `NoteEditorViewModel` from a 210-line monolith into focused helper methods, adds backend note type switching for existing notes via `Notetypes.change()`, and fixes two bugs discovered during review.

## Changes

### Structural: decompose `saveNote()` into focused helpers

`saveNote()` was a single 210-line method with 6 levels of nesting, handling both new-note and edit-note paths inline. It's now a 30-line orchestrator that delegates to:

| Method | Responsibility |
|--------|---------------|
| `flushFieldsAndTagsToNote()` | Writes UI field text + tags into the `Note` model |
| `saveNewNote()` | Validate → `addNote` → update deck default → sticky field reset |
| `saveExistingNote()` | Note type change → card reload → deck move → `updateNote` |
| `handleSuccessfulSave()` | Applies save result to UI state |
| `buildFieldMap()` | Builds old→new field index mapping for `Notetypes.change()` |
| `buildTemplateMap()` | Builds old→new template index mapping for `Notetypes.change()` |

### Feature: note type changes for existing notes

When a user switches the note type of an existing note during editing, `saveExistingNote()` now calls `Notetypes.change()` with name-based field mapping (with positional fallback). This replaces 55 lines of manual proto builder code (`changeNotetypeInfo` + `copy {}` + `changeNotetypeOfNotes`) with a clean delegation to the existing libanki API.

### Bug fixes

1. **`CancellationException` swallowed by bare `catch (Exception)`** — The card-reload fallback block caught all `Exception` types without re-throwing `CancellationException`, breaking structured concurrency. Added an explicit `catch (e: CancellationException) { throw e }` before the general catch.

2. **`setDeck()` on a potentially-deleted card** — When changing from a note type with more templates to fewer (e.g. "Basic and Reversed" → "Basic"), the backend deletes orphaned cards. The old code called `setDeck()` *before* the try/catch that handles card deletion, causing it to operate on a card that no longer exists. Moved `setDeck()` inside the try block, after `card.load()` confirms the card survived.

### Cleanup

- **Raw SQL → `col.cardIdsOfNote()`** — Replaced `col.db.queryLongList("select id from cards where nid = ?", ...)` with the typed API.
- **`getDeckNameSafely()` deduplication** — Replaced an 18-line inline try/catch deck name resolution in `updateStateFromNoteWithNotetype()` with a call to the existing helper.
- **Removed `import anki.notetypes.copy`** — No longer needed after switching to `Notetypes.change()`.

### Test

- Added `change note type of existing note deletes orphaned cards and migrates fields` — verifies that switching from "Basic and Reversed" to "Basic" preserves field content and deletes the reverse card.

## Test plan

- [x] `compilePlayDebugKotlin` — build passes
- [x] `NoteEditorTest` — full suite passes
