### PR TITLE
Migrate dialogs to MaterialAlertDialogBuilder for Material 3 compliance

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -62,6 +62,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.net.toFile
 import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat
@@ -682,7 +683,7 @@ abstract class AbstractFlashcardViewer :
 
     protected fun showDeleteNoteDialog() {
         Timber.i("Displaying 'delete note' dialog")
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             title(R.string.delete_card_title)
             setIcon(R.drawable.ic_warning)
             message(
@@ -2019,7 +2020,7 @@ abstract class AbstractFlashcardViewer :
                 val actionNumber = url.substringAfter(":")
                 val message = getString(R.string.missing_user_action_dialog_message, actionNumber)
                 Timber.i("showing 'missing user action' dialog")
-                AlertDialog.Builder(this@AbstractFlashcardViewer).show {
+                MaterialAlertDialogBuilder(this@AbstractFlashcardViewer).show {
                     setTitle(R.string.vague_error)
                     setMessage(message)
                     setPositiveButton(R.string.dialog_ok) { _, _ -> }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -24,6 +24,7 @@ import android.widget.EditText
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.widget.doAfterTextChanged
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.libanki.CardTemplate
@@ -113,7 +114,7 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
     }
 
     private fun showRestoreDefaultDialog() {
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             positiveButton(R.string.dialog_ok) {
                 restoreDefaultAndClose()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -42,6 +42,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -973,7 +974,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
          * it displays a warning for the user when they attempt to delete a card type that
             would leave some notes without any cards (orphan notes) */
         private fun showOrphanNoteDialog() {
-            val builder = AlertDialog.Builder(requireContext()).setTitle(R.string.orphan_note_title)
+            val builder = MaterialAlertDialogBuilder(requireContext()).setTitle(R.string.orphan_note_title)
                 .setMessage(R.string.orphan_note_message)
                 .setPositiveButton(android.R.string.ok, null)
 
@@ -1154,7 +1155,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                     Timber.i("CardTemplateEditor:: Restore to default button pressed")
 
                     fun askUser(kind: StockNotetype.Kind? = null) {
-                        AlertDialog.Builder(requireContext()).show {
+                        MaterialAlertDialogBuilder(requireContext()).show {
                             setTitle(TR.cardTemplatesRestoreToDefault())
                             setMessage(TR.cardTemplatesRestoreToDefaultConfirmation())
                             setPositiveButton(R.string.dialog_ok) { _, _ ->
@@ -1179,7 +1180,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                         val stockNotetypesNames = withCol {
                             stockNotetypeKinds.map { getStockNotetype(it).name }
                         }
-                        AlertDialog.Builder(requireContext()).show {
+                        MaterialAlertDialogBuilder(requireContext()).show {
                             setTitle(TR.cardTemplatesRestoreToDefault())
                             setNegativeButton(R.string.dialog_cancel) { _, _ -> }
                             listItems(stockNotetypesNames) { _: DialogInterface, index: Int ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -25,6 +25,7 @@ import android.view.WindowManager
 import android.view.WindowManager.BadTokenException
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -274,8 +275,7 @@ fun Context.showError(
     Timber.i("Error dialog displayed")
 
     try {
-        AlertDialog
-            .Builder(this)
+        MaterialAlertDialogBuilder(this)
             .create {
                 title(R.string.vague_error)
                 message(text = message)
@@ -560,7 +560,7 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(col: Collection): Boolean {
         return true
     }
     return suspendCoroutine { coroutine ->
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             message(text = col.tr.deckConfigWillRequireFullSync()) // generic message
             positiveButton(R.string.dialog_ok) {
                 col.modSchemaNoCheck()
@@ -584,7 +584,7 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(): Boolean {
     }
     val hasAcceptedSchemaChange =
         suspendCoroutine { coroutine ->
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 message(text = TR.deckConfigWillRequireFullSync().replace("\\s+".toRegex(), " "))
                 positiveButton(R.string.dialog_ok) { coroutine.resume(true) }
                 negativeButton(R.string.dialog_cancel) { coroutine.resume(false) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -48,6 +48,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -686,7 +687,7 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
                 getString(R.string.link_full_storage_access),
             )
         }
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             title(R.string.directory_inaccessible)
             customView(
                 contentView,
@@ -954,7 +955,7 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
 
     private fun showMediaCheckDialog() {
         Timber.i("showing media check dialog")
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             title(text = getString(R.string.check_media_title))
             message(text = getString(R.string.check_media_warning))
             positiveButton(R.string.dialog_ok) {
@@ -1404,7 +1405,7 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
                 Timber.i("showStartupScreensAndDialogs() running integrityCheck()")
                 // #5852 - since we may have a warning about disk space, we don't want to force a check database
                 // and show a warning before the user knows what is happening.
-                AlertDialog.Builder(this).show {
+                MaterialAlertDialogBuilder(this).show {
                     title(R.string.integrity_check_startup_title)
                     message(R.string.integrity_check_startup_content)
                     positiveButton(R.string.check_db) {
@@ -1555,7 +1556,7 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
         val status = CollectionIntegrityStorageCheck.createInstance(this)
         if (status.shouldWarnOnIntegrityCheck()) {
             Timber.d("Displaying File Size confirmation")
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 title(R.string.check_db_title)
                 message(text = status.getWarningDetails(this@DeckPicker))
                 positiveButton(R.string.integrity_check_continue_anyway) {
@@ -1634,7 +1635,7 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
         }
         // Warn the user in case the connection is metered
         if (!Prefs.allowSyncOnMeteredConnections && isActiveNetworkMetered()) {
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 message(R.string.metered_sync_data_warning)
                 positiveButton(R.string.dialog_continue) { doSync() }
                 negativeButton(R.string.dialog_cancel) { viewModel.isSyncing.value = false }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -37,6 +37,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -943,7 +944,7 @@ class NoteEditorFragment :
 
     private fun displayFontSizeDialog() {
         val sizeCodes = resources.getStringArray(R.array.html_size_codes)
-        AlertDialog.Builder(requireContext()).show {
+        MaterialAlertDialogBuilder(requireContext()).show {
             setItems(R.array.html_size_code_labels) { _, index ->
                 val size = sizeCodes.getOrNull(index) ?: return@setItems
                 applyFormatter("<span style=\"font-size:$size\">", "</span>")
@@ -954,7 +955,7 @@ class NoteEditorFragment :
 
     private fun displayInsertHeadingDialog() {
         val headingTags = arrayOf("h1", "h2", "h3", "h4", "h5")
-        AlertDialog.Builder(requireContext()).show {
+        MaterialAlertDialogBuilder(requireContext()).show {
             setItems(headingTags) { _, index ->
                 val tag = headingTags.getOrNull(index) ?: return@setItems
                 applyFormatter("<$tag>", "</$tag>")
@@ -976,7 +977,7 @@ class NoteEditorFragment :
                 MathJaxOption(TR.editingMathjaxChemistry(), prefix = "\\( \\ce{", suffix = "} \\)"),
             )
 
-        AlertDialog.Builder(requireContext()).show {
+        MaterialAlertDialogBuilder(requireContext()).show {
             setItems(options.map(MathJaxOption::label).toTypedArray()) { _, index ->
                 val option = options.getOrNull(index) ?: return@setItems
                 applyFormatter(option.prefix, option.suffix)
@@ -1757,7 +1758,7 @@ class NoteEditorFragment :
         button: CustomToolbarButton,
         editToolbarItemDialog: AlertDialog,
     ) {
-        AlertDialog.Builder(requireContext()).show {
+        MaterialAlertDialogBuilder(requireContext()).show {
             title(R.string.remove_toolbar_item)
             positiveButton(R.string.dialog_positive_delete) {
                 editToolbarItemDialog.dismiss()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -31,6 +31,7 @@ import android.widget.ListView
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.os.BundleCompat
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.snackbar.Snackbar
@@ -208,7 +209,7 @@ class NoteTypeFieldEditor : AnkiActivity() {
             }
         fieldNameInput?.let { fieldNameInput ->
             fieldNameInput.isSingleLine = true
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 customView(view = fieldNameInput, paddingStart = 64, paddingEnd = 64, paddingTop = 32)
                 title(R.string.model_field_editor_add)
                 positiveButton(R.string.dialog_ok) {
@@ -335,7 +336,7 @@ class NoteTypeFieldEditor : AnkiActivity() {
             fieldNameInput.isSingleLine = true
             fieldNameInput.setText(fieldsLabels[currentPos])
             fieldNameInput.setSelection(fieldNameInput.text!!.length)
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 customView(view = fieldNameInput, paddingStart = 64, paddingEnd = 64, paddingTop = 32)
                 title(R.string.model_field_editor_rename)
                 positiveButton(R.string.rename) {
@@ -384,8 +385,7 @@ class NoteTypeFieldEditor : AnkiActivity() {
             numberOfTemplates: Int,
             result: (Int) -> Unit,
         ) {
-            AlertDialog
-                .Builder(this)
+            MaterialAlertDialogBuilder(this)
                 .show {
                     positiveButton(R.string.dialog_ok) {
                         val input = (it as AlertDialog).getInputField()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -24,6 +24,7 @@ import android.view.WindowManager.BadTokenException
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.libanki.Card
@@ -110,7 +111,7 @@ object ReadText {
         ReadText.did = did
         ReadText.ord = ord
         val res = flashCardViewer.get()!!.resources
-        val dialog = AlertDialog.Builder(flashCardViewer.get()!!)
+        val dialog = MaterialAlertDialogBuilder(flashCardViewer.get()!!)
         if (availableLocales().isEmpty()) {
             Timber.w("ReadText.textToSpeech() no TTS languages available")
             dialog
@@ -152,7 +153,7 @@ object ReadText {
     }
 
     private fun showDialogAfterDelay(
-        dialog: AlertDialog.Builder,
+        dialog: MaterialAlertDialogBuilder,
         delayMillis: Int,
     ) {
         postDelayedOnNewHandler({

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -37,6 +37,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.TooltipCompat
@@ -964,7 +965,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
             resources.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins)
         suspendCancellableCoroutine { coroutines ->
             Timber.i("Showing timebox reached dialog")
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 title(R.string.timebox_reached_title)
                 message(text = timeboxMessage)
                 positiveButton(R.string.dialog_continue) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -22,6 +22,7 @@ import android.view.WindowManager
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import com.google.android.material.textfield.TextInputEditText
@@ -78,7 +79,7 @@ class RepositionCardFragment : DialogFragment() {
                 .browsingRepositionNewCards()
                 .toSentenceCase(requireContext(), R.string.sentence_reposition_new_cards)
         val dialog =
-            AlertDialog.Builder(requireContext()).create {
+            MaterialAlertDialogBuilder(requireContext()).create {
                 title(text = title)
                 customView(dialogView)
                 negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
@@ -19,6 +19,7 @@ import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Lifecycle
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.R
 import com.ichi2.anki.libanki.CardId
@@ -146,7 +147,7 @@ open class OnRenderProcessGoneDelegate(
         } else {
             res.getString(R.string.webview_crash_oom_details)
         }
-        AlertDialog.Builder(target).show {
+        MaterialAlertDialogBuilder(target).show {
             title(R.string.webview_crash_loop_dialog_title)
             message(
                 text = res.getString(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -260,7 +261,7 @@ class BackupPromptDialog private constructor(
                 return
             }
 
-            AlertDialog.Builder(context).show {
+            MaterialAlertDialogBuilder(context).show {
                 title(R.string.dismiss_backup_warning_title)
                 message(message)
                 setIcon(R.drawable.ic_warning)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.R
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.utils.show
@@ -38,7 +39,7 @@ class CardSideSelectionDialog {
                     R.string.card_side_answer,
                 )
 
-            AlertDialog.Builder(ctx).show {
+            MaterialAlertDialogBuilder(ctx).show {
                 title(R.string.card_side_selection_title)
                 setItems(items.map { ctx.getString(it) }.toTypedArray()) { _, index ->
                     when (items[index]) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import com.ichi2.anki.R
 import com.ichi2.utils.create
@@ -60,7 +61,7 @@ class ConfirmationDialog : DialogFragment() {
         super.onCreate(savedInstanceState)
         val res = requireActivity().resources
         val title = requireArguments().getString("title")
-        return AlertDialog.Builder(requireContext()).create {
+        return MaterialAlertDialogBuilder(requireContext()).create {
             title(text = (if ("" == title) res.getString(R.string.app_name) else title)!!)
             message(text = requireArguments().getString("message")!!)
             positiveButton(R.string.dialog_ok) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -25,6 +25,7 @@ import androidx.activity.addCallback
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.app.ActivityCompat
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
@@ -90,7 +91,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreateDialog(savedInstanceState)
         val res = res()
-        val alertDialog = AlertDialog.Builder(requireActivity())
+        val alertDialog = MaterialAlertDialogBuilder(requireActivity())
         val isLoggedIn = isLoggedIn()
         alertDialog
             .cancelable(true)
@@ -259,7 +260,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                                 requireActivity().dismissAllDialogFragments()
                             } else {
                                 // otherwise show an error dialog
-                                AlertDialog.Builder(requireActivity()).show {
+                                MaterialAlertDialogBuilder(requireActivity()).show {
                                     title(R.string.vague_error)
                                     message(R.string.backup_invalid_file_error)
                                     positiveButton(R.string.dialog_ok)
@@ -501,7 +502,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         companion object {
             /** A dialog which creates a new collection in an unsafe location */
             fun displayResetToNewDirectoryDialog(context: AnkiActivity) {
-                AlertDialog.Builder(context).show {
+                MaterialAlertDialogBuilder(context).show {
                     title(R.string.backup_new_collection)
                     setIcon(R.drawable.ic_warning)
                     message(R.string.new_unsafe_collection)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -33,7 +34,7 @@ class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
         var analyticsEnabled = true
-        return AlertDialog.Builder(requireActivity()).create {
+        return MaterialAlertDialogBuilder(requireActivity()).create {
             title(R.string.analytics_dialog_title)
             message(R.string.analytics_summ)
             checkBoxPrompt(R.string.analytics_title, isCheckedDefault = true) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.utils.cancelable
@@ -30,7 +31,7 @@ import com.ichi2.utils.title
 class DeckPickerNoSpaceLeftDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
-        return AlertDialog.Builder(requireActivity()).create {
+        return MaterialAlertDialogBuilder(requireActivity()).create {
             title(R.string.storage_full_title)
             message(R.string.backup_deck_no_storage_left)
             cancelable(true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -28,6 +28,7 @@ import android.widget.Filterable
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.BundleCompat
@@ -115,7 +116,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         val adapter = DecksArrayAdapter(decks)
         recyclerView.adapter = adapter
         adjustToolbar(dialogView, adapter)
-        dialog = AlertDialog.Builder(requireActivity()).create {
+        dialog = MaterialAlertDialogBuilder(requireActivity()).create {
             negativeButton(R.string.dialog_cancel)
             customView(view = dialogView)
             if (arguments.getBoolean(KEEP_RESTORE_DEFAULT_BUTTON)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.dialogs
 
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.utils.message
@@ -37,7 +38,7 @@ object DiscardChangesDialog {
         negativeMethod: () -> Unit = {},
         neutralMethod: (() -> Unit)? = null,
         positiveMethod: () -> Unit,
-    ) = AlertDialog.Builder(context).show {
+    ) = MaterialAlertDialogBuilder(context).show {
         Timber.i("showing 'discard changes' dialog")
         message(text = message)
         positiveButton(text = positiveButtonText) { positiveMethod() }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -37,6 +37,7 @@ import android.widget.CheckBox
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
@@ -94,8 +95,7 @@ class EmptyCardsDialogFragment : DialogFragment() {
             TR.emptyCardsPreserveNotesCheckbox()
         dialogView.findViewById<TextView>(R.id.report).movementMethod = LinkMovementMethod.getInstance()
 
-        return AlertDialog
-            .Builder(requireContext())
+        return MaterialAlertDialogBuilder(requireContext())
             .show {
                 setTitle(
                     TR
@@ -170,7 +170,7 @@ class EmptyCardsDialogFragment : DialogFragment() {
                         is EmptyCardsSearchFailure -> {
                             // the dialog is informational so there's nothing to do but show the
                             // error and exit
-                            AlertDialog.Builder(requireActivity()).show {
+                            MaterialAlertDialogBuilder(requireActivity()).show {
                                 title(R.string.vague_error)
                                 message(text = state.throwable.toString())
                                 positiveButton(R.string.dialog_ok) { }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import android.os.Message
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -31,7 +32,7 @@ class ExportReadyDialog : AsyncDialogFragment() {
             ?: error("Missing required argument: exportPath!")
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
-        val dialog = AlertDialog.Builder(requireActivity())
+        val dialog = MaterialAlertDialogBuilder(requireActivity())
 
         dialog.setTitle(notificationTitle).positiveButton(R.string.export_choice_save_to) {
                 parentFragmentManager.setFragmentResult(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FatalErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FatalErrorDialog.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.dialogs
 
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.InitialActivity.StartupFailure.InitializationError
 import com.ichi2.anki.R
@@ -34,7 +35,7 @@ object FatalErrorDialog {
         failure: InitializationError,
     ): AlertDialog {
         Timber.i("Displaying 'Fatal error'")
-        return AlertDialog.Builder(activity).create {
+        return MaterialAlertDialogBuilder(activity).create {
             title(R.string.ankidroid_init_failed_webview_title)
             message(text = failure.toHumanReadableString(activity))
             positiveButton(R.string.close) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.ImportDialog.Type.DIALOG_IMPORT_ADD_CONFIRM
 import com.ichi2.anki.dialogs.ImportDialog.Type.DIALOG_IMPORT_REPLACE_CONFIRM
@@ -43,7 +44,7 @@ class ImportDialog : AsyncDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreate(savedInstanceState)
-        val dialog = AlertDialog.Builder(requireActivity())
+        val dialog = MaterialAlertDialogBuilder(requireActivity())
         dialog.setCancelable(true)
         val displayFileName = filenameFromPath(convertToDisplayName(packagePath))
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CardTemplateEditor
@@ -65,7 +66,7 @@ class InsertFieldDialog : DialogFragment() {
 
                 override fun getItemCount(): Int = fieldList.size
             }
-        return AlertDialog.Builder(requireContext()).create {
+        return MaterialAlertDialogBuilder(requireContext()).create {
             title(R.string.card_template_editor_select_field)
             negativeButton(R.string.dialog_cancel)
             customListAdapter(adapter)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -23,6 +23,7 @@ import android.widget.Filter
 import android.widget.Filterable
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.RecyclerView
@@ -57,7 +58,7 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
         dialogView
             .findViewById<Toolbar>(R.id.locale_dialog_selection_toolbar)
             .setupMenuWith(localeAdapter)
-        return AlertDialog.Builder(requireContext()).show {
+        return MaterialAlertDialogBuilder(requireContext()).show {
             cancelable(true)
             customView(dialogView)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenu.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.NoteTypeFieldEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
@@ -23,7 +24,7 @@ class NoteTypeFieldEditorContextMenu : AnalyticsDialogFragment() {
         super.onCreate(savedInstanceState)
         val availableItems = NoteTypeFieldEditorContextMenuAction.entries.sortedBy { it.order }
 
-        return AlertDialog.Builder(requireActivity()).create {
+        return MaterialAlertDialogBuilder(requireActivity()).create {
             setTitle(requireArguments().getString(KEY_LABEL))
             setItems(availableItems.map { resources.getString(it.actionTextId) }.toTypedArray()) { _, index ->
                 (activity as? NoteTypeFieldEditor)?.run { handleAction(availableItems[index]) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
@@ -22,6 +22,7 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
@@ -70,8 +71,7 @@ class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
                     removeSearch(searchName)
                 },
             )
-        return AlertDialog
-            .Builder(requireContext())
+        return MaterialAlertDialogBuilder(requireContext())
             .title(text = resources.getString(R.string.card_browser_list_my_searches_title))
             .negativeButton(R.string.dialog_cancel)
             .apply { customListAdapter(adapter) }
@@ -79,7 +79,7 @@ class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
     }
 
     private fun removeSearch(searchName: String) {
-        AlertDialog.Builder(requireActivity()).show {
+        MaterialAlertDialogBuilder(requireActivity()).show {
             message(text = resources.getString(R.string.card_browser_list_my_searches_remove_content, searchName))
             positiveButton(android.R.string.ok) {
                 parentFragmentManager.setFragmentResult(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.FragmentActivity
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.DeckPicker
@@ -29,7 +30,7 @@ import com.ichi2.utils.create
 class SimpleMessageDialog : AsyncDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
-        return AlertDialog.Builder(requireContext()).create {
+        return MaterialAlertDialogBuilder(requireContext()).create {
             setTitle(notificationTitle)
             setMessage(notificationMessage)
             setPositiveButton(R.string.dialog_ok) { _, _ ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.os.Message
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.ConflictResolution
 import com.ichi2.anki.R
@@ -63,7 +64,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
-        val dialog = AlertDialog.Builder(requireContext()).setTitle(title).setMessage(message)
+        val dialog = MaterialAlertDialogBuilder(requireContext()).setTitle(title).setMessage(message)
         return when (dialogType) {
             @Suppress("DEPRECATION") Type.DIALOG_USER_NOT_LOGGED_IN_SYNC -> {
                 dialog.setIcon(R.drawable.ic_sync_problem)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsPlaybackErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsPlaybackErrorDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.app.Activity
 import android.content.Intent
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.FragmentManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
@@ -36,7 +37,7 @@ object TtsPlaybackErrorDialog {
     ) {
         Timber.i("Dialog is shown to guide users correctly to troubleshoot the Tts error: Missing voice error")
         activity.runOnUiThread {
-            AlertDialog.Builder(activity).show {
+            MaterialAlertDialogBuilder(activity).show {
                 setTitle(activity.getString(R.string.tts_error_dialog_title))
                 setMessage(activity.getString(R.string.tts_error_dialog_reason_text, TtsVoices.ttsEngine, ttsTag?.lang))
                 setNegativeButton(context.getString(R.string.tts_error_dialog_change_button_text)) { _, _ -> openSettings(activity) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
@@ -28,6 +28,7 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -149,7 +150,7 @@ class TtsVoicesDialogFragment : DialogFragment() {
         viewModel.availableVoicesFlow.observe {
             if (it is TtsVoicesViewModel.VoiceLoadingState.Failure) {
                 progressBar.visibility = View.VISIBLE
-                AlertDialog.Builder(requireContext()).setMessage(it.exception.localizedMessage)
+                MaterialAlertDialogBuilder(requireContext()).setMessage(it.exception.localizedMessage)
                     .setOnDismissListener { this@TtsVoicesDialogFragment.dismiss() }.show()
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/WhiteBoardWidthDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/WhiteBoardWidthDialog.kt
@@ -22,6 +22,7 @@ import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.R
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.negativeButton
@@ -76,7 +77,7 @@ class WhiteBoardWidthDialog(
                 LinearLayout.LayoutParams.WRAP_CONTENT,
             ),
         )
-        AlertDialog.Builder(context).show {
+        MaterialAlertDialogBuilder(context).show {
             title(R.string.whiteboard_stroke_width)
             positiveButton(R.string.save) {
                 onStrokeWidthChanged?.accept(wbStrokeWidth)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -35,6 +35,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -222,7 +223,7 @@ class InstantNoteEditorActivity :
         setLayoutVisibility()
 
         instantAlertDialog =
-            AlertDialog.Builder(this).show {
+            MaterialAlertDialogBuilder(this).show {
                 setView(dialogView)
                 setCancelable(false)
                 setFinishOnTouchOutside(false)
@@ -478,7 +479,7 @@ class InstantNoteEditorActivity :
     /** Show a dialog when there is no cloze note type is found, allowing user either to cancel or to open
      * AnkiDroid Note Editor **/
     private fun noClozeNoteTypesFoundDialog() {
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             title(R.string.cloze_note_required)
             message(R.string.cloze_not_found_message)
             positiveButton(R.string.open) {
@@ -495,8 +496,7 @@ class InstantNoteEditorActivity :
         viewModel.onError
             .flowWithLifecycle(lifecycle)
             .onEach { errorMessage ->
-                AlertDialog
-                    .Builder(this)
+                MaterialAlertDialogBuilder(this)
                     .setTitle(R.string.vague_error)
                     .setMessage(errorMessage)
                     .show()
@@ -523,7 +523,7 @@ class InstantNoteEditorActivity :
 
     /** In case saving the note fails we, want to allow user to cancel and try again, or exist the activity **/
     private fun savingErrorDialog(message: String) {
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             message(text = message)
             positiveButton(R.string.dialog_cancel) {
                 instantAlertDialog.dismiss()
@@ -535,7 +535,7 @@ class InstantNoteEditorActivity :
     /** Warns the user for no cloze in the cloze field, and provide the choice to proceed or
      * to abort save and go back to the editor  **/
     private fun noClozeDialog(errorMessage: String) {
-        AlertDialog.Builder(this).show {
+        MaterialAlertDialogBuilder(this).show {
             message(text = errorMessage)
             positiveButton(text = TR.actionsSave()) {
                 saveNoteWithProgress(skipClozeCheck = true)

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
 
-    <style name="Theme_Dark.Launcher" />
+    <style name="Theme_Dark.Launcher" parent="Theme_Dark" />
 
     <style name="Animation.Translucent" parent="@android:style/Animation.Translucent">
         <item name="android:windowEnterAnimation">@null</item>
@@ -270,7 +270,7 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
-        <item name="android:alertDialogStyle">@style/AlertDialogStyle</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.AnkiDroid.AlertDialog</item>
     </style>
 
     <style name="ThemeOverlay.App.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -265,7 +265,7 @@
         <item name="shapeAppearance">@style/ShapeAppearance.Anki.ExpressiveCard</item>
     </style>
 
-    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>


### PR DESCRIPTION
This pull request refactors the codebase to use `MaterialAlertDialogBuilder` from the Material Components library instead of the standard `AlertDialog.Builder` for creating dialogs throughout the app. This change ensures a more consistent and modern Material Design appearance for all dialogs. The update touches multiple files, replacing all usages of `AlertDialog.Builder` with `MaterialAlertDialogBuilder` and updating the corresponding imports.

**Dialog Builder Refactoring:**

* Replaced all instances of `AlertDialog.Builder` with `MaterialAlertDialogBuilder` in the following files and their dialog creation methods:
  - `AbstractFlashcardViewer.kt` [[1]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6R65) [[2]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6L685-R686) [[3]](diffhunk://#diff-955ac568bcd1a63f9c751eccb742ed12bde79255897964e68a6ba68c7c1085b6L2022-R2023)
  - `CardTemplateBrowserAppearanceEditor.kt` [[1]](diffhunk://#diff-5a94587cab37bb13b40fa8a10d5587bffb4310e7f6b7b9346960d4f9a18fdea8R27) [[2]](diffhunk://#diff-5a94587cab37bb13b40fa8a10d5587bffb4310e7f6b7b9346960d4f9a18fdea8L116-R117)
  - `CardTemplateEditor.kt` [[1]](diffhunk://#diff-3597cc3a69659d4fdb923cf4a2dfbff629e5890395348722468b8bc250a118abR45) [[2]](diffhunk://#diff-3597cc3a69659d4fdb923cf4a2dfbff629e5890395348722468b8bc250a118abL976-R977) [[3]](diffhunk://#diff-3597cc3a69659d4fdb923cf4a2dfbff629e5890395348722468b8bc250a118abL1157-R1158) [[4]](diffhunk://#diff-3597cc3a69659d4fdb923cf4a2dfbff629e5890395348722468b8bc250a118abL1182-R1183)
  - `CoroutineHelpers.kt` [[1]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73R28) [[2]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73L277-R278) [[3]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73L563-R563) [[4]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73L587-R587)
  - `DeckPicker.kt` [[1]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cR51) [[2]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL689-R690) [[3]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL957-R958) [[4]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL1407-R1408) [[5]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL1558-R1559) [[6]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL1637-R1638)
  - `NoteEditorFragment.kt` [[1]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064R40) [[2]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064L946-R947) [[3]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064L957-R958) [[4]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064L979-R980) [[5]](diffhunk://#diff-f8260347706458e24017a98896b67ae669202bcc80fb7ba6d76faa73a53ee064L1760-R1761)
  - `NoteTypeFieldEditor.kt` [[1]](diffhunk://#diff-7fa2239ab8bf4ef6140468607ff73e3a57e5c0fed17c51bf57c72d92bcd0731eR34) [[2]](diffhunk://#diff-7fa2239ab8bf4ef6140468607ff73e3a57e5c0fed17c51bf57c72d92bcd0731eL211-R212) [[3]](diffhunk://#diff-7fa2239ab8bf4ef6140468607ff73e3a57e5c0fed17c51bf57c72d92bcd0731eL338-R339) [[4]](diffhunk://#diff-7fa2239ab8bf4ef6140468607ff73e3a57e5c0fed17c51bf57c72d92bcd0731eL387-R388)
  - `ReadText.kt` [[1]](diffhunk://#diff-0093d2ec5254f5faeac08c1d56b1fbac3ba267e22ea1d8ddb624355f41602a6aR27) [[2]](diffhunk://#diff-0093d2ec5254f5faeac08c1d56b1fbac3ba267e22ea1d8ddb624355f41602a6aL113-R114)

**Import Updates:**

* Added imports for `com.google.android.material.dialog.MaterialAlertDialogBuilder` and removed unused `AlertDialog` imports where necessary across all affected files. (See references above)

This change improves UI consistency and aligns the app dialogs with Material Design standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized dialog components throughout the application to use Material Design 3, providing a more contemporary and visually consistent experience across all confirmation dialogs, selections, and alerts.

* **Style**
  * Updated the application theme to Material3, enhancing visual consistency and alignment with modern design standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->