### PR TITLE
Implement custom study support in CongratsScreen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -115,8 +115,7 @@ import com.ichi2.anki.dialogs.SyncErrorDialog
 import com.ichi2.anki.dialogs.SyncErrorDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.SyncErrorDialog.SyncErrorDialogListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Companion.REQUEST_KEY
+
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.introduction.CollectionPermissionScreenLauncher
@@ -146,7 +145,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.Destination
-import com.ichi2.anki.utils.ext.setFragmentResultListener
+
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.worker.SyncMediaWorker
 import com.ichi2.anki.worker.SyncWorker
@@ -439,23 +438,6 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
         registerReceiver()
 
         checkWebviewVersion(this)
-
-        setFragmentResultListener(REQUEST_KEY) { _, bundle ->
-            when (CustomStudyAction.fromBundle(bundle)) {
-                CustomStudyAction.CUSTOM_STUDY_SESSION -> {
-                    Timber.d("Custom study created")
-                    updateDeckList()
-                    if (!fragmented) {
-                        openStudyOptionsActivity()
-                    }
-                }
-
-                CustomStudyAction.EXTEND_STUDY_LIMITS -> {
-                    Timber.d("Study limits updated")
-                    updateDeckList()
-                }
-            }
-        }
 
         ViewCompat.setOnReceiveContentListener(
             window.decorView,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -27,6 +27,7 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.ui.windows.managespace.ManageSpaceActivity
 import com.ichi2.anki.utils.ext.setFragmentResultListener
@@ -149,13 +150,15 @@ open class SingleFragmentActivity : AnkiActivity() {
     // Begin - implementation of CustomStudyListener methods here for crash fix
     // TODO - refactor https://github.com/ankidroid/Anki-Android/pull/17508#pullrequestreview-2465561993
     private fun openStudyOptionsAndFinish() {
-        val col = CollectionManager.getColUnsafe()
-        val intent =
-            Intent(this, StudyOptionsComposeActivity::class.java).apply {
-                putExtra(StudyOptionsComposeActivity.DECK_ID, col.decks.current().id)
-            }
-        startActivity(intent, null)
-        this.finish()
+        launchCatchingTask {
+            val deckId = withCol { decks.selected() }
+            val intent =
+                Intent(this@SingleFragmentActivity, StudyOptionsComposeActivity::class.java).apply {
+                    putExtra(StudyOptionsComposeActivity.DECK_ID, deckId)
+                }
+            startActivity(intent, null)
+            finish()
+        }
     }
 
     // END CustomStudyListener temporary implementation - should refactor out

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -149,9 +149,10 @@ open class SingleFragmentActivity : AnkiActivity() {
     // Begin - implementation of CustomStudyListener methods here for crash fix
     // TODO - refactor https://github.com/ankidroid/Anki-Android/pull/17508#pullrequestreview-2465561993
     private fun openStudyOptionsAndFinish() {
+        val col = CollectionManager.getColUnsafe()
         val intent =
             Intent(this, StudyOptionsComposeActivity::class.java).apply {
-                putExtra("withDeckOptions", false)
+                putExtra(StudyOptionsComposeActivity.DECK_ID, col.decks.current().id)
             }
         startActivity(intent, null)
         this.finish()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -72,14 +72,17 @@ class StudyOptionsComposeActivity : AnkiActivity() {
         setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
                 CustomStudyAction.CUSTOM_STUDY_SESSION -> {
-                    val col = CollectionManager.getColUnsafe()
-                    val intent = Intent(
-                        this@StudyOptionsComposeActivity, StudyOptionsComposeActivity::class.java
-                    ).apply {
-                        putExtra(DECK_ID, col.decks.current().id)
+                    launchCatchingTask {
+                        val deckId = withCol { decks.selected() }
+                        val intent = Intent(
+                            this@StudyOptionsComposeActivity,
+                            StudyOptionsComposeActivity::class.java
+                        ).apply {
+                            putExtra(DECK_ID, deckId)
+                        }
+                        startActivity(intent)
+                        finish()
                     }
-                    startActivity(intent)
-                    finish()
                 }
 
                 CustomStudyAction.EXTEND_STUDY_LIMITS -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -20,6 +20,7 @@
  ****************************************************************************************/
 package com.ichi2.anki
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -70,7 +71,16 @@ class StudyOptionsComposeActivity : AnkiActivity() {
 
         setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
-                CustomStudyAction.CUSTOM_STUDY_SESSION -> finish()
+                CustomStudyAction.CUSTOM_STUDY_SESSION -> {
+                    val intent = Intent(
+                        this@StudyOptionsComposeActivity,
+                        StudyOptionsComposeActivity::class.java
+                    ).apply {
+                        putExtra("withDeckOptions", false)
+                    }
+                    reviewerLauncher.launch(intent)
+                }
+
                 CustomStudyAction.EXTEND_STUDY_LIMITS -> {
                     refreshCounter++
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -72,10 +72,12 @@ class StudyOptionsComposeActivity : AnkiActivity() {
         setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
                 CustomStudyAction.CUSTOM_STUDY_SESSION -> {
+                    val col = CollectionManager.getColUnsafe()
                     val intent = Intent(
-                        this@StudyOptionsComposeActivity,
-                        StudyOptionsComposeActivity::class.java
-                    )
+                        this@StudyOptionsComposeActivity, StudyOptionsComposeActivity::class.java
+                    ).apply {
+                        putExtra(DECK_ID, col.decks.current().id)
+                    }
                     startActivity(intent)
                     finish()
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsComposeActivity.kt
@@ -75,10 +75,9 @@ class StudyOptionsComposeActivity : AnkiActivity() {
                     val intent = Intent(
                         this@StudyOptionsComposeActivity,
                         StudyOptionsComposeActivity::class.java
-                    ).apply {
-                        putExtra("withDeckOptions", false)
-                    }
-                    reviewerLauncher.launch(intent)
+                    )
+                    startActivity(intent)
+                    finish()
                 }
 
                 CustomStudyAction.EXTEND_STUDY_LIMITS -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerNavHost.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerNavHost.kt
@@ -216,10 +216,25 @@ fun DeckPickerNavHost(
             CustomStudyDialog.CustomStudyAction.REQUEST_KEY, fragmentActivity
         ) { _, bundle ->
             val action = CustomStudyDialog.CustomStudyAction.fromBundle(bundle)
-            if (action == CustomStudyDialog.CustomStudyAction.CUSTOM_STUDY_SESSION || action == CustomStudyDialog.CustomStudyAction.EXTEND_STUDY_LIMITS) {
-                val currentStack = navigator.state.backStacks[navigator.state.topLevelRoute]
-                if (currentStack?.lastOrNull() is CongratsScreen) {
-                    navigator.goBack()
+            val currentStack = navigator.state.backStacks[navigator.state.topLevelRoute]
+            val isOnCongratsScreen = currentStack?.lastOrNull() is CongratsScreen
+            when (action) {
+                CustomStudyDialog.CustomStudyAction.CUSTOM_STUDY_SESSION -> {
+                    if (isOnCongratsScreen) {
+                        navigator.goBack()
+                    }
+                    // Replicate DeckPicker.kt behavior: update list and open study options
+                    viewModel.updateDeckList()
+                    if (!fragmented) {
+                        viewModel.openStudyOptionsActivity()
+                    }
+                }
+
+                CustomStudyDialog.CustomStudyAction.EXTEND_STUDY_LIMITS -> {
+                    if (isOnCongratsScreen) {
+                        navigator.goBack()
+                    }
+                    viewModel.updateDeckList()
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerNavHost.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerNavHost.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -84,6 +85,7 @@ import com.ichi2.anki.dialogs.compose.CreateDeckDialog
 import com.ichi2.anki.dialogs.compose.ErrorDialog
 import com.ichi2.anki.dialogs.compose.LoginToAnkiWebDialog
 import com.ichi2.anki.dialogs.compose.NetworkErrorDialog
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.navigation.CongratsScreen
 import com.ichi2.anki.navigation.ContributeScreen
@@ -207,6 +209,23 @@ fun DeckPickerNavHost(
     val timeUntilNextDay by viewModel.flowOfTimeUntilNextDay.collectAsStateWithLifecycle()
     val lifecycle = LocalLifecycleOwner.current.lifecycle
 
+    val context = LocalContext.current
+    val fragmentActivity = context as? FragmentActivity
+    LaunchedEffect(fragmentActivity, navigator) {
+        fragmentActivity?.supportFragmentManager?.setFragmentResultListener(
+            CustomStudyDialog.CustomStudyAction.REQUEST_KEY, fragmentActivity
+        ) { _, bundle ->
+            val action = CustomStudyDialog.CustomStudyAction.fromBundle(bundle)
+            if (action == CustomStudyDialog.CustomStudyAction.CUSTOM_STUDY_SESSION || action == CustomStudyDialog.CustomStudyAction.EXTEND_STUDY_LIMITS) {
+                val currentStack = navigator.state.backStacks[navigator.state.topLevelRoute]
+                if (currentStack?.lastOrNull() is CongratsScreen) {
+                    navigator.goBack()
+                }
+            }
+        }
+    }
+
+
     val entryProvider = entryProvider {
         entry<DeckPickerScreen> {
             DeckPickerMainContent(
@@ -241,6 +260,7 @@ fun DeckPickerNavHost(
             CongratsComposable(
                 onNavigateUp = { navigator.goBack() },
                 onDeckOptions = { viewModel.openDeckOptions(key.deckId) },
+                onCustomStudy = { viewModel.showCustomStudyDialog(key.deckId) },
                 timeUntilNextDay = timeUntilNextDay
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerNavHost.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/compose/DeckPickerNavHost.kt
@@ -211,9 +211,11 @@ fun DeckPickerNavHost(
 
     val context = LocalContext.current
     val fragmentActivity = context as? FragmentActivity
-    LaunchedEffect(fragmentActivity, navigator) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(fragmentActivity, lifecycleOwner, navigator) {
         fragmentActivity?.supportFragmentManager?.setFragmentResultListener(
-            CustomStudyDialog.CustomStudyAction.REQUEST_KEY, fragmentActivity
+            CustomStudyDialog.CustomStudyAction.REQUEST_KEY, lifecycleOwner
         ) { _, bundle ->
             val action = CustomStudyDialog.CustomStudyAction.fromBundle(bundle)
             val currentStack = navigator.state.backStacks[navigator.state.topLevelRoute]
@@ -237,6 +239,11 @@ fun DeckPickerNavHost(
                     viewModel.updateDeckList()
                 }
             }
+        }
+        onDispose {
+            fragmentActivity?.supportFragmentManager?.clearFragmentResultListener(
+                CustomStudyDialog.CustomStudyAction.REQUEST_KEY
+            )
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -148,11 +148,14 @@ class CongratsPage : PageFragment(), ChangeManager.Subscriber {
     )
 
     private fun openStudyOptionsAndFinish() {
-        val intent = Intent(requireContext(), StudyOptionsComposeActivity::class.java).apply {
-            putExtra("withDeckOptions", false)
+        launchCatchingTask {
+            val deckId = withCol { decks.selected() }
+            val intent = Intent(requireContext(), StudyOptionsComposeActivity::class.java).apply {
+                putExtra(StudyOptionsComposeActivity.DECK_ID, deckId)
+            }
+            startActivity(intent, null)
+            requireActivity().finish()
         }
-        startActivity(intent, null)
-        requireActivity().finish()
     }
 
     private fun onStudyMore() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsActivity.kt
@@ -25,11 +25,13 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.getColUnsafe
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.StudyOptionsComposeActivity
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
+import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.pages.DeckOptions
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -40,14 +42,13 @@ class CongratsActivity : AnkiActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         try {
-            val col = CollectionManager.getColUnsafe()
+            val col = getColUnsafe()
             val timeUntilNextDay =
                 (col.sched.dayCutoff * 1000 - TimeManager.time.intTimeMS()).coerceAtLeast(0L)
 
             setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
                 when (CustomStudyAction.fromBundle(bundle)) {
-                    CustomStudyAction.CUSTOM_STUDY_SESSION,
-                    CustomStudyAction.EXTEND_STUDY_LIMITS -> {
+                    CustomStudyAction.CUSTOM_STUDY_SESSION, CustomStudyAction.EXTEND_STUDY_LIMITS -> {
                         openStudyOptionsAndFinish()
                     }
                 }
@@ -55,16 +56,13 @@ class CongratsActivity : AnkiActivity() {
 
             setContent {
                 CongratsScreen(
-                    onNavigateUp = { finish() },
-                    onDeckOptions = {
-                        val intent = DeckOptions.getIntent(this, col.decks.current().id)
-                        startActivity(intent)
-                    },
-                    onCustomStudy = {
-                        val customStudy = CustomStudyDialog.createInstance(col.decks.current().id)
-                        showDialogFragment(customStudy)
-                    },
-                    timeUntilNextDay = timeUntilNextDay
+                    onNavigateUp = { finish() }, onDeckOptions = {
+                    val intent = DeckOptions.getIntent(this, col.decks.current().id)
+                    startActivity(intent)
+                }, onCustomStudy = {
+                    val customStudy = CustomStudyDialog.createInstance(col.decks.current().id)
+                    showDialogFragment(customStudy)
+                }, timeUntilNextDay = timeUntilNextDay
                 )
             }
         } catch (e: Exception) {
@@ -74,11 +72,14 @@ class CongratsActivity : AnkiActivity() {
     }
 
     private fun openStudyOptionsAndFinish() {
-        val col = CollectionManager.getColUnsafe()
-        val intent = Intent(this, StudyOptionsComposeActivity::class.java).apply {
-            putExtra(StudyOptionsComposeActivity.DECK_ID, col.decks.current().id)
+        launchCatchingTask {
+            val deckId = withCol { decks.selected() }
+            val intent =
+                Intent(this@CongratsActivity, StudyOptionsComposeActivity::class.java).apply {
+                    putExtra(StudyOptionsComposeActivity.DECK_ID, deckId)
+                }
+            startActivity(intent)
+            finish()
         }
-        startActivity(intent)
-        finish()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsActivity.kt
@@ -74,8 +74,9 @@ class CongratsActivity : AnkiActivity() {
     }
 
     private fun openStudyOptionsAndFinish() {
+        val col = CollectionManager.getColUnsafe()
         val intent = Intent(this, StudyOptionsComposeActivity::class.java).apply {
-            putExtra("withDeckOptions", false)
+            putExtra(StudyOptionsComposeActivity.DECK_ID, col.decks.current().id)
         }
         startActivity(intent)
         finish()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsActivity.kt
@@ -20,13 +20,19 @@
  ****************************************************************************************/
 package com.ichi2.anki.ui.compose
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager
-import com.ichi2.anki.pages.DeckOptions
+import com.ichi2.anki.StudyOptionsComposeActivity
 import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
+import com.ichi2.anki.pages.DeckOptions
+import com.ichi2.anki.utils.ext.setFragmentResultListener
+import com.ichi2.anki.utils.ext.showDialogFragment
 import timber.log.Timber
 
 class CongratsActivity : AnkiActivity() {
@@ -38,18 +44,40 @@ class CongratsActivity : AnkiActivity() {
             val timeUntilNextDay =
                 (col.sched.dayCutoff * 1000 - TimeManager.time.intTimeMS()).coerceAtLeast(0L)
 
+            setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
+                when (CustomStudyAction.fromBundle(bundle)) {
+                    CustomStudyAction.CUSTOM_STUDY_SESSION,
+                    CustomStudyAction.EXTEND_STUDY_LIMITS -> {
+                        openStudyOptionsAndFinish()
+                    }
+                }
+            }
+
             setContent {
                 CongratsScreen(
                     onNavigateUp = { finish() },
                     onDeckOptions = {
-                    val intent = DeckOptions.getIntent(this, col.decks.current().id)
-                    startActivity(intent)
-                }, timeUntilNextDay = timeUntilNextDay
+                        val intent = DeckOptions.getIntent(this, col.decks.current().id)
+                        startActivity(intent)
+                    },
+                    onCustomStudy = {
+                        val customStudy = CustomStudyDialog.createInstance(col.decks.current().id)
+                        showDialogFragment(customStudy)
+                    },
+                    timeUntilNextDay = timeUntilNextDay
                 )
             }
         } catch (e: Exception) {
             Timber.e(e, "Error getting collection in CongratsActivity")
             finish()
         }
+    }
+
+    private fun openStudyOptionsAndFinish() {
+        val intent = Intent(this, StudyOptionsComposeActivity::class.java).apply {
+            putExtra("withDeckOptions", false)
+        }
+        startActivity(intent)
+        finish()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
@@ -49,8 +49,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -62,7 +66,12 @@ import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUntilNextDay: Long) {
+fun CongratsScreen(
+    onNavigateUp: () -> Unit,
+    onDeckOptions: () -> Unit,
+    onCustomStudy: () -> Unit,
+    timeUntilNextDay: Long
+) {
     BackHandler { onNavigateUp() }
     AnkiDroidTheme {
         Scaffold(topBar = {
@@ -122,9 +131,8 @@ fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUnti
                     text = stringResource(R.string.daily_limit_reached),
                     style = MaterialTheme.typography.bodyLarge
                 )
-                Text(
-                    text = stringResource(R.string.study_more),
-                    style = MaterialTheme.typography.bodyLarge
+                StudyMoreClickableText(
+                    onCustomStudy = onCustomStudy
                 )
 
                 Column(
@@ -184,10 +192,71 @@ fun CongratsScreen(onNavigateUp: () -> Unit, onDeckOptions: () -> Unit, timeUnti
     }
 }
 
+
+@Composable
+fun StudyMoreClickableText(
+    onCustomStudy: () -> Unit, modifier: Modifier = Modifier
+) {
+    val studyMoreText = stringResource(id = R.string.study_more)
+    val customStudyText = stringResource(id = R.string.custom_study)
+
+    val range = remember(studyMoreText, customStudyText) {
+        var r = findSubstringRange(studyMoreText, customStudyText)
+        if (r == null) {
+            r = findSubstringRange(studyMoreText, "custom study")
+        }
+        if (r == null && studyMoreText.length >= 12) {
+            r = (studyMoreText.length - 12) until studyMoreText.length
+        }
+        r
+    }
+
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val annotatedString = remember(studyMoreText, range, primaryColor) {
+        buildAnnotatedString {
+            append(studyMoreText)
+            if (range != null) {
+                addLink(
+                    LinkAnnotation.Clickable(tag = "custom_study") { onCustomStudy() },
+                    range.first,
+                    range.last + 1
+                )
+                addStyle(
+                    style = SpanStyle(
+                        color = primaryColor,
+                        textDecoration = TextDecoration.Underline,
+                        fontWeight = FontWeight.Bold
+                    ), range.first, range.last + 1
+                )
+            }
+        }
+    }
+
+    Text(
+        text = annotatedString,
+        modifier = modifier,
+        style = MaterialTheme.typography.bodyLarge.copy(
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    )
+}
+
+
 @Preview
 @Composable
 fun CongratsScreenPreview() {
     CongratsScreen(
-        onNavigateUp = {}, onDeckOptions = {}, timeUntilNextDay = 1000 * 60 * 60 * 4
-    )
+        onNavigateUp = {},
+        onDeckOptions = {},
+        timeUntilNextDay = 1000 * 60 * 60 * 4,
+        onCustomStudy = { })
+}
+
+private fun findSubstringRange(mainString: String, subString: String): IntRange? {
+    val index = mainString.indexOf(subString, ignoreCase = true)
+    return if (index != -1) {
+        index until (index + subString.length)
+    } else {
+        null
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/CongratsScreen.kt
@@ -197,18 +197,11 @@ fun CongratsScreen(
 fun StudyMoreClickableText(
     onCustomStudy: () -> Unit, modifier: Modifier = Modifier
 ) {
-    val studyMoreText = stringResource(id = R.string.study_more)
     val customStudyText = stringResource(id = R.string.custom_study)
+    val studyMoreText = stringResource(id = R.string.study_more, customStudyText)
 
     val range = remember(studyMoreText, customStudyText) {
-        var r = findSubstringRange(studyMoreText, customStudyText)
-        if (r == null) {
-            r = findSubstringRange(studyMoreText, "custom study")
-        }
-        if (r == null && studyMoreText.length >= 12) {
-            r = (studyMoreText.length - 12) until studyMoreText.length
-        }
-        r
+        findSubstringRange(studyMoreText, customStudyText)
     }
 
     val primaryColor = MaterialTheme.colorScheme.primary

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="preview" comment="Generic preview label. Duplicated in card_editor_preview_card for card editor context">Preview</string>
     <string name="note_type_not_found_for_template_editor">Unable to open card template editor: note type not found</string>
     <string name="daily_limit_reached">There are more new cards available, but the daily limit has been reached. You can increase the limit in options, but please bear in mind that the more new cards you introduce, the higher your short-term review workload will become.</string>
-    <string name="study_more">If you wish to study outside of the regular schedule, you can use the custom study feature.</string>
+    <string name="study_more">If you wish to study outside of the regular schedule, you can use the %1$s feature.</string>
     <string name="next_review_in">Next review in:</string>
     <string name="sync_now">Sync now</string>
     <string name="loading">Loading…</string>


### PR DESCRIPTION
This pull request enhances the "Congrats" screen and related navigation flows in AnkiDroid to improve the user experience when daily study limits are reached. The main changes introduce a clickable "Custom Study" link on the Congrats screen, streamline the handling of custom study actions, and ensure consistent navigation between activities and dialogs.

**Congrats Screen Improvements:**

* The "Congrats" screen now displays a clickable "Custom Study" text, allowing users to easily initiate a custom study session directly from the completion message. This is implemented via the new `StudyMoreClickableText` composable, which highlights and links the relevant portion of the message. [[1]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603L125-R135) [[2]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603R195-R261)

* The `CongratsScreen` composable and its usages are updated to accept an `onCustomStudy` callback, enabling the new interaction. [[1]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603L65-R74) [[2]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603L125-R135) [[3]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603R195-R261)

**Custom Study Navigation and Dialog Handling:**

* When the user selects "Custom Study" from the Congrats screen, a `CustomStudyDialog` is shown. Upon completion, the app either opens the study options or updates the deck list as appropriate, with consistent handling across `CongratsActivity`, `DeckPickerNavHost`, and `StudyOptionsComposeActivity`. [[1]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR23-R35) [[2]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR47-R82) [[3]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR47-R82) [[4]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR47-R82) [[5]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR47-R82) [[6]](diffhunk://#diff-6e865358f7a0aff82ae85c5b8f949222b875d55dafb3ca1481b18e899e5f570fL73-R83) [[7]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR212-R243) [[8]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR278)

* Fragment result listeners are set up in both Compose activities and navigation hosts to respond to actions from the custom study dialog, ensuring that navigation and UI updates occur seamlessly. [[1]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR47-R82) [[2]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR212-R243)

**Supporting Refactors and Imports:**

* Necessary imports and utility functions are added to support new navigation flows and UI composables. [[1]](diffhunk://#diff-6e865358f7a0aff82ae85c5b8f949222b875d55dafb3ca1481b18e899e5f570fR23) [[2]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR63) [[3]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR88) [[4]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603R52-R57) [[5]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603L65-R74)

These changes collectively make the custom study workflow more discoverable and user-friendly, especially after reaching daily study limits.

**References:**  
[[1]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603L125-R135) [[2]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603R195-R261) [[3]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603L65-R74) [[4]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR47-R82) [[5]](diffhunk://#diff-ff7cda6850eaba6a84931e75202e31964570a326d0027b494a30e285c511fdedR23-R35) [[6]](diffhunk://#diff-6e865358f7a0aff82ae85c5b8f949222b875d55dafb3ca1481b18e899e5f570fL73-R83) [[7]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR212-R243) [[8]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR278) [[9]](diffhunk://#diff-6e865358f7a0aff82ae85c5b8f949222b875d55dafb3ca1481b18e899e5f570fR23) [[10]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR63) [[11]](diffhunk://#diff-778760178dbd8243a3008b3d00ef220cee5bf9775c512293edeac3d8cf852ecfR88) [[12]](diffhunk://#diff-aa828a1741a691634abdde1f8f27f6fca59c42ea2e8fc79e827c720b847b2603R52-R57)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Study more” text on the congratulations screen is now interactive and opens custom study options.
  * Custom-study dialog can be launched from multiple places and reliably opens the study-options flow for the currently selected deck.
  * Improved navigation so dialog actions consistently transition to the study-options screen.

* **Bug Fixes**
  * Updated displayed text to use the feature placeholder consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->