### PR TITLE
Hard-disable Google Analytics and remove related UI components

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -139,12 +139,6 @@ open class AnkiDroidApp : Application(), ChangeManager.Subscriber {
         Timber.d("Startup - Application Start")
         Timber.i("Timber config: $logType")
 
-        // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
-        UsageAnalytics.initialize(this)
-        if (BuildConfig.DEBUG) {
-            UsageAnalytics.setDryRun(true)
-        }
-
         // Last in the UncaughtExceptionHandlers chain is our filter service
         ThrowableFilterService.initialize()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1328,7 +1328,7 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
         } else if (skip < 2 && !InitialActivity.isLatestVersion(preferences)) {
             Timber.i("AnkiDroid is being updated and a collection already exists.")
             // The user might appreciate us now, see if they will help us get better?
-            if (!preferences.contains(UsageAnalytics.ANALYTICS_OPTIN_KEY)) {
+            if (UsageAnalytics.isAvailable && !preferences.contains(UsageAnalytics.ANALYTICS_OPTIN_KEY)) {
                 displayAnalyticsOptInDialog()
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -40,7 +40,7 @@ import timber.log.Timber
 @KotlinCleanup("see if we can make variables lazy, or properties without the `s` prefix")
 object UsageAnalytics {
     const val ANALYTICS_OPTIN_KEY = "analytics_opt_in"
-    val isAvailable: Boolean = false
+    const val isAvailable = false
 
     @KotlinCleanup("lateinit")
     private var sAnalytics: GoogleAnalytics? = null
@@ -74,6 +74,11 @@ object UsageAnalytics {
         if (!isAvailable) {
             Timber.i("Analytics disabled for this fork; skipping initialization")
             sOptIn = false
+            runCatching {
+                context.sharedPrefs().edit {
+                    putBoolean(ANALYTICS_OPTIN_KEY, false)
+                }
+            }
             return null
         }
         Timber.i("initialize()")
@@ -198,6 +203,11 @@ object UsageAnalytics {
             Timber.i("Analytics disabled for this fork; skipping re-initialization")
             sAnalytics = null
             sOptIn = false
+            runCatching {
+                AnkiDroidApp.sharedPrefs().edit {
+                    putBoolean(ANALYTICS_OPTIN_KEY, false)
+                }
+            }
             return
         }
         // send any pending async hits, re-chain default exception handlers and re-init
@@ -226,10 +236,11 @@ object UsageAnalytics {
      */
     fun sendAnalyticsScreenView(screenName: String) {
         Timber.d("sendAnalyticsScreenView(): %s", screenName)
-        if (!isAvailable || !optIn || sAnalytics == null) {
+        val analytics = sAnalytics
+        if (!isAvailable || !optIn || analytics == null) {
             return
         }
-        sAnalytics!!.screenView().screenName(screenName).sendAsync()
+        analytics.screenView().screenName(screenName).sendAsync()
     }
 
     /**
@@ -247,10 +258,11 @@ object UsageAnalytics {
         label: String? = null,
     ) {
         Timber.d("sendAnalyticsEvent() category/action/value/label: %s/%s/%s/%s", category, action, value, label)
-        if (!isAvailable || !optIn || sAnalytics == null) {
+        val analytics = sAnalytics
+        if (!isAvailable || !optIn || analytics == null) {
             return
         }
-        val event = sAnalytics!!.event().eventCategory(category).eventAction(action)
+        val event = analytics.event().eventCategory(category).eventAction(action)
         if (label != null) {
             event.eventLabel(label)
         }
@@ -294,10 +306,11 @@ object UsageAnalytics {
         fatal: Boolean,
     ) {
         Timber.d("sendAnalyticsException() description/fatal: %s/%s", description, fatal)
-        if (!isAvailable || !sOptIn || sAnalytics == null) {
+        val analytics = sAnalytics
+        if (!isAvailable || !sOptIn || analytics == null) {
             return
         }
-        sAnalytics!!
+        analytics
             .exception()
             .exceptionDescription(description)
             .exceptionFatal(fatal)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -40,6 +40,7 @@ import timber.log.Timber
 @KotlinCleanup("see if we can make variables lazy, or properties without the `s` prefix")
 object UsageAnalytics {
     const val ANALYTICS_OPTIN_KEY = "analytics_opt_in"
+    val isAvailable: Boolean = false
 
     @KotlinCleanup("lateinit")
     private var sAnalytics: GoogleAnalytics? = null
@@ -70,6 +71,11 @@ object UsageAnalytics {
      */
     @Synchronized
     fun initialize(context: Context): GoogleAnalytics? {
+        if (!isAvailable) {
+            Timber.i("Analytics disabled for this fork; skipping initialization")
+            sOptIn = false
+            return null
+        }
         Timber.i("initialize()")
         if (sAnalytics == null) {
             Timber.d("App tracking id 'tid' = %s", getAnalyticsTag(context))
@@ -124,6 +130,10 @@ object UsageAnalytics {
     }
 
     fun setDevMode() {
+        if (!isAvailable) {
+            Timber.i("Analytics disabled for this fork; ignoring dev mode request")
+            return
+        }
         Timber.d("setDevMode() re-configuring for development analytics tagging")
         sAnalyticsTrackingId = "UA-125800786-2"
         sAnalyticsSamplePercentage = 100
@@ -184,6 +194,12 @@ object UsageAnalytics {
      */
     @Synchronized
     fun reInitialize() {
+        if (!isAvailable) {
+            Timber.i("Analytics disabled for this fork; skipping re-initialization")
+            sAnalytics = null
+            sOptIn = false
+            return
+        }
         // send any pending async hits, re-chain default exception handlers and re-init
         Timber.i("reInitialize()")
         sAnalytics!!.flush()
@@ -210,7 +226,7 @@ object UsageAnalytics {
      */
     fun sendAnalyticsScreenView(screenName: String) {
         Timber.d("sendAnalyticsScreenView(): %s", screenName)
-        if (!optIn) {
+        if (!isAvailable || !optIn || sAnalytics == null) {
             return
         }
         sAnalytics!!.screenView().screenName(screenName).sendAsync()
@@ -231,7 +247,7 @@ object UsageAnalytics {
         label: String? = null,
     ) {
         Timber.d("sendAnalyticsEvent() category/action/value/label: %s/%s/%s/%s", category, action, value, label)
-        if (!optIn) {
+        if (!isAvailable || !optIn || sAnalytics == null) {
             return
         }
         val event = sAnalytics!!.event().eventCategory(category).eventAction(action)
@@ -278,7 +294,7 @@ object UsageAnalytics {
         fatal: Boolean,
     ) {
         Timber.d("sendAnalyticsException() description/fatal: %s/%s", description, fatal)
-        if (!sOptIn) {
+        if (!isAvailable || !sOptIn || sAnalytics == null) {
             return
         }
         sAnalytics!!
@@ -304,20 +320,22 @@ object UsageAnalytics {
 
     // A listener on this preference handles the rest
     var isEnabled: Boolean
-        get() {
-            val userPrefs = AnkiDroidApp.instance.sharedPrefs()
-            return userPrefs.getBoolean(ANALYTICS_OPTIN_KEY, false)
-        }
+        get() = false
         set(value) {
-            // A listener on this preference handles the rest
-            AnkiDroidApp.instance.sharedPrefs().edit {
-                putBoolean(ANALYTICS_OPTIN_KEY, value)
+            if (value) {
+                Timber.i("Analytics disabled for this fork; ignoring opt-in request")
+            }
+            runCatching {
+                AnkiDroidApp.sharedPrefs().edit {
+                    putBoolean(ANALYTICS_OPTIN_KEY, false)
+                }
             }
         }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun resetForTests() {
         sAnalytics = null
+        sOptIn = false
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -75,16 +75,6 @@ class DevOptionsFragment : SettingsFragment() {
             Timber.w("Crash triggered on purpose from advanced preferences in debug mode")
             throw RuntimeException("This is a test crash")
         }
-        // Make it possible to test analytics
-        requirePreference<Preference>(R.string.pref_analytics_debug_key).setOnPreferenceClickListener {
-            if (UsageAnalytics.isEnabled) {
-                showSnackbar("Analytics set to dev mode")
-            } else {
-                showSnackbar("Done! Enable Analytics in 'General' settings to use.")
-            }
-            UsageAnalytics.setDevMode()
-            false
-        }
         // Lock database
         requirePreference<Preference>(R.string.pref_lock_database_key).setOnPreferenceClickListener {
             Timber.w("Toggling database lock")

--- a/AnkiDroid/src/main/res/values/analytic_constants.xml
+++ b/AnkiDroid/src/main/res/values/analytic_constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <string name="ga_trackingId" translatable="false">UA-125800786-1</string>
+    <string name="ga_trackingId" translatable="false">fork-disabled</string>
     <!-- If you go over limits, further hits are dropped, setting a sampling percentage can help -->
     <!-- Current limits: 10MM/month globally, 200K/user && 500/session, 1 ever 2s + 60 in a session -->
     <!-- https://developers.google.com/analytics/devguides/collection/android/v4/limits-quotas -->

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -37,10 +37,6 @@
         android:summary="Touch here for an immediate test crash"
         android:key="@string/pref_trigger_crash_key"/>
     <Preference
-        android:title="Switch Analytics to dev mode"
-        android:summary="Touch here to use Analytics dev tag and 100% sample rate"
-        android:key="@string/pref_analytics_debug_key"/>
-    <Preference
         android:title="Lock database"
         android:summary="Touch here to lock the database (all threads block in-process, exception if using second process)"
         android:key="@string/pref_lock_database_key"/>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -39,11 +39,6 @@
             android:key="@string/error_reporting_mode_key"
             android:title="@string/error_reporting_choice"
             app:useSimpleSummaryProvider="true"/>
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="@string/analytics_opt_in_key"
-            android:summary="@string/analytics_summ"
-            android:title="@string/analytics_title" />
     <PreferenceCategory android:title="@string/pref_cat_editing">
         <SwitchPreferenceCompat
             android:defaultValue="true"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
@@ -18,27 +18,20 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.res.Resources
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
-import com.brsanthu.googleanalytics.GoogleAnalytics
-import com.brsanthu.googleanalytics.GoogleAnalyticsBuilder
-import com.brsanthu.googleanalytics.request.ExceptionHit
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.analytics.UsageAnalytics
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.any
-import org.mockito.Mockito.anyString
-import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.mockStatic
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.validateMockitoUsage
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 class AnalyticsTest {
     @Mock
@@ -47,90 +40,57 @@ class AnalyticsTest {
     @Mock
     private lateinit var mockResources: Resources
 
-    private val sharedPreferences =
-        SPMockBuilder().createSharedPreferences().apply {
-            edit {
-                putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
-            }
+    private val sharedPreferences = SPMockBuilder().createSharedPreferences().apply {
+        edit {
+            putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
         }
+    }
 
     @Before
     fun setUp() {
         UsageAnalytics.resetForTests()
+        AnkiDroidApp.sharedPreferencesTestingOverride = sharedPreferences
         MockitoAnnotations.openMocks(this)
 
         whenever((mockResources.getBoolean(R.bool.ga_anonymizeIp))).thenReturn(true)
-        whenever(mockResources.getInteger(R.integer.ga_sampleFrequency))
-            .thenReturn(10)
-        whenever(mockContext.resources)
-            .thenReturn(mockResources)
-        whenever(mockContext.getString(R.string.ga_trackingId))
-            .thenReturn("Mock Tracking ID")
-        whenever(mockContext.getString(R.string.app_name))
-            .thenReturn("Mock Application Name")
-        whenever(mockContext.packageName)
-            .thenReturn("mock_context")
-        whenever(mockContext.getSharedPreferences("mock_context_preferences", Context.MODE_PRIVATE))
-            .thenReturn(sharedPreferences)
-    }
-
-    private class SpyGoogleAnalyticsBuilder : GoogleAnalyticsBuilder() {
-        override fun build(): GoogleAnalytics {
-            val analytics = super.build()
-            return spy(analytics)
-        }
+        whenever(mockResources.getInteger(R.integer.ga_sampleFrequency)).thenReturn(10)
+        whenever(mockContext.resources).thenReturn(mockResources)
+        whenever(mockContext.getString(R.string.ga_trackingId)).thenReturn("Mock Tracking ID")
+        whenever(mockContext.getString(R.string.app_name)).thenReturn("Mock Application Name")
+        whenever(mockContext.packageName).thenReturn("mock_context")
+        whenever(
+            mockContext.getSharedPreferences(
+                "mock_context_preferences",
+                Context.MODE_PRIVATE
+            )
+        ).thenReturn(sharedPreferences)
     }
 
     @After
     fun validate() {
+        AnkiDroidApp.sharedPreferencesTestingOverride = null
         validateMockitoUsage()
     }
 
-    @Test // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
-    @Suppress("DEPRECATION")
-    fun testSendException() {
-        mockStatic(PreferenceManager::class.java).use { _ ->
-            mockStatic(GoogleAnalytics::class.java).use { _ ->
-                whenever(PreferenceManager.getDefaultSharedPreferences(any()))
-                    .thenReturn(sharedPreferences)
-                whenever(GoogleAnalytics.builder())
-                    .thenReturn(SpyGoogleAnalyticsBuilder())
+    @Test
+    fun initializeDoesNotBuildAnalyticsForFork() {
+        assertFalse(UsageAnalytics.isAvailable)
+        assertNull(mockContext.let { UsageAnalytics.initialize(it) })
+        assertFalse(UsageAnalytics.isEnabled)
 
-                // This is actually a Mockito Spy of GoogleAnalyticsImpl
-                val analytics = mockContext.let { UsageAnalytics.initialize(it) }
+        UsageAnalytics.isEnabled = true
 
-                // no root cause
-                val exception = mock(Exception::class.java)
-                whenever(exception.cause).thenReturn(null)
-                val cause = UsageAnalytics.getCause(exception)
-                verify(exception).cause
-                assertEquals(exception, cause)
+        assertFalse(sharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
+    }
 
-                // a 3-exception chain inside the actual analytics call
-                val childException = mock(Exception::class.java)
-                whenever(childException.cause).thenReturn(null)
-                whenever(childException.toString()).thenReturn("child exception toString()")
-                val parentException = mock(Exception::class.java)
-                whenever(parentException.cause).thenReturn(childException)
-                val grandparentException = mock(Exception::class.java)
-                whenever(grandparentException.cause).thenReturn(parentException)
+    @Test
+    fun getCauseReturnsRootCauseWhenAnalyticsDisabled() {
+        val exception = mock(Exception::class.java)
+        whenever(exception.cause).thenReturn(null)
 
-                // prepare analytics so we can inspect what happens
-                val spyHit = spy(ExceptionHit())
-                doReturn(spyHit).whenever(analytics).exception()
-                try {
-                    UsageAnalytics.sendAnalyticsException(grandparentException, false)
-                } catch (_: Exception) {
-                    // do nothing - this is expected because UsageAnalytics isn't fully initialized
-                }
-                verify(grandparentException).cause
-                verify(parentException).cause
-                verify(childException).cause
-                verify(analytics)?.exception()
-                verify(spyHit).exceptionDescription(anyString())
-                verify(spyHit).sendAsync()
-                assertEquals(spyHit.exceptionDescription(), "child exception toString()")
-            }
-        }
+        val cause = UsageAnalytics.getCause(exception)
+
+        verify(exception).cause
+        assertEquals(exception, cause)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.res.Resources
 import androidx.core.content.edit
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
@@ -24,14 +25,13 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.validateMockitoUsage
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class AnalyticsTest {
     @Mock
@@ -40,14 +40,15 @@ class AnalyticsTest {
     @Mock
     private lateinit var mockResources: Resources
 
-    private val sharedPreferences = SPMockBuilder().createSharedPreferences().apply {
-        edit {
-            putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
-        }
-    }
+    private lateinit var sharedPreferences: SharedPreferences
 
     @Before
     fun setUp() {
+        sharedPreferences = SPMockBuilder().createSharedPreferences().apply {
+            edit {
+                putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
+            }
+        }
         UsageAnalytics.resetForTests()
         AnkiDroidApp.sharedPreferencesTestingOverride = sharedPreferences
         MockitoAnnotations.openMocks(this)
@@ -60,8 +61,7 @@ class AnalyticsTest {
         whenever(mockContext.packageName).thenReturn("mock_context")
         whenever(
             mockContext.getSharedPreferences(
-                "mock_context_preferences",
-                Context.MODE_PRIVATE
+                "mock_context_preferences", Context.MODE_PRIVATE
             )
         ).thenReturn(sharedPreferences)
     }
@@ -75,8 +75,26 @@ class AnalyticsTest {
     @Test
     fun initializeDoesNotBuildAnalyticsForFork() {
         assertFalse(UsageAnalytics.isAvailable)
+
+        // Persisted flag should start as true (consent given pre-fork / pre-disablement)
+        assertTrue(sharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
+
         assertNull(mockContext.let { UsageAnalytics.initialize(it) })
+
+        // Assert that initialization cleared the opt-in flag in SharedPreferences since it's disabled
+        assertFalse(sharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
         assertFalse(UsageAnalytics.isEnabled)
+
+        // Reset to true to test reInitialize clearing behavior
+        sharedPreferences.edit {
+            putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
+        }
+        assertTrue(sharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
+
+        UsageAnalytics.reInitialize()
+
+        // Assert that re-initialization cleared the opt-in flag in SharedPreferences
+        assertFalse(sharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
 
         UsageAnalytics.isEnabled = true
 
@@ -85,12 +103,12 @@ class AnalyticsTest {
 
     @Test
     fun getCauseReturnsRootCauseWhenAnalyticsDisabled() {
-        val exception = mock(Exception::class.java)
-        whenever(exception.cause).thenReturn(null)
+        val rootCause = Exception("root cause")
+        val parent = Exception("parent exception", rootCause)
+        val grandparent = Exception("grandparent exception", parent)
 
-        val cause = UsageAnalytics.getCause(exception)
+        val cause = UsageAnalytics.getCause(grandparent)
 
-        verify(exception).cause
-        assertEquals(exception, cause)
+        assertEquals(rootCause, cause)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -130,7 +130,7 @@ class DeckPickerTest : RobolectricTest() {
     }
 
     @Test
-    fun deckPickerOpensWithHelpMakeAnkiDroidBetterDialog() {
+    fun deckPickerSkipsAnalyticsOptInDialogWhenAnalyticsDisabled() {
         try {
             grantWritePermissions()
             targetContext.sharedPrefs().edit {
@@ -143,7 +143,7 @@ class DeckPickerTest : RobolectricTest() {
                 scenario.onActivity { activity ->
                     val dialogFragment =
                         activity.getCurrentDialogFragment<DeckPickerAnalyticsOptInDialog>()
-                    assertNotNull(dialogFragment, "Analytics opt-in should be displayed")
+                    assertNull(dialogFragment, "Analytics opt-in should not be displayed")
                 }
             }
         } finally {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -44,8 +44,6 @@ class PreferencesAnalyticsTest : RobolectricTest() {
     /** Keys of preferences that shouldn't be reported */
     private val excludedPrefs: Set<String> =
         setOf(
-            // Share feature usage: analytics are only reported if this is enabled :)
-            R.string.analytics_opt_in_key, // analytics_opt_in
             // Screens: don't have a value
             R.string.pref_general_screen_key, // generalScreen
             R.string.pref_reviewing_screen_key, // reviewingScreen


### PR DESCRIPTION
- Updated `UsageAnalytics` to hard-code `isAvailable` to `false` and modified all tracking methods to exit early when disabled.
- Refactored `UsageAnalytics.isEnabled` to always return `false` and ignore opt-in requests.
- Removed the analytics opt-in toggle from `preferences_general.xml` and the "Switch Analytics to dev mode" option from `preferences_dev_options.xml`.
- Removed explicit `UsageAnalytics` initialization and dry-run configuration from `AnkiDroidApp`.
- Updated `DeckPicker` to bypass the analytics opt-in dialog logic.
- Refactored `AnalyticsTest` and `DeckPickerTest` to verify that analytics remains inactive and related UI prompts are suppressed.
- Updated the `ga_trackingId` constant to "fork-disabled".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics have been disabled across the app; opt-in is no longer enabled and reporting is suppressed.
  * Analytics opt-in control removed from general settings and developer options; opt-in dialog is skipped when analytics are unavailable.

* **Chores**
  * Tracking ID replaced with a disabled value to prevent reporting.

* **Tests**
  * Test suite updated to reflect analytics being disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->