### PR TITLE
Fix missing warning dialog for note type changes that require a full sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -57,6 +57,9 @@ import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.android.input.ShortcutGroup
+import com.ichi2.anki.dialogs.ConfirmationDialog
+import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
+import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -636,7 +639,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                         noteEditorViewModel.toggleStickyField(index)
                     },
                     onSaveClick = {
-                        launchCatchingTask { saveNote() }
+                        saveNoteWithSchemaConfirmation()
                     },
                     onPreviewClick = {
                         launchCatchingTask { performPreview() }
@@ -755,7 +758,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                             showSaveAction = allowSaveAndPreview,
                             saveEnabled = allowSaveAndPreview,
                             onSaveClick = {
-                                launchCatchingTask { saveNote() }
+                                saveNoteWithSchemaConfirmation()
                             },
                             showPreviewAction = allowSaveAndPreview,
                             previewEnabled = allowSaveAndPreview,
@@ -806,7 +809,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                     noClozeDialogMessage = noClozeDialogMessage,
                     onSaveAnywayClick = {
                         noteEditorViewModel.dismissNoClozeDialog()
-                        launchCatchingTask { saveNote() }
+                        saveNoteWithSchemaConfirmation()
                     },
                     onDismissNoClozeDialog = {
                         noteEditorViewModel.dismissNoClozeDialog()
@@ -897,7 +900,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
         when (keyCode) {
             KeyEvent.KEYCODE_NUMPAD_ENTER, KeyEvent.KEYCODE_ENTER -> if (event.isCtrlPressed) {
                 if (allowSaveAndPreview()) {
-                    launchCatchingTask { saveNote() }
+                    saveNoteWithSchemaConfirmation()
                     return true
                 }
             }
@@ -1084,6 +1087,25 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
             is NoteFieldsCheckResult.Failure -> {
                 addNoteErrorMessage = result.localizedMessage
                 displayErrorSavingNote()
+            }
+        }
+    }
+
+    private fun saveNoteWithSchemaConfirmation() {
+        launchCatchingTask {
+            try {
+                saveNote()
+            } catch (e: ConfirmModSchemaException) {
+                Timber.w(e, "Schema confirmation required before saving note")
+                val dialog = ConfirmationDialog()
+                dialog.setArgs(getString(R.string.full_sync_confirmation))
+                dialog.setConfirm {
+                    launchCatchingTask {
+                        withCol { modSchemaNoCheck() }
+                        saveNote()
+                    }
+                }
+                showDialogFragment(dialog)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.Note.ClozeUtils
 import com.ichi2.anki.libanki.NotetypeJson
+import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
 import com.ichi2.anki.noteeditor.compose.NoteEditorState
 import com.ichi2.anki.noteeditor.compose.NoteFieldState
 import com.ichi2.anki.noteeditor.compose.ToolbarItemDialogState
@@ -882,6 +883,7 @@ class NoteEditorViewModel(
             clearDraftState()
             NoteFieldsCheckResult.Success
         } catch (e: Exception) {
+            if (e is ConfirmModSchemaException) throw e
             Timber.e(e, "Error saving note")
             NoteFieldsCheckResult.Failure(null)
         }
@@ -965,6 +967,7 @@ class NoteEditorViewModel(
         if (note.notetype.id != initialNoteTypeId) {
             val oldNotetype = col.notetypes.get(initialNoteTypeId) ?: note.notetype
             val newNotetype = note.notetype
+            col.modSchema()
             col.notetypes.change(
                 oldNotetype,
                 note.id,


### PR DESCRIPTION
Fixes the missing warning dialog when changing a note type in a way that requires a full one-way sync. The exception `ConfirmModSchemaException` was being swallowed in `NoteEditorViewModel`, preventing `NoteEditorFragment` from catching it and showing the `ConfirmationDialog` with the full sync warning message.

Closes #106 

---
*PR created automatically by Jules for task [3511528790022747332](https://jules.google.com/task/3511528790022747332) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a confirmation dialog when saving notes with modified note types, prompting users to confirm schema changes required for synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->