### PR TITLE
Migrate NoteEditorActivity dialogs to Jetpack Compose

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -53,7 +53,6 @@ import androidx.core.content.edit
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
@@ -61,11 +60,6 @@ import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.common.annotations.NeedsTest
-import com.ichi2.anki.dialogs.DeckSelectionDialog
-import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
-import com.ichi2.anki.dialogs.tags.TagsDialog
-import com.ichi2.anki.dialogs.tags.TagsDialogFactory
-import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
@@ -73,7 +67,6 @@ import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.Utils
 import com.ichi2.anki.libanki.clozeNumbersInNote
-import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.multimedia.AudioRecordingFragment
 import com.ichi2.anki.multimedia.AudioVideoFragment
@@ -111,13 +104,10 @@ import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
-import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.ClipboardUtil
 import com.ichi2.utils.HashUtil
 import com.ichi2.utils.ImportUtils
-import com.ichi2.utils.show
-import com.ichi2.utils.title
 import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
@@ -127,7 +117,7 @@ import timber.log.Timber
 import java.util.function.Consumer
 
 class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, DispatchKeyEventListener,
-    ShortcutGroupProvider, DeckSelectionListener, TagsDialogListener {
+    ShortcutGroupProvider {
 
     override val baseSnackbarBuilder: SnackbarBuilder = { }
 
@@ -142,7 +132,6 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
         get() = noteEditorViewModel.reloadRequired.value
         set(value) = noteEditorViewModel.setReloadRequired(value)
 
-    private var tagsDialogFactory: TagsDialogFactory? = null
 
     private var editorNote: Note? = null
 
@@ -280,7 +269,9 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
         }
     }
 
