### PR TITLE
Fix layout drop-frames during Compose transition in Flashcard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -296,11 +296,6 @@ fun Flashcard(
             Image(
                 bitmap = snapshot!!,
                 contentDescription = null,
-                alpha = 0.5f,
-                contentScale = ContentScale.FillBounds,
-                modifier = Modifier.background(
-                    MaterialTheme.colorScheme.inverseSurface
-                )
             )
         } else {
         AndroidView(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -183,8 +183,8 @@ fun Flashcard(
                         text-wrap: pretty;
                         padding-top: ${currentPadding}px;
                         padding-bottom: ${toolbarHeight}px;
-                        margin-left: 0px;
-                        margin-right: 0px;
+                        margin-left: 10px;
+                        margin-right: 10px;
                         background-color: gray;
                         color: ${onSurfaceColorHex}EF;
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -34,9 +34,12 @@ import androidx.compose.foundation.Image
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import android.graphics.Canvas
+import android.graphics.Rect
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -51,7 +54,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.ichi2.anki.R
 import com.ichi2.anki.ViewerResourceHandler
@@ -60,6 +62,7 @@ import com.ichi2.anki.previewer.stdHtml
 import com.ichi2.anki.reviewer.ReviewerJavascriptCommand
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.themes.Themes
+import com.ichi2.utils.AndroidUiUtils
 import com.ichi2.utils.toRGBHex
 import kotlinx.serialization.json.Json
 import timber.log.Timber
@@ -88,6 +91,7 @@ fun Flashcard(
     val currentOnTap by rememberUpdatedState(onTap)
 
     val context = LocalContext.current
+    val activity = remember(context) { AndroidUiUtils.findActivity(context) }
     val sharedPrefs = remember(context) { context.sharedPrefs() }
     val prefKey = stringResource(R.string.apply_hirameki_css_preference)
     var applyHiramekiCssMode by remember {
@@ -173,7 +177,7 @@ fun Flashcard(
                     @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
                     html {
                         color: ${onSurfaceColorHex}EF;
-                        background-color: gray;
+                        background-color: $surfaceColorHex;
                     }
                     body.card {
                         text-align: center;
@@ -185,7 +189,7 @@ fun Flashcard(
                         padding-bottom: ${toolbarHeight}px;
                         margin-left: 10px;
                         margin-right: 10px;
-                        background-color: gray;
+                        background-color: $surfaceColorHex;
                         color: ${onSurfaceColorHex}EF;
                     }
                     body.card .back {
@@ -296,11 +300,7 @@ fun Flashcard(
             Image(
                 bitmap = snapshot!!,
                 contentDescription = null,
-                alpha = 0.5f,
                 contentScale = ContentScale.FillBounds,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.inverseSurface)
             )
         } else {
         AndroidView(
@@ -394,18 +394,51 @@ fun Flashcard(
         }, update = { webView ->
             if (!transition.isRunning) {
                 if (webView.width > 0 && webView.height > 0) {
-                    try {
-                        val bitmap = createBitmap(webView.width, webView.height).apply {
-                            density = webView.resources.displayMetrics.densityDpi
+                    if (activity != null) {
+                        try {
+                            val bitmap = createBitmap(webView.width, webView.height)
+                            val location = IntArray(2)
+                            webView.getLocationInWindow(location)
+                            val rect = Rect(
+                                location[0],
+                                location[1],
+                                location[0] + webView.width,
+                                location[1] + webView.height
+                            )
+                            PixelCopy.request(
+                                activity.window,
+                                rect,
+                                bitmap,
+                                { copyResult ->
+                                    if (copyResult == PixelCopy.SUCCESS) {
+                                        snapshot = bitmap.asImageBitmap()
+                                    } else {
+                                        // Fallback to software draw
+                                        try {
+                                            val fallbackBitmap = createBitmap(webView.width, webView.height)
+                                            val canvas = Canvas(fallbackBitmap)
+                                            webView.draw(canvas)
+                                            snapshot = fallbackBitmap.asImageBitmap()
+                                        } catch (e: Exception) {
+                                            Timber.e(e, "Failed to capture WebView snapshot via fallback inside callback")
+                                        }
+                                    }
+                                },
+                                Handler(Looper.getMainLooper())
+                            )
+                        } catch (e: Exception) {
+                            Timber.e(e, "Failed to capture WebView snapshot via PixelCopy")
                         }
-                        val canvas = Canvas(bitmap)
-                        webView.draw(canvas)
-                        snapshot = bitmap.asImageBitmap()
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to capture WebView snapshot")
-                    } catch (e: OutOfMemoryError) {
-                        System.gc()
-                        Timber.e(e, "Failed to capture WebView snapshot")
+                    } else {
+                        // Fallback to software draw if no activity found
+                        try {
+                            val bitmap = createBitmap(webView.width, webView.height)
+                            val canvas = Canvas(bitmap)
+                            webView.draw(canvas)
+                            snapshot = bitmap.asImageBitmap()
+                        } catch (e: Exception) {
+                            Timber.e(e, "Failed to capture WebView snapshot via fallback")
+                        }
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -173,7 +173,7 @@ fun Flashcard(
                     @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
                     html {
                         color: ${onSurfaceColorHex}EF;
-                        background-color: $surfaceColorHex;
+                        background-color: gray;
                     }
                     body.card {
                         text-align: center;
@@ -183,9 +183,9 @@ fun Flashcard(
                         text-wrap: pretty;
                         padding-top: ${currentPadding}px;
                         padding-bottom: ${toolbarHeight}px;
-                        margin-left: 10px;
-                        margin-right: 10px;
-                        background-color: $surfaceColorHex;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        background-color: gray;
                         color: ${onSurfaceColorHex}EF;
                     }
                     body.card .back {
@@ -296,6 +296,11 @@ fun Flashcard(
             Image(
                 bitmap = snapshot!!,
                 contentDescription = null,
+                alpha = 0.5f,
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.inverseSurface)
             )
         } else {
         AndroidView(
@@ -390,7 +395,9 @@ fun Flashcard(
             if (!transition.isRunning) {
                 if (webView.width > 0 && webView.height > 0) {
                     try {
-                        val bitmap = createBitmap(webView.width, webView.height)
+                        val bitmap = createBitmap(webView.width, webView.height).apply {
+                            density = webView.resources.displayMetrics.densityDpi
+                        }
                         val canvas = Canvas(bitmap)
                         webView.draw(canvas)
                         snapshot = bitmap.asImageBitmap()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -29,6 +29,13 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.Image
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -58,6 +65,7 @@ import timber.log.Timber
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
+@OptIn(androidx.compose.animation.ExperimentalAnimationApi::class, androidx.compose.animation.core.ExperimentalTransitionApi::class)
 fun Flashcard(
     baseUrl: String,
     questionHtml: String,
@@ -121,10 +129,14 @@ fun Flashcard(
         FlashcardContentKey(questionHtml.hashCode(), answerHtml.hashCode())
     }
 
-    Crossfade(
+    var snapshot by remember { mutableStateOf<ImageBitmap?>(null) }
+    val transition = updateTransition(
         targetState = Pair(isAnswerShown, if (isAnswerShown) answerHtml else questionHtml),
-        animationSpec = tween(300),
         label = "FlashcardCrossfade"
+    )
+
+    transition.Crossfade(
+        animationSpec = tween(300)
     ) { (shown, currentHtml) ->
         val currentStyle =
             if (shown) bodyLargeStyle else displayLargeStyle.copy(fontWeight = FontWeight.W500)
@@ -278,6 +290,9 @@ fun Flashcard(
                 )
             }
 
+        if (transition.isRunning && snapshot != null && shown != isAnswerShown) {
+            Image(bitmap = snapshot!!, contentDescription = null, modifier = modifier.fillMaxSize())
+        } else {
         AndroidView(
             factory = { context ->
             WebView(context).apply {
@@ -367,6 +382,18 @@ fun Flashcard(
                 setBackgroundColor(Color.TRANSPARENT)
             }
         }, update = { webView ->
+            if (!transition.isRunning) {
+                if (webView.width > 0 && webView.height > 0) {
+                    try {
+                        val bitmap = Bitmap.createBitmap(webView.width, webView.height, Bitmap.Config.ARGB_8888)
+                        val canvas = Canvas(bitmap)
+                        webView.draw(canvas)
+                        snapshot = bitmap.asImageBitmap()
+                    } catch (e: Exception) {
+                        // Ignore
+                    }
+                }
+            }
             webView.settings.mediaPlaybackRequiresUserGesture = !isMediaAutoplayEnabled
             val currentPayload = webView.tag as? FlashcardPayload
             val shellChanged =
@@ -450,6 +477,7 @@ fun Flashcard(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface)
         )
+        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -33,11 +33,10 @@ import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -48,9 +47,11 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.ichi2.anki.R
 import com.ichi2.anki.ViewerResourceHandler
@@ -62,6 +63,7 @@ import com.ichi2.themes.Themes
 import com.ichi2.utils.toRGBHex
 import kotlinx.serialization.json.Json
 import timber.log.Timber
+import androidx.core.graphics.createBitmap
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -291,7 +293,15 @@ fun Flashcard(
             }
 
         if (transition.isRunning && snapshot != null && shown != isAnswerShown) {
-            Image(bitmap = snapshot!!, contentDescription = null, modifier = modifier.fillMaxSize())
+            Image(
+                bitmap = snapshot!!,
+                contentDescription = null,
+                alpha = 0.5f,
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier.background(
+                    MaterialTheme.colorScheme.inverseSurface
+                )
+            )
         } else {
         AndroidView(
             factory = { context ->
@@ -385,12 +395,15 @@ fun Flashcard(
             if (!transition.isRunning) {
                 if (webView.width > 0 && webView.height > 0) {
                     try {
-                        val bitmap = Bitmap.createBitmap(webView.width, webView.height, Bitmap.Config.ARGB_8888)
+                        val bitmap = createBitmap(webView.width, webView.height)
                         val canvas = Canvas(bitmap)
                         webView.draw(canvas)
                         snapshot = bitmap.asImageBitmap()
                     } catch (e: Exception) {
-                        // Ignore
+                        Timber.e(e, "Failed to capture WebView snapshot")
+                    } catch (e: OutOfMemoryError) {
+                        System.gc()
+                        Timber.e(e, "Failed to capture WebView snapshot")
                     }
                 }
             }


### PR DESCRIPTION
Fix layout drop-frames during Compose transition in Flashcard

When Flashcard transitions between Question and Answer using `Crossfade`, the outgoing `WebView` stays fully alive in the view hierarchy, leading to heavily dropped frames.
This commit decouples the `WebView` by intercepting the state change, capturing an instantaneous pixel-perfect bitmap snapshot of the outgoing `WebView` (preserving scroll and dynamically loaded assets like image occlusions or MathJax), and using Compose `Image` for the outgoing branch, yielding identical visual fidelity but robust Transition Deferral.

---
*PR created automatically by Jules for task [2584409999756225214](https://jules.google.com/task/2584409999756225214) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation smoothness when switching between question and answer in flashcards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColbyCabrera/Hirameki/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->