### PR TITLE
Address review comments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -145,6 +145,7 @@ class NoteEditorViewModel(
         private const val KEY_TAGS = "note_editor_tags"
         private const val KEY_SELECTED_DECK_NAME = "note_editor_selected_deck_name"
         private const val KEY_FOCUSED_FIELD_INDEX = "note_editor_focused_field_index"
+        private val HTML_LINE_BREAK_REGEX = Regex("<br\\s*/?>", RegexOption.IGNORE_CASE)
 
         // Keys for caller/result state (migrated from Fragment)
         private const val KEY_CALLER = "note_editor_caller"
@@ -509,13 +510,13 @@ class NoteEditorViewModel(
 
                     // Collect all tags from the notes
                     noteIds.asSequence().mapNotNull { noteId ->
-                            try {
-                                col.getNote(noteId).tags
-                            } catch (e: Exception) {
-                                Timber.w(e, "Error getting note tags for note $noteId")
-                                null
-                            }
-                        }.flatten().toSet()
+                        try {
+                            col.getNote(noteId).tags
+                        } catch (e: Exception) {
+                            Timber.w(e, "Error getting note tags for note $noteId")
+                            null
+                        }
+                    }.flatten().toSet()
                 } else {
                     emptySet()
                 }
@@ -1169,10 +1170,8 @@ class NoteEditorViewModel(
         notetype: NotetypeJson,
     ): List<NoteFieldState> = (0 until notetype.fields.length()).map { index ->
         val field = notetype.fields[index]
-        val value = if (index < note.fields.size) note.fields[index] else ""
-        val editableValue =
-            value.replace("<br>", "\n").replace("<br/>", "\n").replace("<br />", "\n")
-                .replace("<BR>", "\n").replace("<BR/>", "\n").replace("<BR />", "\n")
+        val value = note.fields.getOrNull(index).orEmpty()
+        val editableValue = value.replace(HTML_LINE_BREAK_REGEX, "\n")
         NoteFieldState(
             name = field.name,
             value = TextFieldValue(editableValue),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
@@ -16,29 +16,20 @@
 package com.ichi2.anki
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.res.Resources
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
-import com.brsanthu.googleanalytics.GoogleAnalytics
-import com.brsanthu.googleanalytics.GoogleAnalyticsBuilder
-import com.brsanthu.googleanalytics.request.ExceptionHit
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.analytics.UsageAnalytics
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.any
-import org.mockito.Mockito.anyString
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.mockStatic
-import org.mockito.Mockito.spy
-import org.mockito.Mockito.validateMockitoUsage
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 class AnalyticsTest {
     @Mock
@@ -47,90 +38,57 @@ class AnalyticsTest {
     @Mock
     private lateinit var mockResources: Resources
 
-    private val sharedPreferences =
-        SPMockBuilder().createSharedPreferences().apply {
+    private lateinit var sharedPreferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        sharedPreferences = SPMockBuilder().createSharedPreferences().apply {
             edit {
                 putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
             }
         }
-
-    @Before
-    fun setUp() {
         UsageAnalytics.resetForTests()
+        AnkiDroidApp.sharedPreferencesTestingOverride = sharedPreferences
         MockitoAnnotations.openMocks(this)
 
         whenever((mockResources.getBoolean(R.bool.ga_anonymizeIp))).thenReturn(true)
-        whenever(mockResources.getInteger(R.integer.ga_sampleFrequency))
-            .thenReturn(10)
-        whenever(mockContext.resources)
-            .thenReturn(mockResources)
-        whenever(mockContext.getString(R.string.ga_trackingId))
-            .thenReturn("Mock Tracking ID")
-        whenever(mockContext.getString(R.string.app_name))
-            .thenReturn("Mock Application Name")
-        whenever(mockContext.packageName)
-            .thenReturn("mock_context")
-        whenever(mockContext.getSharedPreferences("mock_context_preferences", Context.MODE_PRIVATE))
-            .thenReturn(sharedPreferences)
-    }
-
-    private class SpyGoogleAnalyticsBuilder : GoogleAnalyticsBuilder() {
-        override fun build(): GoogleAnalytics {
-            val analytics = super.build()
-            return spy(analytics)
-        }
+        whenever(mockResources.getInteger(R.integer.ga_sampleFrequency)).thenReturn(10)
+        whenever(mockContext.resources).thenReturn(mockResources)
+        whenever(mockContext.getString(R.string.ga_trackingId)).thenReturn("Mock Tracking ID")
+        whenever(mockContext.getString(R.string.app_name)).thenReturn("Mock Application Name")
+        whenever(mockContext.packageName).thenReturn("mock_context")
+        whenever(
+            mockContext.getSharedPreferences(
+                "mock_context_preferences",
+                Context.MODE_PRIVATE
+            )
+        ).thenReturn(sharedPreferences)
     }
 
     @After
     fun validate() {
-        validateMockitoUsage()
+        AnkiDroidApp.sharedPreferencesTestingOverride = null
     }
 
-    @Test // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
-    @Suppress("DEPRECATION")
-    fun testSendException() {
-        mockStatic(PreferenceManager::class.java).use { _ ->
-            mockStatic(GoogleAnalytics::class.java).use { _ ->
-                whenever(PreferenceManager.getDefaultSharedPreferences(any()))
-                    .thenReturn(sharedPreferences)
-                whenever(GoogleAnalytics.builder())
-                    .thenReturn(SpyGoogleAnalyticsBuilder())
+    @Test
+    fun initializeDoesNotBuildAnalyticsForFork() {
+        assertFalse(UsageAnalytics.isAvailable)
+        assertNull(mockContext.let { UsageAnalytics.initialize(it) })
+        assertFalse(UsageAnalytics.isEnabled)
 
-                // This is actually a Mockito Spy of GoogleAnalyticsImpl
-                val analytics = mockContext.let { UsageAnalytics.initialize(it) }
+        UsageAnalytics.isEnabled = true
 
-                // no root cause
-                val exception = mock(Exception::class.java)
-                whenever(exception.cause).thenReturn(null)
-                val cause = UsageAnalytics.getCause(exception)
-                verify(exception).cause
-                assertEquals(exception, cause)
+        assertFalse(sharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
+    }
 
-                // a 3-exception chain inside the actual analytics call
-                val childException = mock(Exception::class.java)
-                whenever(childException.cause).thenReturn(null)
-                whenever(childException.toString()).thenReturn("child exception toString()")
-                val parentException = mock(Exception::class.java)
-                whenever(parentException.cause).thenReturn(childException)
-                val grandparentException = mock(Exception::class.java)
-                whenever(grandparentException.cause).thenReturn(parentException)
+    @Test
+    fun getCauseReturnsRootCauseWhenAnalyticsDisabled() {
+        val root = IllegalArgumentException("root")
+        val middle = RuntimeException("middle", root)
+        val top = IllegalStateException("top", middle)
 
-                // prepare analytics so we can inspect what happens
-                val spyHit = spy(ExceptionHit())
-                doReturn(spyHit).whenever(analytics).exception()
-                try {
-                    UsageAnalytics.sendAnalyticsException(grandparentException, false)
-                } catch (_: Exception) {
-                    // do nothing - this is expected because UsageAnalytics isn't fully initialized
-                }
-                verify(grandparentException).cause
-                verify(parentException).cause
-                verify(childException).cause
-                verify(analytics)?.exception()
-                verify(spyHit).exceptionDescription(anyString())
-                verify(spyHit).sendAsync()
-                assertEquals(spyHit.exceptionDescription(), "child exception toString()")
-            }
-        }
+        val cause = UsageAnalytics.getCause(top)
+
+        assertEquals(root, cause)
     }
 }


### PR DESCRIPTION
This pull request primarily refactors and improves the test code for analytics in `AnalyticsTest.kt`, and simplifies the handling of HTML line breaks in `NoteEditorViewModel.kt`. The most significant changes are grouped below:

**Test Refactoring and Improvements:**

* Refactored `AnalyticsTest` to use `kotlin.test` assertions instead of JUnit and removed unused imports for cleaner, more idiomatic Kotlin test code.
* Changed `sharedPreferences` initialization to occur in the `@Before` setup method, and ensured it is properly injected and reset for each test using `AnkiDroidApp.sharedPreferencesTestingOverride`.
* Removed legacy tests and Google Analytics mocking, replacing them with new tests for analytics initialization and root cause extraction, improving test clarity and coverage.

**Code Simplification and Robustness:**

* Replaced manual string replacements for HTML line breaks in note fields with a single regex (`HTML_LINE_BREAK_REGEX`), simplifying and unifying the logic for converting HTML breaks to newlines. [[1]](diffhunk://#diff-5ed8181369a0d1bcb7e8c9737ec22b1b284cc07841acc7d4a667dc917c8f05f8R148) [[2]](diffhunk://#diff-5ed8181369a0d1bcb7e8c9737ec22b1b284cc07841acc7d4a667dc917c8f05f8L1172-R1174)