-    override fun onDeckSelected(deck: SelectableDeck?) {
+
+    @VisibleForTesting
+    fun onDeckSelected(deck: SelectableDeck?) {
         if (deck == null) {
             return
         }
@@ -334,10 +325,6 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
         if (!ensureStoragePermissions()) {
             return
         }
-
-        tagsDialogFactory = TagsDialogFactory(this).attachToFragmentManager<TagsDialogFactory>(
-            supportFragmentManager
-        )
 
         if (savedInstanceState != null) {
             addNote = savedInstanceState.getBoolean("addNote")
@@ -575,6 +562,11 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                 val showDiscardChangesDialog by noteEditorViewModel.showDiscardChangesDialog.collectAsStateWithLifecycle()
                 val noClozeDialogMessage by noteEditorViewModel.noClozeDialogState.collectAsStateWithLifecycle()
                 val toolbarDialogState by noteEditorViewModel.toolbarDialogState.collectAsStateWithLifecycle()
+                val showTagsDialog by noteEditorViewModel.showTagsDialog.collectAsStateWithLifecycle()
+                val showFontSizeDialog by noteEditorViewModel.showFontSizeDialog.collectAsStateWithLifecycle()
+                val showHeadingDialog by noteEditorViewModel.showHeadingDialog.collectAsStateWithLifecycle()
+                val showMathJaxDialog by noteEditorViewModel.showMathJaxDialog.collectAsStateWithLifecycle()
+                val showDeckSelectionDialog by noteEditorViewModel.showDeckSelectionDialog.collectAsStateWithLifecycle()
                 val snackbarHostState = remember { SnackbarHostState() }
                 var capitalizeChecked by remember {
                     mutableStateOf(
@@ -661,17 +653,8 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                     onHorizontalRuleClick = {
                         applyFormatter("<hr>", "")
                     },
-                    onHeadingClick = {
-                        displayInsertHeadingDialog()
-                    },
-                    onFontSizeClick = {
-                        displayFontSizeDialog()
-                    },
                     onMathjaxClick = {
                         applyFormatter("\\(", "\\)")
-                    },
-                    onMathjaxLongClick = {
-                        displayInsertMathJaxEquationsDialog()
                     },
                     onClozeClick = {
                         handleClozeInsertion(ClozeInsertionMode.SAME_NUMBER)
@@ -730,7 +713,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                                 id = "font_size",
                                 title = stringResource(R.string.menu_font_size),
                             ) {
-                                displayFontSizeDialog()
+                                noteEditorViewModel.showFontSizeDialog(true)
                             },
                             NoteEditorToggleOverflowItem(
                                 id = "show_toolbar",
@@ -828,6 +811,19 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
                     onDismissNoClozeDialog = {
                         noteEditorViewModel.dismissNoClozeDialog()
                     },
+                    showTagsDialog = showTagsDialog,
+                    onShowTagsDialogChange = { noteEditorViewModel.showTagsDialog(it) },
+                    showFontSizeDialog = showFontSizeDialog,
+                    onShowFontSizeDialogChange = { noteEditorViewModel.showFontSizeDialog(it) },
+                    showHeadingDialog = showHeadingDialog,
+                    onShowHeadingDialogChange = { noteEditorViewModel.showHeadingDialog(it) },
+                    showMathJaxDialog = showMathJaxDialog,
+                    onShowMathJaxDialogChange = { noteEditorViewModel.showMathJaxDialog(it) },
+                    showDeckSelectionDialog = showDeckSelectionDialog,
+                    onShowDeckSelectionDialogChange = {
+                        noteEditorViewModel.showDeckSelectionDialog(it)
+                    },
+                    onApplyFormatter = { prefix, suffix -> applyFormatter(prefix, suffix) },
                     capitalizeSentences = capitalizeChecked,
                 )
 
@@ -882,48 +878,6 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
         noteEditorViewModel.formatSelection(prefix, suffix)
     }
 
-    private fun displayFontSizeDialog() {
-        val sizeCodes = resources.getStringArray(R.array.html_size_codes)
-        MaterialAlertDialogBuilder(this).show {
-            setItems(R.array.html_size_code_labels) { _, index ->
-                val size = sizeCodes.getOrNull(index) ?: return@setItems
-                applyFormatter("<span style=\"font-size:$size\">", "</span>")
-            }
-            title(R.string.menu_font_size)
-        }
-    }
-
-    private fun displayInsertHeadingDialog() {
-        val headingTags = arrayOf("h1", "h2", "h3", "h4", "h5")
-        MaterialAlertDialogBuilder(this).show {
-            setItems(headingTags) { _, index ->
-                val tag = headingTags.getOrNull(index) ?: return@setItems
-                applyFormatter("<$tag>", "</$tag>")
-            }
-            title(R.string.insert_heading)
-        }
-    }
-
-    private fun displayInsertMathJaxEquationsDialog() {
-        data class MathJaxOption(
-            val label: String,
-            val prefix: String,
-            val suffix: String,
-        )
-
-        val options = arrayOf(
-            MathJaxOption(TR.editingMathjaxBlock(), prefix = "\\[\\", suffix = "\\]"),
-            MathJaxOption(TR.editingMathjaxChemistry(), prefix = "\\( \\ce{", suffix = "} \\)"),
-        )
-
-        MaterialAlertDialogBuilder(this).show {
-            setItems(options.map(MathJaxOption::label).toTypedArray()) { _, index ->
-                val option = options.getOrNull(index) ?: return@setItems
-                applyFormatter(option.prefix, option.suffix)
-            }
-            title(R.string.insert_mathjax)
-        }
-    }
 
     private fun handleClozeInsertion(mode: ClozeInsertionMode) {
         val isClozeType = noteEditorViewModel.noteEditorState.value.isClozeType
@@ -949,7 +903,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
             }
 
             KeyEvent.KEYCODE_D -> if (event.isCtrlPressed) {
-                showDeckSelectionDialog()
+                noteEditorViewModel.showDeckSelectionDialog(true)
                 return true
             }
 
@@ -959,7 +913,7 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
             }
 
             KeyEvent.KEYCODE_T -> if (event.isCtrlPressed && event.isShiftPressed) {
-                showTagsDialog()
+                noteEditorViewModel.showTagsDialog(true)
                 return true
             }
 
@@ -1263,41 +1217,6 @@ class NoteEditorActivity : AnkiActivity(), BaseSnackbarBuilderProvider, Dispatch
         }
     }
 
-    private fun showDeckSelectionDialog() {
-        launchCatchingTask {
-            val selectableDecks = withCol {
-                decks.allNamesAndIds().map { SelectableDeck.Deck(it.id, it.name) }
-            }
-
-            val dialog = DeckSelectionDialog.newInstance(
-                title = getString(R.string.select_deck_title),
-                summaryMessage = null,
-                keepRestoreDefaultButton = false,
-                decks = selectableDecks,
-            )
-            dialog.show(supportFragmentManager, "deck_selection_dialog")
-        }
-    }
-
-    private fun showTagsDialog() {
-        val currentTags = noteEditorViewModel.noteEditorState.value.tags
-        val selTags = ArrayList(currentTags)
-
-        val dialog = tagsDialogFactory!!.newTagsDialog().withArguments(
-            context = this,
-            type = TagsDialog.DialogType.EDIT_TAGS,
-            checkedTags = selTags,
-        )
-        showDialogFragment(dialog)
-    }
-
-    override fun onSelectedTags(
-        selectedTags: List<String>,
-        indeterminateTags: List<String>,
-        stateFilter: CardStateFilter,
-    ) {
-        noteEditorViewModel.updateTags(selectedTags.toSet())
-    }
 
     private fun showCardTemplateEditor() {
         val intent = Intent(this, CardTemplateEditor::class.java)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorViewModel.kt
@@ -235,6 +235,21 @@ class NoteEditorViewModel(
      */
     val toolbarDialogState: StateFlow<ToolbarItemDialogState> = _toolbarDialogState.asStateFlow()
 
+    private val _showTagsDialog = MutableStateFlow(false)
+    val showTagsDialog: StateFlow<Boolean> = _showTagsDialog.asStateFlow()
+
+    private val _showFontSizeDialog = MutableStateFlow(false)
+    val showFontSizeDialog: StateFlow<Boolean> = _showFontSizeDialog.asStateFlow()
+
+    private val _showHeadingDialog = MutableStateFlow(false)
+    val showHeadingDialog: StateFlow<Boolean> = _showHeadingDialog.asStateFlow()
+
+    private val _showMathJaxDialog = MutableStateFlow(false)
+    val showMathJaxDialog: StateFlow<Boolean> = _showMathJaxDialog.asStateFlow()
+
+    private val _showDeckSelectionDialog = MutableStateFlow(false)
+    val showDeckSelectionDialog: StateFlow<Boolean> = _showDeckSelectionDialog.asStateFlow()
+
     private val _currentNote = MutableStateFlow<Note?>(null)
 
     /** The underlying Note being edited (null when creating a new, not yet initialized). */
@@ -1544,6 +1559,26 @@ class NoteEditorViewModel(
      */
     fun dismissToolbarDialog() {
         _toolbarDialogState.value = ToolbarItemDialogState()
+    }
+
+    fun showTagsDialog(show: Boolean) {
+        _showTagsDialog.value = show
+    }
+
+    fun showFontSizeDialog(show: Boolean) {
+        _showFontSizeDialog.value = show
+    }
+
+    fun showHeadingDialog(show: Boolean) {
+        _showHeadingDialog.value = show
+    }
+
+    fun showMathJaxDialog(show: Boolean) {
+        _showMathJaxDialog.value = show
+    }
+
+    fun showDeckSelectionDialog(show: Boolean) {
+        _showDeckSelectionDialog.value = show
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditor.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +35,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddAPhoto
@@ -140,10 +140,7 @@ fun NoteEditorScreen(
     onItalicClick: () -> Unit,
     onUnderlineClick: () -> Unit,
     onHorizontalRuleClick: () -> Unit = {},
-    onHeadingClick: () -> Unit = {},
-    onFontSizeClick: () -> Unit = {},
     onMathjaxClick: () -> Unit = {},
-    onMathjaxLongClick: (() -> Unit)? = null,
     onClozeClick: () -> Unit,
     onClozeIncrementClick: () -> Unit,
     onCustomButtonClick: (ToolbarButtonModel) -> Unit,
@@ -166,20 +163,30 @@ fun NoteEditorScreen(
     noClozeDialogMessage: String?,
     onSaveAnywayClick: () -> Unit,
     onDismissNoClozeDialog: () -> Unit,
+    showTagsDialog: Boolean,
+    onShowTagsDialogChange: (Boolean) -> Unit,
+    showFontSizeDialog: Boolean,
+    onShowFontSizeDialogChange: (Boolean) -> Unit,
+    showHeadingDialog: Boolean,
+    onShowHeadingDialogChange: (Boolean) -> Unit,
+    showMathJaxDialog: Boolean,
+    onShowMathJaxDialogChange: (Boolean) -> Unit,
+    showDeckSelectionDialog: Boolean,
+    onShowDeckSelectionDialogChange: (Boolean) -> Unit,
+    onApplyFormatter: (String, String) -> Unit,
     capitalizeSentences: Boolean = true,
 ) {
     // Observe keyboard state for auto-scrolling
     val imeState = rememberImeState()
     val scrollState = rememberScrollState()
-    var showTagsDialog by remember { mutableStateOf(false) }
     var filterByDeck by remember(deckTags) { mutableStateOf(deckTags.isNotEmpty()) }
 
     if (showTagsDialog) {
         TagsDialog(
-            onDismissRequest = { showTagsDialog = false },
+            onDismissRequest = { onShowTagsDialogChange(false) },
             onConfirm = { checked, _ ->
                 onUpdateTags(checked)
-                showTagsDialog = false
+                onShowTagsDialogChange(false)
             },
             allTags = allTags,
             initialSelection = state.tags.toSet(),
@@ -193,6 +200,24 @@ fun NoteEditorScreen(
             onFilterByDeckChanged = { filterByDeck = it },
         )
     }
+
+    FontSizeDialog(show = showFontSizeDialog, onSizeSelected = { size ->
+        onApplyFormatter("<span style=\"font-size:$size\">", "</span>")
+    }, onDismissRequest = { onShowFontSizeDialogChange(false) })
+
+    InsertHeadingDialog(show = showHeadingDialog, onHeadingSelected = { tag ->
+        onApplyFormatter("<$tag>", "</$tag>")
+    }, onDismissRequest = { onShowHeadingDialogChange(false) })
+
+    InsertMathJaxDialog(show = showMathJaxDialog, onOptionSelected = { prefix, suffix ->
+        onApplyFormatter(prefix, suffix)
+    }, onDismissRequest = { onShowMathJaxDialogChange(false) })
+
+    DeckSelectionDialog(
+        show = showDeckSelectionDialog,
+        decks = availableDecks,
+        onDeckSelected = onDeckSelected,
+        onDismissRequest = { onShowDeckSelectionDialogChange(false) })
 
     if (showDiscardChangesDialog) {
         DiscardChangesDialog(
@@ -239,10 +264,10 @@ fun NoteEditorScreen(
                 onItalicClick = onItalicClick,
                 onUnderlineClick = onUnderlineClick,
                 onHorizontalRuleClick = onHorizontalRuleClick,
-                onHeadingClick = onHeadingClick,
-                onFontSizeClick = onFontSizeClick,
+                onHeadingClick = { onShowHeadingDialogChange(true) },
+                onFontSizeClick = { onShowFontSizeDialogChange(true) },
                 onMathjaxClick = onMathjaxClick,
-                onMathjaxLongClick = onMathjaxLongClick,
+                onMathjaxLongClick = { onShowMathJaxDialogChange(true) },
                 onClozeClick = onClozeClick,
                 onClozeIncrementClick = onClozeIncrementClick,
                 onCustomButtonClick = onCustomButtonClick,
@@ -334,7 +359,7 @@ fun NoteEditorScreen(
             Row(modifier = Modifier.fillMaxWidth()) {
                 // Tags Button
                 Button(
-                    onClick = { showTagsDialog = true },
+                    onClick = { onShowTagsDialogChange(true) },
                     modifier = Modifier
                         .height(52.dp)
                         .weight(1f),
@@ -738,10 +763,7 @@ fun NoteEditorScreenPreview() {
             onItalicClick = {},
             onUnderlineClick = {},
             onHorizontalRuleClick = {},
-            onHeadingClick = {},
-            onFontSizeClick = {},
             onMathjaxClick = {},
-            onMathjaxLongClick = {},
             onClozeClick = {},
             onClozeIncrementClick = {},
             onCustomButtonClick = {},
@@ -760,6 +782,17 @@ fun NoteEditorScreenPreview() {
             noClozeDialogMessage = null,
             onSaveAnywayClick = {},
             onDismissNoClozeDialog = {},
+            showTagsDialog = false,
+            onShowTagsDialogChange = {},
+            showFontSizeDialog = false,
+            onShowFontSizeDialogChange = {},
+            showHeadingDialog = false,
+            onShowHeadingDialogChange = {},
+            showMathJaxDialog = false,
+            onShowMathJaxDialogChange = {},
+            showDeckSelectionDialog = false,
+            onShowDeckSelectionDialogChange = {},
+            onApplyFormatter = { _, _ -> },
             capitalizeSentences = true,
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditorDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditorDialogs.kt
@@ -34,7 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -240,9 +240,8 @@ fun FontSizeDialog(
 ) {
     if (!show) return
 
-    val context = LocalContext.current
-    val sizeLabels = remember { context.resources.getStringArray(R.array.html_size_code_labels) }
-    val sizeCodes = remember { context.resources.getStringArray(R.array.html_size_codes) }
+    val sizeLabels = stringArrayResource(R.array.html_size_code_labels)
+    val sizeCodes = stringArrayResource(R.array.html_size_codes)
 
     AlertDialog(
         onDismissRequest = onDismissRequest,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditorDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/compose/NoteEditorDialogs.kt
@@ -19,6 +19,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -31,9 +34,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 
@@ -224,4 +230,202 @@ private fun EditToolbarItemDialogPreview() {
             onHelpClick = {},
         )
     }
+}
+
+@Composable
+fun FontSizeDialog(
+    show: Boolean,
+    onSizeSelected: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (!show) return
+
+    val context = LocalContext.current
+    val sizeLabels = remember { context.resources.getStringArray(R.array.html_size_code_labels) }
+    val sizeCodes = remember { context.resources.getStringArray(R.array.html_size_codes) }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.menu_font_size)) },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
+            ) {
+                items(sizeLabels.zip(sizeCodes)) { (label, code) ->
+                    TextButton(
+                        onClick = {
+                            onSizeSelected(code)
+                            onDismissRequest()
+                        }, modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = label,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Start
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
+}
+
+@Composable
+fun InsertHeadingDialog(
+    show: Boolean,
+    onHeadingSelected: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (!show) return
+
+    val headingTags = remember { arrayOf("h1", "h2", "h3", "h4", "h5") }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.insert_heading)) },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
+            ) {
+                items(headingTags) { tag ->
+                    TextButton(
+                        onClick = {
+                            onHeadingSelected(tag)
+                            onDismissRequest()
+                        }, modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = tag,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Start
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
+}
+
+data class MathJaxOption(
+    val label: String,
+    val prefix: String,
+    val suffix: String,
+)
+
+@Composable
+fun InsertMathJaxDialog(
+    show: Boolean,
+    onOptionSelected: (String, String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (!show) return
+
+    val options = remember {
+        listOf(
+            MathJaxOption(TR.editingMathjaxBlock(), prefix = "\\[\\", suffix = "\\]"),
+            MathJaxOption(TR.editingMathjaxChemistry(), prefix = "\\( \\ce{", suffix = "} \\)"),
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.insert_mathjax)) },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 200.dp)
+            ) {
+                items(options) { option ->
+                    TextButton(
+                        onClick = {
+                            onOptionSelected(option.prefix, option.suffix)
+                            onDismissRequest()
+                        }, modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = option.label,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Start
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
+}
+
+@Composable
+fun DeckSelectionDialog(
+    show: Boolean,
+    decks: List<String>,
+    onDeckSelected: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (!show) return
+
+    var searchQueryParams by remember { mutableStateOf("") }
+    val filteredDecks = remember(decks, searchQueryParams) {
+        if (searchQueryParams.isBlank()) {
+            decks
+        } else {
+            decks.filter { it.contains(searchQueryParams, ignoreCase = true) }
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.select_deck_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = searchQueryParams,
+                    onValueChange = { searchQueryParams = it },
+                    placeholder = { Text(stringResource(R.string.search_deck)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp)
+                ) {
+                    items(filteredDecks) { deckName ->
+                        TextButton(
+                            onClick = {
+                                onDeckSelected(deckName)
+                                onDismissRequest()
+                            }, modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = deckName,
+                                modifier = Modifier.fillMaxWidth(),
+                                textAlign = TextAlign.Start
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
 }

--- a/COMPOSE_MIGRATION.md
+++ b/COMPOSE_MIGRATION.md
@@ -351,7 +351,7 @@ Status by screen:
   - `DeckPickerAnalyticsOptInDialog` -> `AnalyticsOptInDialog`
   - `DeckPickerConfirmDeleteDeckDialog` -> `ConfirmDeleteDeckDialog`
 - **CardBrowser**: Pending dialog migration.
-- **NoteEditor**: Pending dialog migration.
+- **NoteEditor [COMPLETED]**: Migrated all remaining dialogs (Font Size, Insert Heading, Insert MathJax, and Deck Selection) to Jetpack Compose dialogs with state management in `NoteEditorViewModel`.
 
 ### Phase 5: Expand Nav3 From DeckPicker To App-Level Navigation
 


### PR DESCRIPTION
This pull request refactors the way dialogs are managed and invoked in the note editor, moving from imperative dialog calls in the `Activity` to a more declarative, state-driven approach via the `ViewModel` and Compose UI. Dialog visibility is now controlled by state flows, and dialog invocations are handled through Compose, improving testability and separation of concerns.

**Refactoring dialog management to ViewModel-driven state:**

* Introduced `MutableStateFlow` properties in `NoteEditorViewModel` to control the visibility of the tags, font size, heading, MathJax, and deck selection dialogs, along with corresponding setter functions. (`NoteEditorViewModel.kt`) [[1]](diffhunk://#diff-5ed8181369a0d1bcb7e8c9737ec22b1b284cc07841acc7d4a667dc917c8f05f8R238-R252) [[2]](diffhunk://#diff-5ed8181369a0d1bcb7e8c9737ec22b1b284cc07841acc7d4a667dc917c8f05f8R1564-R1583)
* Removed direct dialog creation and imperative show methods from `NoteEditorActivity`, including all logic for showing tags, font size, heading, MathJax, and deck selection dialogs. (`NoteEditorActivity.kt`) [[1]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL885-L926) [[2]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL1266-L1300)
* Updated Compose UI (`NoteEditorScreen`) to observe new dialog state flows and render dialogs declaratively. Dialogs are now shown/hidden based on state, and actions are propagated through callbacks. (`NoteEditor.kt`) [[1]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR166-R189) [[2]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fR204-R221) [[3]](diffhunk://#diff-e9787a48b2e1ceb6b58a6bb00be8be0b0125d145992bc1e0844e06655070462fL242-R270)

**Simplification and cleanup of activity interfaces:**

* Removed now-unnecessary dialog-related interfaces and dependencies from `NoteEditorActivity` (such as `DeckSelectionListener`, `TagsDialogListener`, and `TagsDialogFactory`). (`NoteEditorActivity.kt`) [[1]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL130-R120) [[2]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL145) [[3]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL338-L341)
* Changed dialog-related keyboard shortcuts and menu actions to update dialog state in the ViewModel, rather than directly invoking dialog display methods. (`NoteEditorActivity.kt`) [[1]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL952-R906) [[2]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL962-R916) [[3]](diffhunk://#diff-0d12d03c033196d4c6719bf937619a878ec796fdf8da4f8fbce6a3882c78d00eL733-R716)

**Improvements to Compose UI integration:**

* Added new dialog composables (`FontSizeDialog`, `InsertHeadingDialog`, `InsertMathJaxDialog`, `DeckSelectionDialog`) and connected them to state and callbacks in `NoteEditorScreen`. (`NoteEditor.kt`)
* Updated toolbar and overflow menu actions to trigger dialog state changes via callbacks, ensuring all dialog interactions are routed through Compose and the ViewModel. (`NoteEditor.kt`)

These changes make dialog presentation more modular, testable, and consistent with modern Compose and MVVM best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated note editor dialogs from legacy Android implementation to modern Compose framework, improving consistency and maintainability across the editor interface while preserving all existing functionality for font sizing, heading insertion, MathJax equations, deck selection, and tag management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->