### PR TITLE
🎨 Palette: Add keyboard action to submit answers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -33,6 +33,8 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -58,6 +60,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -114,7 +117,9 @@ fun AnswerButtons(
                 colors = TextFieldDefaults.colors(
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
-                )
+                ),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { onShowAnswer() }),
             )
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -31,10 +31,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -114,12 +114,17 @@ fun AnswerButtons(
                 shape = MaterialTheme.shapes.extraLargeIncreased,
                 interactionSource = interactionSource,
                 readOnly = isAnswerShown, // when answer shown, don't allow typing
+                singleLine = true,
                 colors = TextFieldDefaults.colors(
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
                 ),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = { onShowAnswer() }),
+                keyboardActions = KeyboardActions(onDone = {
+                    if (!isAnswerShown) {
+                        onShowAnswer()
+                    }
+                }),
             )
         }
 


### PR DESCRIPTION
This PR adds `KeyboardOptions` and `KeyboardActions` to the AnswerButtons type-in answer `TextField`. It maps the "Done" keyboard action to automatically call `onShowAnswer()`, allowing users to submit answers using their software keyboard and improving usability.

---
*PR created automatically by Jules for task [8158515265700295603](https://jules.google.com/task/8158515265700295603) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard input experience: the “type in the answer” field now supports the device keyboard’s **Done** action to quickly show your typed response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->