### PR TITLE
Improve reviewer time-to-first-paint by loading media asynchronously

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -61,6 +61,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.net.toFile
 import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat
@@ -69,7 +71,6 @@ import androidx.lifecycle.Lifecycle.State.RESUMED
 import anki.collection.OpChanges
 import anki.scheduler.CardAnswer.Rating
 import com.drakeet.drawer.FullDraggableContainer
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.Signal.Companion.toSignal
@@ -152,6 +153,7 @@ import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.squareup.seismic.ShakeDetector
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 import java.io.File
@@ -1186,9 +1188,11 @@ abstract class AbstractFlashcardViewer :
         content: String,
     ) {
         if (card != null) {
-            // Note: `mediaPlaybackRequiresUserGesture` is updated asynchronously once the card's config is loaded.
-            // We default to requiring a user gesture here to avoid using stale config from the previous card.
-            card.settings.mediaPlaybackRequiresUserGesture = true
+            // Note: `mediaPlaybackRequiresUserGesture` uses cardMediaPlayer.config but this is initialized asynchronously now
+            // To ensure safety, we'll try to set it but default to false if not initialized (though usually we don't autoplay videos by default)
+            val autoPlay =
+                if (this::cardMediaPlayer.isInitialized && cardMediaPlayer.hasConfig) cardMediaPlayer.config.autoplay else false
+            card.settings.mediaPlaybackRequiresUserGesture = !autoPlay
             card.loadDataWithBaseURL(
                 server.baseUrl(),
                 content,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1067,18 +1067,17 @@ abstract class AbstractFlashcardViewer :
         cardContent = content.html
         fillFlashcard()
 
-        val card = currentCard
-        val isDisplayingAnswer = displayAnswer
-        if (card != null) {
-            launchCatchingTask {
-                cardMediaPlayer.loadCardAvTags(card)
-                if (card != currentCard || isDisplayingAnswer != displayAnswer) {
-                    return@launchCatchingTask
-                }
+        val card = currentCard ?: return
+        val wasDisplayingAnswer = displayAnswer
 
-                webView?.settings?.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
-                playMedia(false) // Play media if appropriate
+        launchCatchingTask {
+            cardMediaPlayer.loadCardAvTags(card)
+            if (card != currentCard || wasDisplayingAnswer != displayAnswer) {
+                return@launchCatchingTask
             }
+
+            webView?.settings?.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
+            playMedia(false) // Play media if appropriate
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -61,7 +61,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.net.toFile
 import androidx.core.net.toUri
@@ -153,7 +152,6 @@ import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.squareup.seismic.ShakeDetector
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1066,13 +1066,12 @@ abstract class AbstractFlashcardViewer :
 
     private fun updateCard(content: RenderedCard) {
         Timber.d("updateCard()")
-        // TODO: This doesn't need to be blocking
-        runBlocking {
-            cardMediaPlayer.loadCardAvTags(currentCard!!)
-        }
         cardContent = content.html
         fillFlashcard()
-        playMedia(false) // Play media if appropriate
+        launchCatchingTask {
+            cardMediaPlayer.loadCardAvTags(currentCard!!)
+            playMedia(false) // Play media if appropriate
+        }
     }
 
     /**
@@ -1180,7 +1179,10 @@ abstract class AbstractFlashcardViewer :
         content: String,
     ) {
         if (card != null) {
-            card.settings.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
+            // Note: `mediaPlaybackRequiresUserGesture` uses cardMediaPlayer.config but this is initialized asynchronously now
+            // To ensure safety, we'll try to set it but default to false if not initialized (though usually we don't autoplay videos by default)
+            val autoPlay = if (this::cardMediaPlayer.isInitialized && cardMediaPlayer.hasConfig) cardMediaPlayer.config.autoplay else false
+            card.settings.mediaPlaybackRequiresUserGesture = !autoPlay
             card.loadDataWithBaseURL(
                 server.baseUrl(),
                 content,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -61,8 +61,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.net.toFile
 import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat
@@ -71,6 +69,7 @@ import androidx.lifecycle.Lifecycle.State.RESUMED
 import anki.collection.OpChanges
 import anki.scheduler.CardAnswer.Rating
 import com.drakeet.drawer.FullDraggableContainer
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.Signal.Companion.toSignal
@@ -153,7 +152,6 @@ import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.squareup.seismic.ShakeDetector
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 import java.io.File
@@ -1068,9 +1066,19 @@ abstract class AbstractFlashcardViewer :
         Timber.d("updateCard()")
         cardContent = content.html
         fillFlashcard()
-        launchCatchingTask {
-            cardMediaPlayer.loadCardAvTags(currentCard!!)
-            playMedia(false) // Play media if appropriate
+
+        val card = currentCard
+        val isDisplayingAnswer = displayAnswer
+        if (card != null) {
+            launchCatchingTask {
+                cardMediaPlayer.loadCardAvTags(card)
+                if (card != currentCard || isDisplayingAnswer != displayAnswer) {
+                    return@launchCatchingTask
+                }
+
+                webView?.settings?.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
+                playMedia(false) // Play media if appropriate
+            }
         }
     }
 
@@ -1179,10 +1187,9 @@ abstract class AbstractFlashcardViewer :
         content: String,
     ) {
         if (card != null) {
-            // Note: `mediaPlaybackRequiresUserGesture` uses cardMediaPlayer.config but this is initialized asynchronously now
-            // To ensure safety, we'll try to set it but default to false if not initialized (though usually we don't autoplay videos by default)
-            val autoPlay = if (this::cardMediaPlayer.isInitialized && cardMediaPlayer.hasConfig) cardMediaPlayer.config.autoplay else false
-            card.settings.mediaPlaybackRequiresUserGesture = !autoPlay
+            // Note: `mediaPlaybackRequiresUserGesture` is updated asynchronously once the card's config is loaded.
+            // We default to requiring a user gesture here to avoid using stale config from the previous card.
+            card.settings.mediaPlaybackRequiresUserGesture = true
             card.loadDataWithBaseURL(
                 server.baseUrl(),
                 content,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -113,6 +113,8 @@ class CardMediaPlayer : Closeable {
     private lateinit var answerAvTags: List<AvTag>
 
     lateinit var config: CardSoundConfig
+    val hasConfig: Boolean
+        get() = this::config.isInitialized
 
     var isEnabled: Boolean = true
         private set

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -143,7 +143,7 @@ class SoundTagPlayer(
             try {
                 awaitSetDataSource(soundUri.toString())
             } catch (e: Exception) {
-                if (continuation.isCancelled) {
+                if (continuation.isCompleted) {
                     return
                 }
                 val continuationBehavior =
@@ -152,12 +152,12 @@ class SoundTagPlayer(
                 return continuation.resumeWithException(exception)
             }
 
-            if (continuation.isCancelled) {
+            if (continuation.isCompleted) {
                 return
             }
 
             if (requestAudioFocus() == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-                if (continuation.isCancelled) {
+                if (continuation.isCompleted) {
                     abandonAudioFocus()
                     return
                 }
@@ -165,7 +165,9 @@ class SoundTagPlayer(
                 start()
             } else {
                 Timber.d("unable to get audio focus, cancelling work")
-                continuation.cancel()
+                if (!continuation.isCompleted) {
+                    continuation.cancel()
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -30,7 +30,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.ensureActive
 import com.ichi2.anki.libanki.SoundOrVideoTag
 import com.ichi2.anki.multimedia.getTagType
 import kotlinx.coroutines.CancellableContinuation
@@ -144,15 +143,24 @@ class SoundTagPlayer(
             try {
                 awaitSetDataSource(soundUri.toString())
             } catch (e: Exception) {
-                continuation.ensureActive()
+                if (continuation.isCancelled) {
+                    return
+                }
                 val continuationBehavior =
                     mediaErrorListener?.onError(soundUri) ?: MediaErrorBehavior.CONTINUE_MEDIA
                 val exception = MediaException(continuationBehavior, e)
                 return continuation.resumeWithException(exception)
             }
 
+            if (continuation.isCancelled) {
+                return
+            }
+
             if (requestAudioFocus() == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-                continuation.ensureActive()
+                if (continuation.isCancelled) {
+                    abandonAudioFocus()
+                    return
+                }
                 Timber.d("starting sound tag")
                 start()
             } else {


### PR DESCRIPTION
Resolves a bottleneck in the reviewer where retrieving audio/video tags blocked the UI thread right before displaying the flashcard content.

By moving `loadCardAvTags` out of a `runBlocking` block and into a `launchCatchingTask`, the WebView's `fillFlashcard()` method can be invoked immediately without having to wait for the media tags to parse. This reduces the time to first paint for the reviewer content.

---
*PR created automatically by Jules for task [11735272359574244144](https://jules.google.com/task/11735272359574244144) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flashcard content now appears immediately while media loading/playback runs asynchronously to avoid blocking interaction.
  * Improved media-player initialization and safer autoplay handling when player settings are not yet available (defaults to requiring user gesture).
  * More robust audio playback flow that cancels gracefully to prevent resume/errors when operations are aborted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->