### PR TITLE
Migrate CardBrowser dialogs to Jetpack Compose and refactor UI components

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -46,12 +46,8 @@ import com.ichi2.anki.browser.compose.CardBrowserLayout
 import com.ichi2.anki.browser.compose.FilterByTagsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
-import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.compose.FlagRenameDialog
-import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.libanki.Collection
-import com.ichi2.anki.model.CardStateFilter
-import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
@@ -65,8 +61,7 @@ import timber.log.Timber
  * Composable, which is responsible for rendering the UI. It retains the [CardBrowserViewModel]
  * for state management and business logic.
  */
-open class CardBrowser : AnkiActivity(), ChangeManager.Subscriber,
-    DeckSelectionDialog.DeckSelectionListener, TagsDialogListener, SnackbarForwarder {
+open class CardBrowser : AnkiActivity(), ChangeManager.Subscriber, SnackbarForwarder {
 
     val fragmented: Boolean
         get() = resources.configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK == Configuration.SCREENLAYOUT_SIZE_XLARGE
@@ -340,17 +335,6 @@ open class CardBrowser : AnkiActivity(), ChangeManager.Subscriber,
 
     companion object {
         fun clearLastDeckId() = SharedPreferencesLastDeckIdRepository.clearLastDeckId()
-    }
-
-    override fun onSelectedTags(
-        selectedTags: List<String>, indeterminateTags: List<String>, stateFilter: CardStateFilter
-    ) {
-        actionHandler.onSelectedTags(selectedTags, indeterminateTags, stateFilter)
-    }
-
-
-    override fun onDeckSelected(deck: SelectableDeck?) {
-        actionHandler.onDeckSelected(deck)
     }
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -204,8 +204,7 @@ import com.ichi2.utils.dp as viewDp
 open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogListener,
     OnRequestPermissionsResultCallback, ChangeManager.Subscriber, ImportColpkgListener,
     ApkgImportResultLauncherProvider, CsvImportResultLauncherProvider,
-    CollectionPermissionScreenLauncher, DeckSelectionDialog.DeckSelectionListener,
-    TagsDialogListener {
+    CollectionPermissionScreenLauncher {
     val viewModel: DeckPickerViewModel by viewModels()
 
     var fragmented: Boolean
@@ -554,8 +553,12 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
                 is DeckPickerEffect.CheckDatabase -> {
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_CONFIRM_DATABASE_CHECK)
                 }
+
                 is DeckPickerEffect.ShowEmptyCardsDialog -> {
-                    EmptyCardsDialogFragment().show(supportFragmentManager, EmptyCardsDialogFragment.TAG)
+                    EmptyCardsDialogFragment().show(
+                        supportFragmentManager,
+                        EmptyCardsDialogFragment.TAG
+                    )
                 }
             }
         }
@@ -1420,7 +1423,6 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
     }
 
 
-
     @SuppressLint("UseKtx") // keep SharedPreferences.edit() instead of edit {} fot tests
     fun getPreviousVersion(
         preferences: SharedPreferences,
@@ -1729,18 +1731,6 @@ open class DeckPicker : AnkiActivity(), SyncErrorDialogListener, ImportDialogLis
     }
 
     // CardBrowser Helpers
-
-    override fun onSelectedTags(
-        selectedTags: List<String>,
-        indeterminateTags: List<String>,
-        stateFilter: CardStateFilter,
-    ) {
-        actionHandler.onSelectedTags(selectedTags, indeterminateTags, stateFilter)
-    }
-
-    override fun onDeckSelected(deck: SelectableDeck?) {
-        actionHandler.onDeckSelected(deck)
-    }
 
     override val shortcuts
         get() = ShortcutGroup(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
@@ -20,21 +20,14 @@ import android.content.Intent
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
-import com.ichi2.anki.dialogs.DeckSelectionDialog
-import com.ichi2.anki.dialogs.GradeNowDialog
 import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.CardId
-import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
-import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.previewer.PreviewerFragment
-import com.ichi2.anki.scheduling.ForgetCardsDialog
-import com.ichi2.anki.scheduling.SetDueDateDialog
-import com.ichi2.anki.undoAndShowSnackbar
 import timber.log.Timber
 
 /**
@@ -71,26 +64,6 @@ class CardBrowserActionHandler(
         viewModel.updateTags(selectedTags)
     }
 
-    fun onDeckSelected(deck: SelectableDeck?) {
-        val did = (deck as? SelectableDeck.Deck)?.deckId ?: return
-        moveSelectedCardsToDeck(did)
-    }
-
-    private fun moveSelectedCardsToDeck(did: DeckId) = activity.launchCatchingTask {
-        val changed = withProgress { viewModel.moveSelectedCardsToDeck(did).await() }
-        viewModel.launchSearchForCards()
-        val message = activity.resources.getQuantityString(
-            R.plurals.card_browser_cards_moved, changed.count, changed.count
-        )
-        viewModel.emitSnackbarMessage(
-            message, activity.getString(R.string.undo)
-        ) {
-            activity.launchCatchingTask {
-                activity.undoAndShowSnackbar()
-                viewModel.launchSearchForCards()
-            }
-        }
-    }
 
     fun openNoteEditorForCard(cardId: CardId) {
         viewModel.currentCardId = cardId
@@ -98,24 +71,15 @@ class CardBrowserActionHandler(
         launchEditCard(launcher.toIntent(activity))
     }
 
-    fun showChangeDeckDialog() = activity.launchCatchingTask {
-        if (!ensureSelection("Change Deck")) return@launchCatchingTask
-        val selectableDecks = viewModel.getAvailableDecks()
-        val dialog = DeckSelectionDialog.newInstance(
-            activity.getString(R.string.move_all_to_deck), null, false, selectableDecks
-        )
-        dialog.show(activity.supportFragmentManager, "deck_selection_dialog")
+    fun showChangeDeckDialog() {
+        if (!ensureSelection("Change Deck")) return
+        viewModel.showDeckSelectionDialog(true)
     }
 
     fun rescheduleSelectedCards() {
         if (!ensureSelection("reschedule")) return
         if (warnUserIfInNotesOnlyMode()) return
-
-        activity.launchCatchingTask {
-            val allCardIds = viewModel.queryAllSelectedCardIds()
-            SetDueDateDialog.newInstance(allCardIds)
-                .show(activity.supportFragmentManager, "set_due_date_dialog")
-        }
+        viewModel.showSetDueDateDialog(true)
     }
 
     fun repositionSelectedCards() {
@@ -147,13 +111,14 @@ class CardBrowserActionHandler(
                         )
                         return@launchCatchingTask
                     }
-                    val repositionDialog = RepositionCardFragment.newInstance(
-                        queueTop = top,
-                        queueBottom = bottom,
-                        random = repositionCardsResult.random,
-                        shift = repositionCardsResult.shift
+                    viewModel.showRepositionDialog(
+                        CardBrowserViewModel.RepositionDialogState.Visible(
+                            queueTop = top,
+                            queueBottom = bottom,
+                            random = repositionCardsResult.random,
+                            shift = repositionCardsResult.shift
+                        )
                     )
-                    repositionDialog.show(activity.supportFragmentManager, "reposition_dialog")
                 }
             }
         }
@@ -162,16 +127,13 @@ class CardBrowserActionHandler(
     fun onResetProgress() {
         if (!ensureSelection("reset progress")) return
         if (warnUserIfInNotesOnlyMode()) return
-        ForgetCardsDialog().show(activity.supportFragmentManager, "reset_progress_dialog")
+        viewModel.showForgetCardsDialog(true)
     }
 
     fun onGradeNow() {
         if (!ensureSelection("grade now")) return
         if (warnUserIfInNotesOnlyMode()) return
-        activity.launchCatchingTask {
-            val cids = viewModel.queryAllSelectedCardIds()
-            GradeNowDialog.showDialog(activity, cids)
-        }
+        viewModel.showGradeNowDialog(true)
     }
 
     fun exportSelected() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserActionHandler.kt
@@ -24,7 +24,6 @@ import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.CardId
-import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.previewer.PreviewerFragment
@@ -41,30 +40,6 @@ class CardBrowserActionHandler(
     private val launchAddNote: (Intent) -> Unit,
     private val launchPreview: (Intent) -> Unit
 ) {
-
-    private suspend fun <T> withProgress(block: suspend () -> T): T {
-        try {
-            activity.showProgressBar()
-            return block()
-        } finally {
-            activity.hideProgressBar()
-        }
-    }
-
-    fun onSelectedTags(
-        selectedTags: List<String>,
-        @Suppress("UNUSED_PARAMETER") indeterminateTags: List<String>,
-        @Suppress("UNUSED_PARAMETER") stateFilter: CardStateFilter
-    ) {
-        // _indeterminateTags and _stateFilter are used in the TagSelectionDialog to update UI state,
-        // but they are not needed here in the action handler because viewModel.updateTags()
-        // only requires the list of selected tags to perform the bulk update on the backend.
-        // We suppress the UNUSED_PARAMETER warning instead of removing them to maintain consistency
-        // with the TagsDialogListener interface, which this method signature mirrors.
-        viewModel.updateTags(selectedTags)
-    }
-
-
     fun openNoteEditorForCard(cardId: CardId) {
         viewModel.currentCardId = cardId
         val launcher = NoteEditorLauncher.EditCard(cardId, Direction.DEFAULT, false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
 import anki.config.ConfigKey
+import anki.scheduler.CardAnswer.Rating
 import anki.search.BrowserColumns
 import anki.search.BrowserRow
 import com.ichi2.anki.AnkiDroidApp
@@ -280,6 +281,137 @@ class CardBrowserViewModel(
         _createDeckDialogState.value = CreateDeckDialogState.Hidden
     }
 
+    // New Compose dialog states
+    private val _showDeckSelectionDialog = MutableStateFlow(false)
+    val showDeckSelectionDialog = _showDeckSelectionDialog.asStateFlow()
+
+    private val _showSetDueDateDialog = MutableStateFlow(false)
+    val showSetDueDateDialog = _showSetDueDateDialog.asStateFlow()
+
+    private val _showForgetCardsDialog = MutableStateFlow(false)
+    val showForgetCardsDialog = _showForgetCardsDialog.asStateFlow()
+
+    private val _showGradeNowDialog = MutableStateFlow(false)
+    val showGradeNowDialog = _showGradeNowDialog.asStateFlow()
+
+    private val _showExportDialog = MutableStateFlow(false)
+    val showExportDialog = _showExportDialog.asStateFlow()
+
+    sealed interface RepositionDialogState {
+        data object Hidden : RepositionDialogState
+        data class Visible(
+            val queueTop: Int,
+            val queueBottom: Int,
+            val random: Boolean,
+            val shift: Boolean,
+        ) : RepositionDialogState
+    }
+
+    private val _repositionDialogState =
+        MutableStateFlow<RepositionDialogState>(RepositionDialogState.Hidden)
+    val repositionDialogState = _repositionDialogState.asStateFlow()
+
+    fun showDeckSelectionDialog(show: Boolean) {
+        _showDeckSelectionDialog.value = show
+    }
+
+    fun showSetDueDateDialog(show: Boolean) {
+        _showSetDueDateDialog.value = show
+    }
+
+    fun showForgetCardsDialog(show: Boolean) {
+        _showForgetCardsDialog.value = show
+    }
+
+    fun showGradeNowDialog(show: Boolean) {
+        _showGradeNowDialog.value = show
+    }
+
+    fun showExportDialog(show: Boolean) {
+        _showExportDialog.value = show
+    }
+
+    fun showRepositionDialog(state: RepositionDialogState) {
+        _repositionDialogState.value = state
+    }
+
+    // Compose database operations
+    fun forgetSelectedCards(restorePosition: Boolean, resetCounts: Boolean) {
+        viewModelScope.launch {
+            val cardsIds = queryAllSelectedCardIds()
+            Timber.i(
+                "forgetting %d cards, restorePosition = %b, resetCounts = %b",
+                cardsIds.size,
+                restorePosition,
+                resetCounts
+            )
+            try {
+                undoableOp {
+                    sched.forgetCards(
+                        cardsIds,
+                        restorePosition = restorePosition,
+                        resetCounts = resetCounts
+                    )
+                }
+                Timber.d("forgot %d cards", cardsIds.size)
+                val resources = AnkiDroidApp.instance.resources
+                emitSnackbarMessage(
+                    resources.getQuantityString(
+                        R.plurals.reset_cards_dialog_acknowledge, cardsIds.size, cardsIds.size
+                    )
+                )
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to forget cards")
+                emitSnackbarMessage(AnkiDroidApp.instance.getString(R.string.something_wrong))
+            }
+        }
+    }
+
+    fun gradeSelectedCards(rating: Rating) {
+        viewModelScope.launch {
+            val ids = queryAllSelectedCardIds()
+            if (!ids.any()) {
+                Timber.w("no selected cards to grade")
+                return@launch
+            }
+            Timber.d("Grading %d cards as %s", ids.size, rating.name)
+            try {
+                undoableOp { backend.gradeNow(ids, rating) }
+                val resources = AnkiDroidApp.instance.resources
+                emitSnackbarMessage(
+                    TR.schedulingGradedCardsDone(ids.size), resources.getString(R.string.undo)
+                ) {
+                    viewModelScope.launch {
+                        undo()
+                        launchSearchForCards()
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to grade cards")
+                emitSnackbarMessage(AnkiDroidApp.instance.getString(R.string.something_wrong))
+            }
+        }
+    }
+
+    fun repositionSelectedCards(
+        position: Int,
+        step: Int,
+        shuffle: Boolean,
+        shift: Boolean,
+    ) {
+        viewModelScope.launch {
+            try {
+                val count = repositionSelectedRows(
+                    position = position, step = step, shuffle = shuffle, shift = shift
+                )
+                emitSnackbarMessage(TR.browsingChangedNewPosition(count))
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to reposition cards")
+                emitSnackbarMessage(AnkiDroidApp.instance.getString(R.string.something_wrong))
+            }
+        }
+    }
+
     suspend fun validateDeckName(
         name: String, dialogState: CreateDeckDialogState.Visible
     ): DeckPickerViewModel.DeckNameError? {
@@ -456,9 +588,7 @@ class CardBrowserViewModel(
     val flowOfSnackbarString = MutableSharedFlow<SnackbarMessageEvent>()
 
     fun emitSnackbarMessage(
-        message: String,
-        actionLabel: String? = null,
-        action: (() -> Unit)? = null
+        message: String, actionLabel: String? = null, action: (() -> Unit)? = null
     ) {
         viewModelScope.launch {
             flowOfSnackbarString.emit(SnackbarMessageEvent(message, actionLabel, action))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -294,8 +294,6 @@ class CardBrowserViewModel(
     private val _showGradeNowDialog = MutableStateFlow(false)
     val showGradeNowDialog = _showGradeNowDialog.asStateFlow()
 
-    private val _showExportDialog = MutableStateFlow(false)
-    val showExportDialog = _showExportDialog.asStateFlow()
 
     sealed interface RepositionDialogState {
         data object Hidden : RepositionDialogState
@@ -327,9 +325,6 @@ class CardBrowserViewModel(
         _showGradeNowDialog.value = show
     }
 
-    fun showExportDialog(show: Boolean) {
-        _showExportDialog.value = show
-    }
 
     fun showRepositionDialog(state: RepositionDialogState) {
         _repositionDialogState.value = state

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -306,15 +306,15 @@ fun SetDueDateDialog(
                 Tab(selected = selectedTabIndex == 0, onClick = { selectedTabIndex = 0 }, icon = {
                     Icon(
                         painter = painterResource(R.drawable.calendar_single_day),
-                        contentDescription = "Single Day"
+                        contentDescription = stringResource(R.string.single_day)
                     )
-                }, text = { Text("Single Day") })
+                }, text = { Text(stringResource(R.string.single_day)) })
                 Tab(selected = selectedTabIndex == 1, onClick = { selectedTabIndex = 1 }, icon = {
                     Icon(
                         painter = painterResource(R.drawable.calendar_date_range),
-                        contentDescription = "Date Range"
+                        contentDescription = stringResource(R.string.date_range)
                     )
-                }, text = { Text("Date Range") })
+                }, text = { Text(stringResource(R.string.date_range)) })
             }
 
             if (selectedTabIndex == 0) {
@@ -594,7 +594,7 @@ fun RepositionCardDialog(
                     text = if (isInspection) {
                         "Queue top: $queueTop\nQueue bottom: $queueBottom"
                     } else {
-                        "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueTop(queueBottom)}"
+                        "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueBottom(queueBottom)}"
                     },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -689,10 +689,7 @@ private fun CardBrowserDeckSelectionDialogPreview() {
 }
 
 @Preview(
-    name = "Set Due Date Dialog - Single Day",
-    widthDp = 400,
-    heightDp = 450,
-    showBackground = true
+    name = "Set Due Date Dialog - Single Day", widthDp = 400, heightDp = 450, showBackground = true
 )
 @Composable
 private fun SetDueDateDialogSingleDayPreview() {
@@ -713,10 +710,7 @@ private fun SetDueDateDialogSingleDayPreview() {
 }
 
 @Preview(
-    name = "Set Due Date Dialog - Date Range",
-    widthDp = 400,
-    heightDp = 450,
-    showBackground = true
+    name = "Set Due Date Dialog - Date Range", widthDp = 400, heightDp = 450, showBackground = true
 )
 @Composable
 private fun SetDueDateDialogDateRangePreview() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -963,7 +963,7 @@ private fun SetDueDateDialogDateRangePreview() {
     }
 }
 
-@Preview(name = "Forget Cards Dialog", widthDp = 400, heightDp = 250, showBackground = true)
+@Preview(name = "Forget Cards Dialog", widthDp = 400, heightDp = 400, showBackground = true)
 @Composable
 private fun ForgetCardsDialogPreview() {
     AnkiDroidTheme {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -109,9 +109,10 @@ fun CardBrowserDeckSelectionDialog(
     var searchQuery by remember { mutableStateOf("") }
     val expandedDecks = remember { mutableStateMapOf<String, Boolean>() }
 
-    val deckHierarchy = remember(availableDecks, searchQuery) {
-        buildDeckHierarchyForDialog(availableDecks, searchQuery)
-    }
+    val deckHierarchy =
+        remember(availableDecks, searchQuery) {
+            buildDeckHierarchyForDialog(availableDecks, searchQuery)
+        }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -151,12 +152,13 @@ fun CardBrowserDeckSelectionDialog(
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     shape = MaterialTheme.shapes.medium,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = Color.Transparent,
-                    ),
+                    colors =
+                        OutlinedTextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = Color.Transparent,
+                        ),
                     trailingIcon = {
                         if (searchQuery.isNotEmpty()) {
                             IconButton(onClick = { searchQuery = "" }) {
@@ -167,22 +169,25 @@ fun CardBrowserDeckSelectionDialog(
                 )
 
                 val rootChildren = deckHierarchy[""] ?: emptyList()
-                val flatDeckList = remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
-                    buildFlatDeckList(
-                        deckHierarchy = deckHierarchy,
-                        children = rootChildren,
-                        expandedDecks = expandedDecks,
-                        searchQuery = searchQuery,
-                    )
-                }
-                val hasAnySubDecks = remember(flatDeckList) {
-                    flatDeckList.any { it.depth > 0 || it.hasChildren }
-                }
+                val flatDeckList =
+                    remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
+                        buildFlatDeckList(
+                            deckHierarchy = deckHierarchy,
+                            children = rootChildren,
+                            expandedDecks = expandedDecks,
+                            searchQuery = searchQuery,
+                        )
+                    }
+                val hasAnySubDecks =
+                    remember(flatDeckList) {
+                        flatDeckList.any { it.depth > 0 || it.hasChildren }
+                    }
 
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 300.dp),
                 ) {
                     items(
                         items = flatDeckList,
@@ -205,7 +210,8 @@ fun CardBrowserDeckSelectionDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        })
+        },
+    )
 }
 
 private data class FlatDeckItem(
@@ -262,15 +268,15 @@ private fun DeckRow(
 ) {
     val deck = flatItem.deck
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = 48.dp)
-            .clip(MaterialTheme.shapes.medium)
-            .combinedClickable(
-                onClick = { onDeckSelected(deck) },
-                onLongClick = { onCreateSubDeck(deck.deckId) },
-            )
-            .padding(vertical = 8.dp, horizontal = 16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .clip(MaterialTheme.shapes.medium)
+                .combinedClickable(
+                    onClick = { onDeckSelected(deck) },
+                    onLongClick = { onCreateSubDeck(deck.deckId) },
+                ).padding(vertical = 8.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
@@ -285,16 +291,18 @@ private fun DeckRow(
             if (flatItem.hasChildren) {
                 IconButton(onClick = { onToggleExpand(deck.name) }) {
                     Icon(
-                        painter = painterResource(
-                            if (flatItem.isExpanded) {
-                                R.drawable.keyboard_arrow_down_24px
-                            } else {
-                                R.drawable.keyboard_arrow_right_24px
-                            },
-                        ),
-                        contentDescription = stringResource(
-                            if (flatItem.isExpanded) R.string.collapse else R.string.expand,
-                        ),
+                        painter =
+                            painterResource(
+                                if (flatItem.isExpanded) {
+                                    R.drawable.keyboard_arrow_down_24px
+                                } else {
+                                    R.drawable.keyboard_arrow_right_24px
+                                },
+                            ),
+                        contentDescription =
+                            stringResource(
+                                if (flatItem.isExpanded) R.string.collapse else R.string.expand,
+                            ),
                     )
                 }
             } else if (flatItem.depth > 0) {
@@ -311,23 +319,24 @@ private fun buildDeckHierarchyForDialog(
     val hierarchy = mutableMapOf<String, MutableList<SelectableDeck.Deck>>()
     val topLevelDecks = mutableListOf<SelectableDeck.Deck>()
 
-    val decksToShow = if (searchQuery.isEmpty()) {
-        decks
-    } else {
-        val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
-        val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
-        val allDecksByName = decks.associateBy { it.name }
+    val decksToShow =
+        if (searchQuery.isEmpty()) {
+            decks
+        } else {
+            val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
+            val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
+            val allDecksByName = decks.associateBy { it.name }
 
-        for (deck in matchingDecks) {
-            requiredDecks.add(deck)
-            var currentName = deck.name
-            while (currentName.contains("::")) {
-                currentName = currentName.substringBeforeLast("::")
-                allDecksByName[currentName]?.let { requiredDecks.add(it) }
+            for (deck in matchingDecks) {
+                requiredDecks.add(deck)
+                var currentName = deck.name
+                while (currentName.contains("::")) {
+                    currentName = currentName.substringBeforeLast("::")
+                    allDecksByName[currentName]?.let { requiredDecks.add(it) }
+                }
             }
+            requiredDecks.toList()
         }
-        requiredDecks.toList()
-    }
 
     for (deck in decksToShow) {
         val parts = deck.name.split("::")
@@ -360,11 +369,12 @@ fun SetDueDateDialog(
     var updateInterval by remember { mutableStateOf(viewModel.updateIntervalToMatchDueDate) }
 
     LaunchedEffect(selectedTabIndex) {
-        viewModel.currentTab = if (selectedTabIndex == 0) {
-            SetDueDateViewModel.Tab.SINGLE_DAY
-        } else {
-            SetDueDateViewModel.Tab.DATE_RANGE
-        }
+        viewModel.currentTab =
+            if (selectedTabIndex == 0) {
+                SetDueDateViewModel.Tab.SINGLE_DAY
+            } else {
+                SetDueDateViewModel.Tab.DATE_RANGE
+            }
     }
 
     AlertDialog(
@@ -457,21 +467,23 @@ fun SetDueDateDialog(
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         shape = MaterialTheme.shapes.medium,
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                            focusedBorderColor = MaterialTheme.colorScheme.primary,
-                            unfocusedBorderColor = Color.Transparent,
-                        ),
+                        colors =
+                            OutlinedTextFieldDefaults.colors(
+                                focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = Color.Transparent,
+                            ),
                     )
                 } else {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(
-                            text = pluralStringResource(
-                                R.plurals.set_due_date_range_label,
-                                viewModel.cardCount,
-                                viewModel.cardCount,
-                            ),
+                            text =
+                                pluralStringResource(
+                                    R.plurals.set_due_date_range_label,
+                                    viewModel.cardCount,
+                                    viewModel.cardCount,
+                                ),
                             style = MaterialTheme.typography.bodyMedium,
                         )
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -496,12 +508,13 @@ fun SetDueDateDialog(
                                 modifier = Modifier.weight(1f),
                                 singleLine = true,
                                 shape = MaterialTheme.shapes.medium,
-                                colors = OutlinedTextFieldDefaults.colors(
-                                    focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                                    unfocusedBorderColor = Color.Transparent,
-                                ),
+                                colors =
+                                    OutlinedTextFieldDefaults.colors(
+                                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                        unfocusedBorderColor = Color.Transparent,
+                                    ),
                             )
                             OutlinedTextField(
                                 value = endText,
@@ -524,12 +537,13 @@ fun SetDueDateDialog(
                                 modifier = Modifier.weight(1f),
                                 singleLine = true,
                                 shape = MaterialTheme.shapes.medium,
-                                colors = OutlinedTextFieldDefaults.colors(
-                                    focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                                    unfocusedBorderColor = Color.Transparent,
-                                ),
+                                colors =
+                                    OutlinedTextFieldDefaults.colors(
+                                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                        unfocusedBorderColor = Color.Transparent,
+                                    ),
                             )
                         }
                     }
@@ -537,18 +551,18 @@ fun SetDueDateDialog(
 
                 if (viewModel.canSetUpdateIntervalToMatchDueDate) {
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(MaterialTheme.shapes.medium)
-                            .toggleable(
-                                value = updateInterval,
-                                role = Role.Checkbox,
-                                onValueChange = {
-                                    updateInterval = it
-                                    viewModel.updateIntervalToMatchDueDate = it
-                                },
-                            )
-                            .padding(vertical = 8.dp, horizontal = 8.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(MaterialTheme.shapes.medium)
+                                .toggleable(
+                                    value = updateInterval,
+                                    role = Role.Checkbox,
+                                    onValueChange = {
+                                        updateInterval = it
+                                        viewModel.updateIntervalToMatchDueDate = it
+                                    },
+                                ).padding(vertical = 8.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Checkbox(
@@ -562,11 +576,12 @@ fun SetDueDateDialog(
 
                 currentInterval?.let { interval ->
                     Text(
-                        text = pluralStringResource(
-                            R.plurals.set_due_date_current_interval,
-                            interval,
-                            interval,
-                        ),
+                        text =
+                            pluralStringResource(
+                                R.plurals.set_due_date_current_interval,
+                                interval,
+                                interval,
+                            ),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -587,7 +602,8 @@ fun SetDueDateDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        })
+        },
+    )
 }
 
 @Composable
@@ -625,15 +641,15 @@ fun ForgetCardsDialog(
             val isInspection = LocalInspectionMode.current
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(MaterialTheme.shapes.medium)
-                        .toggleable(
-                            value = restorePosition,
-                            role = Role.Checkbox,
-                            onValueChange = { restorePosition = it },
-                        )
-                        .padding(vertical = 8.dp, horizontal = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.medium)
+                            .toggleable(
+                                value = restorePosition,
+                                role = Role.Checkbox,
+                                onValueChange = { restorePosition = it },
+                            ).padding(vertical = 8.dp, horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
@@ -645,15 +661,15 @@ fun ForgetCardsDialog(
                 }
 
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(MaterialTheme.shapes.medium)
-                        .toggleable(
-                            value = resetCounts,
-                            role = Role.Checkbox,
-                            onValueChange = { resetCounts = it },
-                        )
-                        .padding(vertical = 8.dp, horizontal = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.medium)
+                            .toggleable(
+                                value = resetCounts,
+                                role = Role.Checkbox,
+                                onValueChange = { resetCounts = it },
+                            ).padding(vertical = 8.dp, horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
@@ -677,7 +693,8 @@ fun ForgetCardsDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        })
+        },
+    )
 }
 
 private data class GradeOption(
@@ -700,44 +717,54 @@ fun GradeNowDialog(
     onDismissRequest: () -> Unit,
 ) {
     val isInspection = LocalInspectionMode.current
-    val options = remember(isInspection) {
-        if (isInspection) {
-            listOf(
-                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
-                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
-                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
-                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy"),
-            )
-        } else {
-            listOf(
-                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
-                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
-                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
-                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
+    val options =
+        remember(isInspection) {
+            if (isInspection) {
+                listOf(
+                    GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
+                    GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
+                    GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
+                    GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy"),
+                )
+            } else {
+                listOf(
+                    GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+                    GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+                    GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+                    GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
+                )
+            }
+        }
+
+    val ratingVisuals =
+        remember {
+            mapOf(
+                Rating.AGAIN to
+                    RatingVisuals(
+                        shape = MaterialShapes.Arch,
+                        containerColor = { MaterialTheme.colorScheme.errorContainer },
+                        contentColor = { MaterialTheme.colorScheme.onErrorContainer },
+                    ),
+                Rating.HARD to
+                    RatingVisuals(
+                        shape = MaterialShapes.Slanted,
+                        containerColor = { MaterialTheme.colorScheme.tertiaryContainer },
+                        contentColor = { MaterialTheme.colorScheme.onTertiaryContainer },
+                    ),
+                Rating.GOOD to
+                    RatingVisuals(
+                        shape = MaterialShapes.Ghostish,
+                        containerColor = { MaterialTheme.colorScheme.secondaryContainer },
+                        contentColor = { MaterialTheme.colorScheme.onSecondaryContainer },
+                    ),
+                Rating.EASY to
+                    RatingVisuals(
+                        shape = MaterialShapes.Clover4Leaf,
+                        containerColor = { MaterialTheme.colorScheme.primaryContainer },
+                        contentColor = { MaterialTheme.colorScheme.onPrimaryContainer },
+                    ),
             )
         }
-    }
-
-    val ratingVisuals = remember {
-        mapOf(
-            Rating.AGAIN to RatingVisuals(
-                shape = MaterialShapes.Arch,
-                containerColor = { MaterialTheme.colorScheme.errorContainer },
-                contentColor = { MaterialTheme.colorScheme.onErrorContainer }),
-            Rating.HARD to RatingVisuals(
-                shape = MaterialShapes.Slanted,
-                containerColor = { MaterialTheme.colorScheme.tertiaryContainer },
-                contentColor = { MaterialTheme.colorScheme.onTertiaryContainer }),
-            Rating.GOOD to RatingVisuals(
-                shape = MaterialShapes.Ghostish,
-                containerColor = { MaterialTheme.colorScheme.secondaryContainer },
-                contentColor = { MaterialTheme.colorScheme.onSecondaryContainer }),
-            Rating.EASY to RatingVisuals(
-                shape = MaterialShapes.Clover4Leaf,
-                containerColor = { MaterialTheme.colorScheme.primaryContainer },
-                contentColor = { MaterialTheme.colorScheme.onPrimaryContainer })
-        )
-    }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -750,15 +777,16 @@ fun GradeNowDialog(
         },
         text = {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 300.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 options.chunked(2).forEach { rowOptions ->
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         rowOptions.forEach { option ->
                             val visuals = ratingVisuals[option.rating]
@@ -768,7 +796,7 @@ fun GradeNowDialog(
                                     visuals = visuals,
                                     modifier = Modifier.weight(1f),
                                     onConfirm = onConfirm,
-                                    onDismissRequest = onDismissRequest
+                                    onDismissRequest = onDismissRequest,
                                 )
                             }
                         }
@@ -807,20 +835,23 @@ private fun GradeCard(
     val animatedScale by animateFloatAsState(
         targetValue = if (isPressed) 0.92f else 1.0f,
         animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
-        label = "GradeCardScale"
+        label = "GradeCardScale",
     )
 
     val animatedMorphProgress by animateFloatAsState(
-        targetValue = 1f, animationSpec = slowSpatialSpec, label = "GradeCardMorph"
+        targetValue = 1f,
+        animationSpec = slowSpatialSpec,
+        label = "GradeCardMorph",
     )
 
     // Combined morph progress (intro animation scaled by interaction factor)
     val finalMorphProgress = mountProgress.value * animatedMorphProgress
 
     // Set up normalized Morph from Circle to target shape
-    val morph = remember(visuals.shape) {
-        Morph(MaterialShapes.Circle.normalized(), visuals.shape.normalized())
-    }
+    val morph =
+        remember(visuals.shape) {
+            Morph(MaterialShapes.Circle.normalized(), visuals.shape.normalized())
+        }
     val morphingShape = MorphShape(morph, finalMorphProgress)
 
     Surface(
@@ -828,48 +859,52 @@ private fun GradeCard(
             onConfirm(option.rating)
             onDismissRequest()
         },
-        modifier = modifier
-            .graphicsLayer {
-                scaleX = animatedScale
-                scaleY = animatedScale
-            }
-            .aspectRatio(1.1f),
+        modifier =
+            modifier
+                .graphicsLayer {
+                    scaleX = animatedScale
+                    scaleY = animatedScale
+                }.aspectRatio(1.1f),
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceVariant,
         interactionSource = interactionSource,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(8.dp),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             Box(
-                modifier = Modifier
-                    .size(56.dp)
-                    .clip(morphingShape)
-                    .background(visuals.containerColor()), contentAlignment = Alignment.Center
+                modifier =
+                    Modifier
+                        .size(56.dp)
+                        .clip(morphingShape)
+                        .background(visuals.containerColor()),
+                contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     painter = painterResource(option.iconRes),
                     contentDescription = null,
                     tint = visuals.contentColor(),
-                    modifier = Modifier.size(28.dp)
+                    modifier = Modifier.size(28.dp),
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = option.label,
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
 }
 
 private enum class HelpTopic {
-    RANDOMIZE_ORDER, SHIFT_POSITION
+    RANDOMIZE_ORDER,
+    SHIFT_POSITION,
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -904,7 +939,7 @@ fun RepositionCardDialog(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 Text(
-                    text = "Change when these new cards will be shown for review. Cards with lower queue numbers are shown sooner.",
+                    text = stringResource(R.string.reposition_description),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -912,25 +947,26 @@ fun RepositionCardDialog(
                 Surface(
                     color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                     shape = MaterialTheme.shapes.medium,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     Column(modifier = Modifier.padding(12.dp)) {
                         Text(
-                            text = "Current Queue Bounds",
+                            text = stringResource(R.string.reposition_current_queue_bounds),
                             style = MaterialTheme.typography.labelLargeEmphasized,
                             color = MaterialTheme.colorScheme.primary,
                         )
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
-                            text = if (isInspection) {
-                                "Queue top: $queueTop\nQueue bottom: $queueBottom"
-                            } else {
-                                "${TR.browsingQueueTop(queueTop)}\n${
-                                    TR.browsingQueueBottom(
-                                        queueBottom
-                                    )
-                                }"
-                            },
+                            text =
+                                if (isInspection) {
+                                    "Queue top: $queueTop\nQueue bottom: $queueBottom"
+                                } else {
+                                    "${TR.browsingQueueTop(queueTop)}\n${
+                                        TR.browsingQueueBottom(
+                                            queueBottom,
+                                        )
+                                    }"
+                                },
                             style = MaterialTheme.typography.bodyMedium,
                         )
                     }
@@ -953,18 +989,19 @@ fun RepositionCardDialog(
                         )
                     },
                     supportingText = {
-                        Text("The queue position assigned to the first card. Values closer to $queueTop appear sooner.")
+                        Text(stringResource(R.string.reposition_start_position_help, queueTop))
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     shape = MaterialTheme.shapes.medium,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = Color.Transparent,
-                    ),
+                    colors =
+                        OutlinedTextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = Color.Transparent,
+                        ),
                 )
 
                 OutlinedTextField(
@@ -980,30 +1017,31 @@ fun RepositionCardDialog(
                         )
                     },
                     supportingText = {
-                        Text("Spacing between cards in the queue. 1 places them next to each other; higher numbers spread them out.")
+                        Text(stringResource(R.string.reposition_step_help))
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     shape = MaterialTheme.shapes.medium,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = Color.Transparent,
-                    ),
+                    colors =
+                        OutlinedTextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = Color.Transparent,
+                        ),
                 )
 
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(MaterialTheme.shapes.medium)
-                        .toggleable(
-                            value = randomizeOrder,
-                            role = Role.Checkbox,
-                            onValueChange = { randomizeOrder = it },
-                        )
-                        .padding(top = 8.dp, start = 8.dp, end = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.medium)
+                            .toggleable(
+                                value = randomizeOrder,
+                                role = Role.Checkbox,
+                                onValueChange = { randomizeOrder = it },
+                            ).padding(top = 8.dp, start = 8.dp, end = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
@@ -1017,7 +1055,8 @@ fun RepositionCardDialog(
                         modifier = Modifier.weight(1f),
                     )
                     IconButton(
-                        onClick = { activeHelpTopic = HelpTopic.RANDOMIZE_ORDER }) {
+                        onClick = { activeHelpTopic = HelpTopic.RANDOMIZE_ORDER },
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.HelpOutline,
                             contentDescription = stringResource(R.string.help),
@@ -1026,15 +1065,15 @@ fun RepositionCardDialog(
                 }
 
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(MaterialTheme.shapes.medium)
-                        .toggleable(
-                            value = shiftPosition,
-                            role = Role.Checkbox,
-                            onValueChange = { shiftPosition = it },
-                        )
-                        .padding(horizontal = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.medium)
+                            .toggleable(
+                                value = shiftPosition,
+                                role = Role.Checkbox,
+                                onValueChange = { shiftPosition = it },
+                            ).padding(horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
@@ -1048,7 +1087,8 @@ fun RepositionCardDialog(
                         modifier = Modifier.weight(1f),
                     )
                     IconButton(
-                        onClick = { activeHelpTopic = HelpTopic.SHIFT_POSITION }) {
+                        onClick = { activeHelpTopic = HelpTopic.SHIFT_POSITION },
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.HelpOutline,
                             contentDescription = stringResource(R.string.help),
@@ -1084,22 +1124,43 @@ fun RepositionCardDialog(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp)
-                    .padding(bottom = 32.dp, top = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(bottom = 32.dp, top = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                val title = when (activeHelpTopic) {
-                    HelpTopic.RANDOMIZE_ORDER -> if (isInspection) "Randomize order" else TR.browsingRandomizeOrder()
-                    HelpTopic.SHIFT_POSITION -> if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards()
-                    null -> ""
-                }
-                val description = when (activeHelpTopic) {
-                    HelpTopic.RANDOMIZE_ORDER -> "Shuffle cards randomly instead of keeping their current sequence."
-                    HelpTopic.SHIFT_POSITION -> "Push existing cards down the queue to insert these cards cleanly. Otherwise, positions are shared."
-                    null -> ""
-                }
+                val title =
+                    when (activeHelpTopic) {
+                        HelpTopic.RANDOMIZE_ORDER -> if (isInspection) "Randomize order" else TR.browsingRandomizeOrder()
+                        HelpTopic.SHIFT_POSITION ->
+                            if (isInspection) {
+                                "Shift position of existing cards"
+                            } else {
+                                TR
+                                    .browsingShiftPositionOfExistingCards()
+                            }
+                        null -> ""
+                    }
+                val description =
+                    when (activeHelpTopic) {
+                        HelpTopic.RANDOMIZE_ORDER ->
+                            if (isInspection) {
+                                "Shuffle cards randomly instead of keeping their current sequence."
+                            } else {
+                                stringResource(R.string.reposition_randomize_order_help)
+                            }
+
+                        HelpTopic.SHIFT_POSITION ->
+                            if (isInspection) {
+                                "Push existing cards down the queue to insert these cards cleanly. Otherwise, positions are shared."
+                            } else {
+                                stringResource(R.string.reposition_shift_position_help)
+                            }
+
+                        null -> ""
+                    }
 
                 Text(
                     text = title,
@@ -1126,13 +1187,14 @@ fun RepositionCardDialog(
 private fun CardBrowserDeckSelectionDialogPreview() {
     AnkiDroidTheme {
         CardBrowserDeckSelectionDialog(
-            availableDecks = listOf(
-                SelectableDeck.Deck(1L, "Default"),
-                SelectableDeck.Deck(2L, "Languages"),
-                SelectableDeck.Deck(3L, "Languages::Spanish"),
-                SelectableDeck.Deck(4L, "Languages::French"),
-                SelectableDeck.Deck(5L, "Geography"),
-            ),
+            availableDecks =
+                listOf(
+                    SelectableDeck.Deck(1L, "Default"),
+                    SelectableDeck.Deck(2L, "Languages"),
+                    SelectableDeck.Deck(3L, "Languages::Spanish"),
+                    SelectableDeck.Deck(4L, "Languages::French"),
+                    SelectableDeck.Deck(5L, "Geography"),
+                ),
             onDeckSelected = {},
             onDismissRequest = {},
             onCreateDeck = {},
@@ -1149,13 +1211,14 @@ private fun CardBrowserDeckSelectionDialogPreview() {
 )
 @Composable
 private fun SetDueDateDialogSingleDayPreview() {
-    val viewModel = remember {
-        SetDueDateViewModel().apply {
-            cardIds = listOf(1L)
-            currentInterval.value = 14
-            nextSingleDayDueDate = 5
+    val viewModel =
+        remember {
+            SetDueDateViewModel().apply {
+                cardIds = listOf(1L)
+                currentInterval.value = 14
+                nextSingleDayDueDate = 5
+            }
         }
-    }
     AnkiDroidTheme {
         SetDueDateDialog(
             viewModel = viewModel,
@@ -1174,14 +1237,15 @@ private fun SetDueDateDialogSingleDayPreview() {
 )
 @Composable
 private fun SetDueDateDialogDateRangePreview() {
-    val viewModel = remember {
-        SetDueDateViewModel().apply {
-            cardIds = listOf(1L, 2L, 3L)
-            currentTab = SetDueDateViewModel.Tab.DATE_RANGE
-            setNextDateRangeStart(3)
-            setNextDateRangeEnd(7)
+    val viewModel =
+        remember {
+            SetDueDateViewModel().apply {
+                cardIds = listOf(1L, 2L, 3L)
+                currentTab = SetDueDateViewModel.Tab.DATE_RANGE
+                setNextDateRangeStart(3)
+                setNextDateRangeEnd(7)
+            }
         }
-    }
     AnkiDroidTheme {
         SetDueDateDialog(
             viewModel = viewModel,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -380,7 +380,7 @@ fun SetDueDateDialog(
                     value = singleDayText,
                     onValueChange = { newValue ->
                         if (newValue.all { it.isDigit() }) {
-                            viewModel.singleDayText.value = newValue
+                            viewModel.setSingleDayText(newValue)
                             viewModel.nextSingleDayDueDate = newValue.toIntOrNull()
                         }
                     },
@@ -420,7 +420,7 @@ fun SetDueDateDialog(
                             value = startText,
                             onValueChange = { newValue ->
                                 if (newValue.all { it.isDigit() }) {
-                                    viewModel.startText.value = newValue
+                                    viewModel.setStartText(newValue)
                                     viewModel.setNextDateRangeStart(newValue.toIntOrNull())
                                 }
                             },
@@ -441,7 +441,7 @@ fun SetDueDateDialog(
                             value = endText,
                             onValueChange = { newValue ->
                                 if (newValue.all { it.isDigit() }) {
-                                    viewModel.endText.value = newValue
+                                    viewModel.setEndText(newValue)
                                     viewModel.setNextDateRangeEnd(newValue.toIntOrNull())
                                 }
                             },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -830,14 +830,7 @@ private fun GradeCard(
         label = "GradeCardScale",
     )
 
-    val animatedMorphProgress by animateFloatAsState(
-        targetValue = 1f,
-        animationSpec = slowSpatialSpec,
-        label = "GradeCardMorph",
-    )
-
-    // Combined morph progress (intro animation scaled by interaction factor)
-    val finalMorphProgress = mountProgress.value * animatedMorphProgress
+    val finalMorphProgress = mountProgress.value
 
     // Set up normalized Morph from Circle to target shape
     val morph =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -38,14 +39,17 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -734,6 +738,11 @@ fun GradeNowDialog(
     )
 }
 
+private enum class HelpTopic {
+    RANDOMIZE_ORDER, SHIFT_POSITION
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RepositionCardDialog(
     queueTop: Int,
@@ -748,6 +757,7 @@ fun RepositionCardDialog(
     var stepText by rememberSaveable { mutableStateOf("1") }
     var randomizeOrder by rememberSaveable { mutableStateOf(initialRandom) }
     var shiftPosition by rememberSaveable { mutableStateOf(initialShift) }
+    var activeHelpTopic by remember { mutableStateOf<HelpTopic?>(null) }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -764,14 +774,37 @@ fun RepositionCardDialog(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 Text(
-                    text = if (isInspection) {
-                        "Queue top: $queueTop\nQueue bottom: $queueBottom"
-                    } else {
-                        "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueBottom(queueBottom)}"
-                    },
+                    text = "Change when these new cards will be shown for review. Cards with lower queue numbers are shown sooner.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            text = "Current Queue Bounds",
+                            style = MaterialTheme.typography.labelLargeEmphasized,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = if (isInspection) {
+                                "Queue top: $queueTop\nQueue bottom: $queueBottom"
+                            } else {
+                                "${TR.browsingQueueTop(queueTop)}\n${
+                                    TR.browsingQueueBottom(
+                                        queueBottom
+                                    )
+                                }"
+                            },
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
 
                 OutlinedTextField(
                     value = startPositionText,
@@ -788,6 +821,9 @@ fun RepositionCardDialog(
                                 TR.browsingStartPosition().removeSuffix(":")
                             },
                         )
+                    },
+                    supportingText = {
+                        Text("The queue position assigned to the first card. Values closer to $queueTop appear sooner.")
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
@@ -813,6 +849,9 @@ fun RepositionCardDialog(
                             if (isInspection) "Step" else TR.browsingStep().removeSuffix(":"),
                         )
                     },
+                    supportingText = {
+                        Text("Spacing between cards in the queue. 1 places them next to each other; higher numbers spread them out.")
+                    },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
@@ -834,7 +873,7 @@ fun RepositionCardDialog(
                             role = Role.Checkbox,
                             onValueChange = { randomizeOrder = it },
                         )
-                        .padding(vertical = 8.dp, horizontal = 8.dp),
+                        .padding(top = 8.dp, start = 8.dp, end = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
@@ -842,7 +881,18 @@ fun RepositionCardDialog(
                         onCheckedChange = null,
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = if (isInspection) "Randomize order" else TR.browsingRandomizeOrder())
+                    Text(
+                        text = if (isInspection) "Randomize order" else TR.browsingRandomizeOrder(),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = { activeHelpTopic = HelpTopic.RANDOMIZE_ORDER }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                            contentDescription = stringResource(R.string.help),
+                        )
+                    }
                 }
 
                 Row(
@@ -862,7 +912,18 @@ fun RepositionCardDialog(
                         onCheckedChange = null,
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards())
+                    Text(
+                        text = if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards(),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = { activeHelpTopic = HelpTopic.SHIFT_POSITION }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                            contentDescription = stringResource(R.string.help),
+                        )
+                    }
                 }
             }
         },
@@ -885,6 +946,44 @@ fun RepositionCardDialog(
             }
         },
     )
+
+    if (activeHelpTopic != null) {
+        ModalBottomSheet(
+            onDismissRequest = { activeHelpTopic = null },
+            shape = MaterialTheme.shapes.extraLarge,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 32.dp, top = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                val title = when (activeHelpTopic) {
+                    HelpTopic.RANDOMIZE_ORDER -> if (isInspection) "Randomize order" else TR.browsingRandomizeOrder()
+                    HelpTopic.SHIFT_POSITION -> if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards()
+                    null -> ""
+                }
+                val description = when (activeHelpTopic) {
+                    HelpTopic.RANDOMIZE_ORDER -> "Shuffle cards randomly instead of keeping their current sequence."
+                    HelpTopic.SHIFT_POSITION -> "Push existing cards down the queue to insert these cards cleanly. Otherwise, positions are shared."
+                    null -> ""
+                }
+
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
 }
 
 @Preview(
@@ -979,7 +1078,7 @@ private fun GradeNowDialogPreview() {
     }
 }
 
-@Preview(name = "Reposition Card Dialog", widthDp = 400, heightDp = 600, showBackground = true)
+@Preview(name = "Reposition Card Dialog", widthDp = 400, heightDp = 700, showBackground = true)
 @Composable
 private fun RepositionCardDialogPreview() {
     AnkiDroidTheme {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -1,0 +1,693 @@
+/*
+ Copyright (c) 2026 Colby Cabrera <colbycabrera.wd@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.browser.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import anki.scheduler.CardAnswer.Rating
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.R
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.scheduling.SetDueDateViewModel
+
+@Composable
+fun CardBrowserDeckSelectionDialog(
+    availableDecks: List<SelectableDeck.Deck>,
+    onDeckSelected: (SelectableDeck.Deck) -> Unit,
+    onDismissRequest: () -> Unit,
+    onCreateDeck: () -> Unit,
+    onCreateSubDeck: (DeckId) -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    val expandedDecks = remember { mutableStateMapOf<String, Boolean>() }
+
+    val deckHierarchy = remember(availableDecks, searchQuery) {
+        buildDeckHierarchyForDialog(availableDecks, searchQuery)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            searchQuery = ""
+            expandedDecks.clear()
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = stringResource(R.string.select_deck_title))
+                IconButton(onClick = onCreateDeck) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(R.string.new_deck)
+                    )
+                }
+            }
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text(stringResource(R.string.search_deck)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    trailingIcon = {
+                        if (searchQuery.isNotEmpty()) {
+                            IconButton(onClick = { searchQuery = "" }) {
+                                Icon(Icons.Default.Close, contentDescription = null)
+                            }
+                        }
+                    }
+                )
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp)
+                ) {
+                    val rootChildren = deckHierarchy[""] ?: emptyList()
+                    item {
+                        DeckHierarchyList(
+                            deckHierarchy = deckHierarchy,
+                            children = rootChildren,
+                            expandedDecks = expandedDecks,
+                            onDeckSelected = onDeckSelected,
+                            onCreateSubDeck = onCreateSubDeck,
+                            searchQuery = searchQuery
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+private fun DeckHierarchyList(
+    deckHierarchy: Map<String, List<SelectableDeck.Deck>>,
+    children: List<SelectableDeck.Deck>,
+    expandedDecks: MutableMap<String, Boolean>,
+    onDeckSelected: (SelectableDeck.Deck) -> Unit,
+    onCreateSubDeck: (DeckId) -> Unit,
+    searchQuery: String,
+    parentName: String = ""
+) {
+    Column {
+        for (deck in children) {
+            val isExpanded = expandedDecks[deck.name] ?: (searchQuery.isNotEmpty())
+            val hasChildren = deckHierarchy.containsKey(deck.name)
+            val parts = deck.name.split("::")
+            val depth = parts.size - 1
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onDeckSelected(deck) }
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Spacer(modifier = Modifier.width((depth * 16).dp))
+
+                if (hasChildren) {
+                    Icon(
+                        painter = painterResource(
+                            if (isExpanded) R.drawable.keyboard_arrow_down_24px
+                            else R.drawable.keyboard_arrow_right_24px
+                        ),
+                        contentDescription = stringResource(
+                            if (isExpanded) R.string.collapse else R.string.expand
+                        ),
+                        modifier = Modifier
+                            .clickable { expandedDecks[deck.name] = !isExpanded }
+                            .padding(4.dp)
+                    )
+                } else {
+                    Spacer(modifier = Modifier.width(32.dp))
+                }
+
+                Text(
+                    text = deck.getDisplayName(LocalContext.current),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+
+                IconButton(onClick = { onCreateSubDeck(deck.deckId) }) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(R.string.create_subdeck),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            if (isExpanded && hasChildren) {
+                val subChildren = deckHierarchy[deck.name] ?: emptyList()
+                DeckHierarchyList(
+                    deckHierarchy = deckHierarchy,
+                    children = subChildren,
+                    expandedDecks = expandedDecks,
+                    onDeckSelected = onDeckSelected,
+                    onCreateSubDeck = onCreateSubDeck,
+                    searchQuery = searchQuery,
+                    parentName = deck.name
+                )
+            }
+        }
+    }
+}
+
+private fun buildDeckHierarchyForDialog(
+    decks: List<SelectableDeck.Deck>, searchQuery: String
+): Map<String, List<SelectableDeck.Deck>> {
+    val hierarchy = mutableMapOf<String, MutableList<SelectableDeck.Deck>>()
+    val topLevelDecks = mutableListOf<SelectableDeck.Deck>()
+
+    val decksToShow = if (searchQuery.isEmpty()) {
+        decks
+    } else {
+        val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
+        val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
+        val allDecksByName = decks.associateBy { it.name }
+
+        for (deck in matchingDecks) {
+            requiredDecks.add(deck)
+            var currentName = deck.name
+            while (currentName.contains("::")) {
+                currentName = currentName.substringBeforeLast("::")
+                allDecksByName[currentName]?.let { requiredDecks.add(it) }
+            }
+        }
+        requiredDecks.toList()
+    }
+
+    for (deck in decksToShow) {
+        val parts = deck.name.split("::")
+        if (parts.size > 1) {
+            val parentName = parts.dropLast(1).joinToString("::")
+            hierarchy.getOrPut(parentName) { mutableListOf() }.add(deck)
+        } else {
+            topLevelDecks.add(deck)
+        }
+    }
+
+    hierarchy[""] = topLevelDecks
+    return hierarchy
+}
+
+@Composable
+@Suppress("DEPRECATION")
+fun SetDueDateDialog(
+    viewModel: SetDueDateViewModel,
+    onHelpClicked: () -> Unit,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+
+    val isValid by viewModel.isValidFlow.collectAsStateWithLifecycle()
+    val currentInterval by viewModel.currentInterval.collectAsStateWithLifecycle()
+    var selectedTabIndex by remember { mutableStateOf(0) }
+
+    var singleDayText by remember { mutableStateOf("") }
+    var startText by remember { mutableStateOf("") }
+    var endText by remember { mutableStateOf("") }
+    var updateInterval by remember { mutableStateOf(viewModel.updateIntervalToMatchDueDate) }
+
+    LaunchedEffect(selectedTabIndex) {
+        viewModel.currentTab = if (selectedTabIndex == 0) {
+            SetDueDateViewModel.Tab.SINGLE_DAY
+        } else {
+            SetDueDateViewModel.Tab.DATE_RANGE
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = stringResource(R.string.sentence_set_due_date))
+                IconButton(onClick = onHelpClicked) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                        contentDescription = stringResource(R.string.help)
+                    )
+                }
+            }
+        },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
+                TabRow(selectedTabIndex = selectedTabIndex) {
+                    Tab(
+                        selected = selectedTabIndex == 0,
+                        onClick = { selectedTabIndex = 0 },
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.calendar_single_day),
+                                contentDescription = "Single Day"
+                            )
+                        },
+                        text = { Text("Single Day") }
+                    )
+                    Tab(
+                        selected = selectedTabIndex == 1,
+                        onClick = { selectedTabIndex = 1 },
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.calendar_date_range),
+                                contentDescription = "Date Range"
+                            )
+                        },
+                        text = { Text("Date Range") }
+                    )
+                }
+
+                if (selectedTabIndex == 0) {
+                    OutlinedTextField(
+                        value = singleDayText,
+                        onValueChange = {
+                            singleDayText = it
+                            viewModel.nextSingleDayDueDate = it.toIntOrNull()
+                        },
+                        label = {
+                            Text(
+                                pluralStringResource(
+                                    R.plurals.set_due_date_single_day_label,
+                                    viewModel.cardCount,
+                                    viewModel.cardCount
+                                )
+                            )
+                        },
+                        suffix = {
+                            Text(
+                                pluralStringResource(
+                                    R.plurals.set_due_date_label_suffix,
+                                    singleDayText.toIntOrNull() ?: 0
+                                )
+                            )
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = pluralStringResource(
+                                R.plurals.set_due_date_range_label,
+                                viewModel.cardCount,
+                                viewModel.cardCount
+                            ),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedTextField(
+                                value = startText,
+                                onValueChange = {
+                                    startText = it
+                                    viewModel.setNextDateRangeStart(it.toIntOrNull())
+                                },
+                                label = { Text(stringResource(R.string.set_due_date_range_start)) },
+                                suffix = {
+                                    Text(
+                                        pluralStringResource(
+                                            R.plurals.set_due_date_label_suffix,
+                                            startText.toIntOrNull() ?: 0
+                                        )
+                                    )
+                                },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.weight(1f),
+                                singleLine = true
+                            )
+                            OutlinedTextField(
+                                value = endText,
+                                onValueChange = {
+                                    endText = it
+                                    viewModel.setNextDateRangeEnd(it.toIntOrNull())
+                                },
+                                label = { Text(stringResource(R.string.set_due_date_range_end)) },
+                                suffix = {
+                                    Text(
+                                        pluralStringResource(
+                                            R.plurals.set_due_date_label_suffix,
+                                            endText.toIntOrNull() ?: 0
+                                        )
+                                    )
+                                },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.weight(1f),
+                                singleLine = true
+                            )
+                        }
+                    }
+                }
+
+                if (viewModel.canSetUpdateIntervalToMatchDueDate) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = updateInterval,
+                            onCheckedChange = {
+                                updateInterval = it
+                                viewModel.updateIntervalToMatchDueDate = it
+                            }
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = stringResource(R.string.set_due_date_match_interval))
+                    }
+                }
+
+                currentInterval?.let { interval ->
+                    Text(
+                        text = LocalContext.current.resources.getQuantityString(
+                            R.plurals.set_due_date_current_interval,
+                            interval,
+                            interval
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm()
+                    onDismissRequest()
+                },
+                enabled = isValid
+            ) {
+                Text(text = stringResource(R.string.dialog_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun ForgetCardsDialog(
+    onHelpClicked: () -> Unit,
+    onDismissRequest: () -> Unit,
+    onConfirm: (restorePosition: Boolean, resetCounts: Boolean) -> Unit,
+) {
+
+    var restorePosition by remember { mutableStateOf(true) }
+    var resetCounts by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = stringResource(R.string.reset_card_dialog_title))
+                IconButton(onClick = onHelpClicked) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                        contentDescription = stringResource(R.string.help)
+                    )
+                }
+            }
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = restorePosition,
+                        onCheckedChange = { restorePosition = it }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = TR.schedulingRestorePosition())
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = resetCounts,
+                        onCheckedChange = { resetCounts = it }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = TR.schedulingResetCounts())
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm(restorePosition, resetCounts)
+                onDismissRequest()
+            }) {
+                Text(text = stringResource(R.string.dialog_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        }
+    )
+}
+
+private data class GradeOption(
+    val rating: Rating,
+    val iconRes: Int,
+    val label: String,
+)
+
+@Composable
+fun GradeNowDialog(
+    onConfirm: (Rating) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+
+    val options = remember {
+        listOf(
+            GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+            GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+            GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+            GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy())
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.sentence_grade_now)) },
+        text = {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 250.dp)
+            ) {
+                items(options) { option ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                onConfirm(option.rating)
+                                onDismissRequest()
+                            }
+                            .padding(vertical = 12.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(option.iconRes),
+                            contentDescription = null,
+                            tint = Color.Unspecified
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(
+                            text = option.label,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun RepositionCardDialog(
+    queueTop: Int,
+    queueBottom: Int,
+    initialRandom: Boolean,
+    initialShift: Boolean,
+    onConfirm: (position: Int, step: Int, random: Boolean, shift: Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+
+    var startPositionText by remember { mutableStateOf(queueTop.toString()) }
+    var stepText by remember { mutableStateOf("1") }
+    var randomizeOrder by remember { mutableStateOf(initialRandom) }
+    var shiftPosition by remember { mutableStateOf(initialShift) }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.sentence_reposition_new_cards)) },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueTop(queueBottom)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                OutlinedTextField(
+                    value = startPositionText,
+                    onValueChange = { startPositionText = it },
+                    label = { Text(TR.browsingStartPosition().removeSuffix(":")) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                OutlinedTextField(
+                    value = stepText,
+                    onValueChange = { stepText = it },
+                    label = { Text(TR.browsingStep().removeSuffix(":")) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = randomizeOrder,
+                        onCheckedChange = { randomizeOrder = it }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = TR.browsingRandomizeOrder())
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = shiftPosition,
+                        onCheckedChange = { shiftPosition = it }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = TR.browsingShiftPositionOfExistingCards())
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val pos = startPositionText.toIntOrNull() ?: queueTop
+                    val step = stepText.toIntOrNull() ?: 1
+                    onConfirm(pos, step, randomizeOrder, shiftPosition)
+                    onDismissRequest()
+                },
+                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null
+            ) {
+                Text(text = stringResource(R.string.dialog_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        }
+    )
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -58,10 +58,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import anki.scheduler.CardAnswer.Rating
@@ -70,6 +72,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.scheduling.SetDueDateViewModel
+import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 
 @Composable
 fun CardBrowserDeckSelectionDialog(
@@ -173,7 +176,8 @@ private fun DeckHierarchyList(
                         onClick = { onDeckSelected(deck) },
                         onLongClick = { onCreateSubDeck(deck.deckId) })
                     .padding(vertical = 8.dp, horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically) {
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Spacer(modifier = Modifier.width((depth * 16).dp))
 
                 if (hasChildren) {
@@ -299,26 +303,18 @@ fun SetDueDateDialog(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
             TabRow(selectedTabIndex = selectedTabIndex) {
-                Tab(
-                    selected = selectedTabIndex == 0,
-                    onClick = { selectedTabIndex = 0 },
-                    icon = {
-                        Icon(
-                            painter = painterResource(R.drawable.calendar_single_day),
-                            contentDescription = "Single Day"
-                        )
-                    },
-                    text = { Text("Single Day") })
-                Tab(
-                    selected = selectedTabIndex == 1,
-                    onClick = { selectedTabIndex = 1 },
-                    icon = {
-                        Icon(
-                            painter = painterResource(R.drawable.calendar_date_range),
-                            contentDescription = "Date Range"
-                        )
-                    },
-                    text = { Text("Date Range") })
+                Tab(selected = selectedTabIndex == 0, onClick = { selectedTabIndex = 0 }, icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.calendar_single_day),
+                        contentDescription = "Single Day"
+                    )
+                }, text = { Text("Single Day") })
+                Tab(selected = selectedTabIndex == 1, onClick = { selectedTabIndex = 1 }, icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.calendar_date_range),
+                        contentDescription = "Date Range"
+                    )
+                }, text = { Text("Date Range") })
             }
 
             if (selectedTabIndex == 0) {
@@ -467,25 +463,24 @@ fun ForgetCardsDialog(
             }
         }
     }, text = {
+        val isInspection = LocalInspectionMode.current
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically
             ) {
                 Checkbox(
                     checked = restorePosition, onCheckedChange = { restorePosition = it })
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = TR.schedulingRestorePosition())
+                Text(text = if (isInspection) "Restore position" else TR.schedulingRestorePosition())
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically
             ) {
                 Checkbox(
                     checked = resetCounts, onCheckedChange = { resetCounts = it })
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = TR.schedulingResetCounts())
+                Text(text = if (isInspection) "Reset counts" else TR.schedulingResetCounts())
             }
         }
     }, confirmButton = {
@@ -514,13 +509,23 @@ fun GradeNowDialog(
     onDismissRequest: () -> Unit,
 ) {
 
-    val options = remember {
-        listOf(
-            GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
-            GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
-            GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
-            GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy())
-        )
+    val isInspection = LocalInspectionMode.current
+    val options = remember(isInspection) {
+        if (isInspection) {
+            listOf(
+                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
+                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
+                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
+                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy")
+            )
+        } else {
+            listOf(
+                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy())
+            )
+        }
     }
 
     AlertDialog(
@@ -571,6 +576,7 @@ fun RepositionCardDialog(
     onDismissRequest: () -> Unit,
 ) {
 
+    val isInspection = LocalInspectionMode.current
     var startPositionText by remember { mutableStateOf(queueTop.toString()) }
     var stepText by remember { mutableStateOf("1") }
     var randomizeOrder by remember { mutableStateOf(initialRandom) }
@@ -585,7 +591,11 @@ fun RepositionCardDialog(
                 modifier = Modifier.verticalScroll(rememberScrollState())
             ) {
                 Text(
-                    text = "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueTop(queueBottom)}",
+                    text = if (isInspection) {
+                        "Queue top: $queueTop\nQueue bottom: $queueBottom"
+                    } else {
+                        "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueTop(queueBottom)}"
+                    },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -593,7 +603,12 @@ fun RepositionCardDialog(
                 OutlinedTextField(
                     value = startPositionText,
                     onValueChange = { startPositionText = it },
-                    label = { Text(TR.browsingStartPosition().removeSuffix(":")) },
+                    label = {
+                        Text(
+                            if (isInspection) "Start position" else TR.browsingStartPosition()
+                                .removeSuffix(":")
+                        )
+                    },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
@@ -602,7 +617,11 @@ fun RepositionCardDialog(
                 OutlinedTextField(
                     value = stepText,
                     onValueChange = { stepText = it },
-                    label = { Text(TR.browsingStep().removeSuffix(":")) },
+                    label = {
+                        Text(
+                            if (isInspection) "Step" else TR.browsingStep().removeSuffix(":")
+                        )
+                    },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
@@ -615,7 +634,7 @@ fun RepositionCardDialog(
                     Checkbox(
                         checked = randomizeOrder, onCheckedChange = { randomizeOrder = it })
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = TR.browsingRandomizeOrder())
+                    Text(text = if (isInspection) "Randomize order" else TR.browsingRandomizeOrder())
                 }
 
                 Row(
@@ -625,7 +644,7 @@ fun RepositionCardDialog(
                     Checkbox(
                         checked = shiftPosition, onCheckedChange = { shiftPosition = it })
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = TR.browsingShiftPositionOfExistingCards())
+                    Text(text = if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards())
                 }
             }
         },
@@ -647,4 +666,103 @@ fun RepositionCardDialog(
                 Text(text = stringResource(R.string.dialog_cancel))
             }
         })
+}
+
+@Preview(
+    name = "Card Browser Deck Selection Dialog",
+    widthDp = 400,
+    heightDp = 600,
+    showBackground = true
+)
+@Composable
+private fun CardBrowserDeckSelectionDialogPreview() {
+    AnkiDroidTheme {
+        CardBrowserDeckSelectionDialog(
+            availableDecks = listOf(
+            SelectableDeck.Deck(1L, "Default"),
+            SelectableDeck.Deck(2L, "Languages"),
+            SelectableDeck.Deck(3L, "Languages::Spanish"),
+            SelectableDeck.Deck(4L, "Languages::French"),
+            SelectableDeck.Deck(5L, "Geography")
+        ), onDeckSelected = {}, onDismissRequest = {}, onCreateDeck = {}, onCreateSubDeck = {})
+    }
+}
+
+@Preview(
+    name = "Set Due Date Dialog - Single Day",
+    widthDp = 400,
+    heightDp = 450,
+    showBackground = true
+)
+@Composable
+private fun SetDueDateDialogSingleDayPreview() {
+    val viewModel = remember {
+        SetDueDateViewModel().apply {
+            cardIds = listOf(1L)
+            currentInterval.value = 14
+            nextSingleDayDueDate = 5
+        }
+    }
+    AnkiDroidTheme {
+        SetDueDateDialog(
+            viewModel = viewModel,
+            onHelpClicked = {},
+            onDismissRequest = {},
+            onConfirm = {})
+    }
+}
+
+@Preview(
+    name = "Set Due Date Dialog - Date Range",
+    widthDp = 400,
+    heightDp = 450,
+    showBackground = true
+)
+@Composable
+private fun SetDueDateDialogDateRangePreview() {
+    val viewModel = remember {
+        SetDueDateViewModel().apply {
+            cardIds = listOf(1L, 2L, 3L)
+            currentTab = SetDueDateViewModel.Tab.DATE_RANGE
+            setNextDateRangeStart(3)
+            setNextDateRangeEnd(7)
+        }
+    }
+    AnkiDroidTheme {
+        SetDueDateDialog(
+            viewModel = viewModel,
+            onHelpClicked = {},
+            onDismissRequest = {},
+            onConfirm = {})
+    }
+}
+
+@Preview(name = "Forget Cards Dialog", widthDp = 400, heightDp = 250, showBackground = true)
+@Composable
+private fun ForgetCardsDialogPreview() {
+    AnkiDroidTheme {
+        ForgetCardsDialog(onHelpClicked = {}, onDismissRequest = {}, onConfirm = { _, _ -> })
+    }
+}
+
+@Preview(name = "Grade Now Dialog", widthDp = 400, heightDp = 400, showBackground = true)
+@Composable
+private fun GradeNowDialogPreview() {
+    AnkiDroidTheme {
+        GradeNowDialog(onConfirm = {}, onDismissRequest = {})
+    }
+}
+
+@Preview(name = "Reposition Card Dialog", widthDp = 400, heightDp = 600, showBackground = true)
+@Composable
+private fun RepositionCardDialogPreview() {
+    AnkiDroidTheme {
+        RepositionCardDialog(
+            queueTop = 1,
+            queueBottom = 100,
+            initialRandom = true,
+            initialShift = false,
+            onConfirm = { _, _, _, _ -> },
+            onDismissRequest = {})
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -82,10 +82,9 @@ fun CardBrowserDeckSelectionDialog(
     var searchQuery by remember { mutableStateOf("") }
     val expandedDecks = remember { mutableStateMapOf<String, Boolean>() }
 
-    val deckHierarchy =
-        remember(availableDecks, searchQuery) {
-            buildDeckHierarchyForDialog(availableDecks, searchQuery)
-        }
+    val deckHierarchy = remember(availableDecks, searchQuery) {
+        buildDeckHierarchyForDialog(availableDecks, searchQuery)
+    }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -94,66 +93,59 @@ fun CardBrowserDeckSelectionDialog(
         }
     }
 
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = {
-            Row(
+    AlertDialog(onDismissRequest = onDismissRequest, title = {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = stringResource(R.string.select_deck_title))
+            IconButton(onClick = onCreateDeck) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.new_deck)
+                )
+            }
+        }
+    }, text = {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = { Text(stringResource(R.string.search_deck)) },
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                singleLine = true,
+                trailingIcon = {
+                    if (searchQuery.isNotEmpty()) {
+                        IconButton(onClick = { searchQuery = "" }) {
+                            Icon(Icons.Default.Close, contentDescription = null)
+                        }
+                    }
+                })
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
             ) {
-                Text(text = stringResource(R.string.select_deck_title))
-                IconButton(onClick = onCreateDeck) {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = stringResource(R.string.new_deck),
+                val rootChildren = deckHierarchy[""] ?: emptyList()
+                item {
+                    DeckHierarchyList(
+                        deckHierarchy = deckHierarchy,
+                        children = rootChildren,
+                        expandedDecks = expandedDecks,
+                        onDeckSelected = onDeckSelected,
+                        onCreateSubDeck = onCreateSubDeck,
+                        searchQuery = searchQuery
                     )
                 }
             }
-        },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    placeholder = { Text(stringResource(R.string.search_deck)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    trailingIcon = {
-                        if (searchQuery.isNotEmpty()) {
-                            IconButton(onClick = { searchQuery = "" }) {
-                                Icon(Icons.Default.Close, contentDescription = null)
-                            }
-                        }
-                    },
-                )
-
-                LazyColumn(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 300.dp),
-                ) {
-                    val rootChildren = deckHierarchy[""] ?: emptyList()
-                    item {
-                        DeckHierarchyList(
-                            deckHierarchy = deckHierarchy,
-                            children = rootChildren,
-                            expandedDecks = expandedDecks,
-                            onDeckSelected = onDeckSelected,
-                            onCreateSubDeck = onCreateSubDeck,
-                            searchQuery = searchQuery,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(text = stringResource(R.string.dialog_cancel))
-            }
-        },
-    )
+        }
+    }, confirmButton = {
+        TextButton(onClick = onDismissRequest) {
+            Text(text = stringResource(R.string.dialog_cancel))
+        }
+    })
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -165,7 +157,7 @@ private fun DeckHierarchyList(
     onDeckSelected: (SelectableDeck.Deck) -> Unit,
     onCreateSubDeck: (DeckId) -> Unit,
     searchQuery: String,
-    parentName: String = "",
+    parentName: String = ""
 ) {
     Column {
         for (deck in children) {
@@ -175,36 +167,27 @@ private fun DeckHierarchyList(
             val depth = parts.size - 1
 
             Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .combinedClickable(
-                            onClick = { onDeckSelected(deck) },
-                            onLongClick = { onCreateSubDeck(deck.deckId) },
-                        ).padding(vertical = 8.dp, horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .combinedClickable(
+                        onClick = { onDeckSelected(deck) },
+                        onLongClick = { onCreateSubDeck(deck.deckId) })
+                    .padding(vertical = 8.dp, horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically) {
                 Spacer(modifier = Modifier.width((depth * 16).dp))
 
                 if (hasChildren) {
                     Icon(
-                        painter =
-                            painterResource(
-                                if (isExpanded) {
-                                    R.drawable.keyboard_arrow_down_24px
-                                } else {
-                                    R.drawable.keyboard_arrow_right_24px
-                                },
-                            ),
-                        contentDescription =
-                            stringResource(
-                                if (isExpanded) R.string.collapse else R.string.expand,
-                            ),
-                        modifier =
-                            Modifier
-                                .clickable { expandedDecks[deck.name] = !isExpanded }
-                                .padding(4.dp),
-                    )
+                        painter = painterResource(
+                        if (isExpanded) R.drawable.keyboard_arrow_down_24px
+                        else R.drawable.keyboard_arrow_right_24px
+                    ),
+                        contentDescription = stringResource(
+                            if (isExpanded) R.string.collapse else R.string.expand
+                        ),
+                        modifier = Modifier
+                            .clickable { expandedDecks[deck.name] = !isExpanded }
+                            .padding(4.dp))
                 } else {
                     Spacer(modifier = Modifier.width(32.dp))
                 }
@@ -212,7 +195,7 @@ private fun DeckHierarchyList(
                 Text(
                     text = deck.getDisplayName(LocalContext.current),
                     modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.bodyLarge
                 )
             }
 
@@ -225,7 +208,7 @@ private fun DeckHierarchyList(
                     onDeckSelected = onDeckSelected,
                     onCreateSubDeck = onCreateSubDeck,
                     searchQuery = searchQuery,
-                    parentName = deck.name,
+                    parentName = deck.name
                 )
             }
         }
@@ -233,30 +216,28 @@ private fun DeckHierarchyList(
 }
 
 private fun buildDeckHierarchyForDialog(
-    decks: List<SelectableDeck.Deck>,
-    searchQuery: String,
+    decks: List<SelectableDeck.Deck>, searchQuery: String
 ): Map<String, List<SelectableDeck.Deck>> {
     val hierarchy = mutableMapOf<String, MutableList<SelectableDeck.Deck>>()
     val topLevelDecks = mutableListOf<SelectableDeck.Deck>()
 
-    val decksToShow =
-        if (searchQuery.isEmpty()) {
-            decks
-        } else {
-            val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
-            val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
-            val allDecksByName = decks.associateBy { it.name }
+    val decksToShow = if (searchQuery.isEmpty()) {
+        decks
+    } else {
+        val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
+        val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
+        val allDecksByName = decks.associateBy { it.name }
 
-            for (deck in matchingDecks) {
-                requiredDecks.add(deck)
-                var currentName = deck.name
-                while (currentName.contains("::")) {
-                    currentName = currentName.substringBeforeLast("::")
-                    allDecksByName[currentName]?.let { requiredDecks.add(it) }
-                }
+        for (deck in matchingDecks) {
+            requiredDecks.add(deck)
+            var currentName = deck.name
+            while (currentName.contains("::")) {
+                currentName = currentName.substringBeforeLast("::")
+                allDecksByName[currentName]?.let { requiredDecks.add(it) }
             }
-            requiredDecks.toList()
         }
+        requiredDecks.toList()
+    }
 
     for (deck in decksToShow) {
         val parts = deck.name.split("::")
@@ -280,6 +261,7 @@ fun SetDueDateDialog(
     onDismissRequest: () -> Unit,
     onConfirm: () -> Unit,
 ) {
+
     val isValid by viewModel.isValidFlow.collectAsStateWithLifecycle()
     val currentInterval by viewModel.currentInterval.collectAsStateWithLifecycle()
     var selectedTabIndex by remember { mutableIntStateOf(0) }
@@ -290,191 +272,174 @@ fun SetDueDateDialog(
     var updateInterval by remember { mutableStateOf(viewModel.updateIntervalToMatchDueDate) }
 
     LaunchedEffect(selectedTabIndex) {
-        viewModel.currentTab =
-            if (selectedTabIndex == 0) {
-                SetDueDateViewModel.Tab.SINGLE_DAY
-            } else {
-                SetDueDateViewModel.Tab.DATE_RANGE
-            }
+        viewModel.currentTab = if (selectedTabIndex == 0) {
+            SetDueDateViewModel.Tab.SINGLE_DAY
+        } else {
+            SetDueDateViewModel.Tab.DATE_RANGE
+        }
     }
 
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(text = stringResource(R.string.sentence_set_due_date))
-                IconButton(onClick = onHelpClicked) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = stringResource(R.string.help),
-                    )
-                }
+    AlertDialog(onDismissRequest = onDismissRequest, title = {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = stringResource(R.string.sentence_set_due_date))
+            IconButton(onClick = onHelpClicked) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                    contentDescription = stringResource(R.string.help)
+                )
             }
-        },
-        text = {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.verticalScroll(rememberScrollState()),
-            ) {
-                TabRow(selectedTabIndex = selectedTabIndex) {
-                    Tab(
-                        selected = selectedTabIndex == 0,
-                        onClick = { selectedTabIndex = 0 },
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.calendar_single_day),
-                                contentDescription = "Single Day",
-                            )
-                        },
-                        text = { Text("Single Day") },
-                    )
-                    Tab(
-                        selected = selectedTabIndex == 1,
-                        onClick = { selectedTabIndex = 1 },
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.calendar_date_range),
-                                contentDescription = "Date Range",
-                            )
-                        },
-                        text = { Text("Date Range") },
-                    )
-                }
+        }
+    }, text = {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.verticalScroll(rememberScrollState())
+        ) {
+            TabRow(selectedTabIndex = selectedTabIndex) {
+                Tab(
+                    selected = selectedTabIndex == 0,
+                    onClick = { selectedTabIndex = 0 },
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.calendar_single_day),
+                            contentDescription = "Single Day"
+                        )
+                    },
+                    text = { Text("Single Day") })
+                Tab(
+                    selected = selectedTabIndex == 1,
+                    onClick = { selectedTabIndex = 1 },
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.calendar_date_range),
+                            contentDescription = "Date Range"
+                        )
+                    },
+                    text = { Text("Date Range") })
+            }
 
-                if (selectedTabIndex == 0) {
-                    OutlinedTextField(
-                        value = singleDayText,
-                        onValueChange = {
-                            singleDayText = it
-                            viewModel.nextSingleDayDueDate = it.toIntOrNull()
-                        },
-                        label = {
-                            Text(
-                                pluralStringResource(
-                                    R.plurals.set_due_date_single_day_label,
-                                    viewModel.cardCount,
-                                    viewModel.cardCount,
-                                ),
-                            )
-                        },
-                        suffix = {
-                            Text(
-                                pluralStringResource(
-                                    R.plurals.set_due_date_label_suffix,
-                                    singleDayText.toIntOrNull() ?: 0,
-                                ),
-                            )
-                        },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-                } else {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (selectedTabIndex == 0) {
+                OutlinedTextField(
+                    value = singleDayText,
+                    onValueChange = {
+                        singleDayText = it
+                        viewModel.nextSingleDayDueDate = it.toIntOrNull()
+                    },
+                    label = {
                         Text(
-                            text =
-                                pluralStringResource(
-                                    R.plurals.set_due_date_range_label,
-                                    viewModel.cardCount,
-                                    viewModel.cardCount,
-                                ),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            OutlinedTextField(
-                                value = startText,
-                                onValueChange = {
-                                    startText = it
-                                    viewModel.setNextDateRangeStart(it.toIntOrNull())
-                                },
-                                label = { Text(stringResource(R.string.set_due_date_range_start)) },
-                                suffix = {
-                                    Text(
-                                        pluralStringResource(
-                                            R.plurals.set_due_date_label_suffix,
-                                            startText.toIntOrNull() ?: 0,
-                                        ),
-                                    )
-                                },
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                modifier = Modifier.weight(1f),
-                                singleLine = true,
-                            )
-                            OutlinedTextField(
-                                value = endText,
-                                onValueChange = {
-                                    endText = it
-                                    viewModel.setNextDateRangeEnd(it.toIntOrNull())
-                                },
-                                label = { Text(stringResource(R.string.set_due_date_range_end)) },
-                                suffix = {
-                                    Text(
-                                        pluralStringResource(
-                                            R.plurals.set_due_date_label_suffix,
-                                            endText.toIntOrNull() ?: 0,
-                                        ),
-                                    )
-                                },
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                modifier = Modifier.weight(1f),
-                                singleLine = true,
-                            )
-                        }
-                    }
-                }
-
-                if (viewModel.canSetUpdateIntervalToMatchDueDate) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = updateInterval,
-                            onCheckedChange = {
-                                updateInterval = it
-                                viewModel.updateIntervalToMatchDueDate = it
-                            },
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = stringResource(R.string.set_due_date_match_interval))
-                    }
-                }
-
-                currentInterval?.let { interval ->
-                    Text(
-                        text =
                             pluralStringResource(
-                                R.plurals.set_due_date_current_interval,
-                                interval,
-                                interval,
-                            ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                R.plurals.set_due_date_single_day_label,
+                                viewModel.cardCount,
+                                viewModel.cardCount
+                            )
+                        )
+                    },
+                    suffix = {
+                        Text(
+                            pluralStringResource(
+                                R.plurals.set_due_date_label_suffix,
+                                singleDayText.toIntOrNull() ?: 0
+                            )
+                        )
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.set_due_date_range_label,
+                            viewModel.cardCount,
+                            viewModel.cardCount
+                        ), style = MaterialTheme.typography.bodyMedium
                     )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = startText,
+                            onValueChange = {
+                                startText = it
+                                viewModel.setNextDateRangeStart(it.toIntOrNull())
+                            },
+                            label = { Text(stringResource(R.string.set_due_date_range_start)) },
+                            suffix = {
+                                Text(
+                                    pluralStringResource(
+                                        R.plurals.set_due_date_label_suffix,
+                                        startText.toIntOrNull() ?: 0
+                                    )
+                                )
+                            },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            modifier = Modifier.weight(1f),
+                            singleLine = true
+                        )
+                        OutlinedTextField(
+                            value = endText,
+                            onValueChange = {
+                                endText = it
+                                viewModel.setNextDateRangeEnd(it.toIntOrNull())
+                            },
+                            label = { Text(stringResource(R.string.set_due_date_range_end)) },
+                            suffix = {
+                                Text(
+                                    pluralStringResource(
+                                        R.plurals.set_due_date_label_suffix,
+                                        endText.toIntOrNull() ?: 0
+                                    )
+                                )
+                            },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            modifier = Modifier.weight(1f),
+                            singleLine = true
+                        )
+                    }
                 }
             }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onConfirm()
-                    onDismissRequest()
-                },
-                enabled = isValid,
-            ) {
-                Text(text = stringResource(R.string.dialog_ok))
+
+            if (viewModel.canSetUpdateIntervalToMatchDueDate) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = updateInterval, onCheckedChange = {
+                            updateInterval = it
+                            viewModel.updateIntervalToMatchDueDate = it
+                        })
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = stringResource(R.string.set_due_date_match_interval))
+                }
             }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(text = stringResource(R.string.dialog_cancel))
+
+            currentInterval?.let { interval ->
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.set_due_date_current_interval, interval, interval
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-        },
-    )
+        }
+    }, confirmButton = {
+        TextButton(
+            onClick = {
+                onConfirm()
+                onDismissRequest()
+            }, enabled = isValid
+        ) {
+            Text(text = stringResource(R.string.dialog_ok))
+        }
+    }, dismissButton = {
+        TextButton(onClick = onDismissRequest) {
+            Text(text = stringResource(R.string.dialog_cancel))
+        }
+    })
 }
 
 @Composable
@@ -483,67 +448,58 @@ fun ForgetCardsDialog(
     onDismissRequest: () -> Unit,
     onConfirm: (restorePosition: Boolean, resetCounts: Boolean) -> Unit,
 ) {
+
     var restorePosition by remember { mutableStateOf(true) }
     var resetCounts by remember { mutableStateOf(false) }
 
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = {
+    AlertDialog(onDismissRequest = onDismissRequest, title = {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = stringResource(R.string.reset_card_dialog_title))
+            IconButton(onClick = onHelpClicked) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                    contentDescription = stringResource(R.string.help)
+                )
+            }
+        }
+    }, text = {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = stringResource(R.string.reset_card_dialog_title))
-                IconButton(onClick = onHelpClicked) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = stringResource(R.string.help),
-                    )
-                }
+                Checkbox(
+                    checked = restorePosition, onCheckedChange = { restorePosition = it })
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = TR.schedulingRestorePosition())
             }
-        },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Checkbox(
-                        checked = restorePosition,
-                        onCheckedChange = { restorePosition = it },
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = TR.schedulingRestorePosition())
-                }
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Checkbox(
-                        checked = resetCounts,
-                        onCheckedChange = { resetCounts = it },
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = TR.schedulingResetCounts())
-                }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = resetCounts, onCheckedChange = { resetCounts = it })
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = TR.schedulingResetCounts())
             }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                onConfirm(restorePosition, resetCounts)
-                onDismissRequest()
-            }) {
-                Text(text = stringResource(R.string.dialog_ok))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(text = stringResource(R.string.dialog_cancel))
-            }
-        },
-    )
+        }
+    }, confirmButton = {
+        TextButton(onClick = {
+            onConfirm(restorePosition, resetCounts)
+            onDismissRequest()
+        }) {
+            Text(text = stringResource(R.string.dialog_ok))
+        }
+    }, dismissButton = {
+        TextButton(onClick = onDismissRequest) {
+            Text(text = stringResource(R.string.dialog_cancel))
+        }
+    })
 }
 
 private data class GradeOption(
@@ -557,46 +513,42 @@ fun GradeNowDialog(
     onConfirm: (Rating) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-    val options =
-        remember {
-            listOf(
-                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
-                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
-                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
-                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
-            )
-        }
+
+    val options = remember {
+        listOf(
+            GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+            GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+            GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+            GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy())
+        )
+    }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text(text = stringResource(R.string.sentence_grade_now)) },
         text = {
             LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 250.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 250.dp)
             ) {
                 items(options) { option ->
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    onConfirm(option.rating)
-                                    onDismissRequest()
-                                }.padding(vertical = 12.dp, horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
+                    Row(modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onConfirm(option.rating)
+                            onDismissRequest()
+                        }
+                        .padding(vertical = 12.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             painter = painterResource(option.iconRes),
                             contentDescription = null,
-                            tint = Color.Unspecified,
+                            tint = Color.Unspecified
                         )
                         Spacer(modifier = Modifier.width(16.dp))
                         Text(
-                            text = option.label,
-                            style = MaterialTheme.typography.bodyLarge,
+                            text = option.label, style = MaterialTheme.typography.bodyLarge
                         )
                     }
                 }
@@ -606,8 +558,7 @@ fun GradeNowDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        },
-    )
+        })
 }
 
 @Composable
@@ -619,6 +570,7 @@ fun RepositionCardDialog(
     onConfirm: (position: Int, step: Int, random: Boolean, shift: Boolean) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
+
     var startPositionText by remember { mutableStateOf(queueTop.toString()) }
     var stepText by remember { mutableStateOf("1") }
     var randomizeOrder by remember { mutableStateOf(initialRandom) }
@@ -630,12 +582,12 @@ fun RepositionCardDialog(
         text = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.verticalScroll(rememberScrollState()),
+                modifier = Modifier.verticalScroll(rememberScrollState())
             ) {
                 Text(
                     text = "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueTop(queueBottom)}",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
                 OutlinedTextField(
@@ -644,7 +596,7 @@ fun RepositionCardDialog(
                     label = { Text(TR.browsingStartPosition().removeSuffix(":")) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
+                    singleLine = true
                 )
 
                 OutlinedTextField(
@@ -653,29 +605,25 @@ fun RepositionCardDialog(
                     label = { Text(TR.browsingStep().removeSuffix(":")) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
+                    singleLine = true
                 )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Checkbox(
-                        checked = randomizeOrder,
-                        onCheckedChange = { randomizeOrder = it },
-                    )
+                        checked = randomizeOrder, onCheckedChange = { randomizeOrder = it })
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = TR.browsingRandomizeOrder())
                 }
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Checkbox(
-                        checked = shiftPosition,
-                        onCheckedChange = { shiftPosition = it },
-                    )
+                        checked = shiftPosition, onCheckedChange = { shiftPosition = it })
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = TR.browsingShiftPositionOfExistingCards())
                 }
@@ -689,7 +637,7 @@ fun RepositionCardDialog(
                     onConfirm(pos, step, randomizeOrder, shiftPosition)
                     onDismissRequest()
                 },
-                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null,
+                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null
             ) {
                 Text(text = stringResource(R.string.dialog_ok))
             }
@@ -698,6 +646,5 @@ fun RepositionCardDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        },
-    )
+        })
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -53,6 +54,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,6 +64,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -85,9 +88,10 @@ fun CardBrowserDeckSelectionDialog(
     var searchQuery by remember { mutableStateOf("") }
     val expandedDecks = remember { mutableStateMapOf<String, Boolean>() }
 
-    val deckHierarchy = remember(availableDecks, searchQuery) {
-        buildDeckHierarchyForDialog(availableDecks, searchQuery)
-    }
+    val deckHierarchy =
+        remember(availableDecks, searchQuery) {
+            buildDeckHierarchyForDialog(availableDecks, searchQuery)
+        }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -100,13 +104,13 @@ fun CardBrowserDeckSelectionDialog(
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(text = stringResource(R.string.select_deck_title))
             IconButton(onClick = onCreateDeck) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.new_deck)
+                    contentDescription = stringResource(R.string.new_deck),
                 )
             }
         }
@@ -124,32 +128,38 @@ fun CardBrowserDeckSelectionDialog(
                             Icon(Icons.Default.Close, contentDescription = null)
                         }
                     }
-                })
+                },
+            )
 
             val rootChildren = deckHierarchy[""] ?: emptyList()
-            val flatDeckList = remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
-                buildFlatDeckList(
-                    deckHierarchy = deckHierarchy,
-                    children = rootChildren,
-                    expandedDecks = expandedDecks,
-                    searchQuery = searchQuery
-                )
-            }
+            val flatDeckList =
+                remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
+                    buildFlatDeckList(
+                        deckHierarchy = deckHierarchy,
+                        children = rootChildren,
+                        expandedDecks = expandedDecks,
+                        searchQuery = searchQuery,
+                    )
+                }
 
             LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 300.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp),
             ) {
                 items(
-                    items = flatDeckList, key = { it.deck.deckId }) { flatItem ->
+                    items = flatDeckList,
+                    key = { it.deck.deckId },
+                ) { flatItem ->
                     DeckRow(
                         flatItem = flatItem,
                         onDeckSelected = onDeckSelected,
                         onCreateSubDeck = onCreateSubDeck,
                         onToggleExpand = { deckName ->
                             expandedDecks[deckName] = !flatItem.isExpanded
-                        })
+                        },
+                    )
                 }
             }
         }
@@ -161,7 +171,10 @@ fun CardBrowserDeckSelectionDialog(
 }
 
 private data class FlatDeckItem(
-    val deck: SelectableDeck.Deck, val depth: Int, val hasChildren: Boolean, val isExpanded: Boolean
+    val deck: SelectableDeck.Deck,
+    val depth: Int,
+    val hasChildren: Boolean,
+    val isExpanded: Boolean,
 )
 
 private fun buildFlatDeckList(
@@ -169,7 +182,7 @@ private fun buildFlatDeckList(
     children: List<SelectableDeck.Deck>,
     expandedDecks: Map<String, Boolean>,
     searchQuery: String,
-    flatList: MutableList<FlatDeckItem> = mutableListOf()
+    flatList: MutableList<FlatDeckItem> = mutableListOf(),
 ): List<FlatDeckItem> {
     for (deck in children) {
         val isExpanded = expandedDecks[deck.name] ?: (searchQuery.isNotEmpty())
@@ -179,8 +192,11 @@ private fun buildFlatDeckList(
 
         flatList.add(
             FlatDeckItem(
-                deck = deck, depth = depth, hasChildren = hasChildren, isExpanded = isExpanded
-            )
+                deck = deck,
+                depth = depth,
+                hasChildren = hasChildren,
+                isExpanded = isExpanded,
+            ),
         )
 
         if (isExpanded && hasChildren) {
@@ -190,7 +206,7 @@ private fun buildFlatDeckList(
                 children = subChildren,
                 expandedDecks = expandedDecks,
                 searchQuery = searchQuery,
-                flatList = flatList
+                flatList = flatList,
             )
         }
     }
@@ -203,30 +219,40 @@ private fun DeckRow(
     flatItem: FlatDeckItem,
     onDeckSelected: (SelectableDeck.Deck) -> Unit,
     onCreateSubDeck: (DeckId) -> Unit,
-    onToggleExpand: (String) -> Unit
+    onToggleExpand: (String) -> Unit,
 ) {
     val deck = flatItem.deck
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .combinedClickable(
-                onClick = { onDeckSelected(deck) },
-                onLongClick = { onCreateSubDeck(deck.deckId) })
-            .padding(vertical = 8.dp, horizontal = 16.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    onClick = { onDeckSelected(deck) },
+                    onLongClick = { onCreateSubDeck(deck.deckId) },
+                ).padding(vertical = 8.dp, horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
 
         if (flatItem.hasChildren) {
             Icon(
-                painter = painterResource(
-                if (flatItem.isExpanded) R.drawable.keyboard_arrow_down_24px
-                else R.drawable.keyboard_arrow_right_24px
-            ), contentDescription = stringResource(
-                if (flatItem.isExpanded) R.string.collapse else R.string.expand
-            ), modifier = Modifier
-                    .clickable { onToggleExpand(deck.name) }
-                    .padding(4.dp))
+                painter =
+                    painterResource(
+                        if (flatItem.isExpanded) {
+                            R.drawable.keyboard_arrow_down_24px
+                        } else {
+                            R.drawable.keyboard_arrow_right_24px
+                        },
+                    ),
+                contentDescription =
+                    stringResource(
+                        if (flatItem.isExpanded) R.string.collapse else R.string.expand,
+                    ),
+                modifier =
+                    Modifier
+                        .clickable { onToggleExpand(deck.name) }
+                        .padding(4.dp),
+            )
         } else {
             Spacer(modifier = Modifier.width(32.dp))
         }
@@ -234,34 +260,36 @@ private fun DeckRow(
         Text(
             text = deck.getDisplayName(LocalContext.current),
             modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyLarge
+            style = MaterialTheme.typography.bodyLarge,
         )
     }
 }
 
 private fun buildDeckHierarchyForDialog(
-    decks: List<SelectableDeck.Deck>, searchQuery: String
+    decks: List<SelectableDeck.Deck>,
+    searchQuery: String,
 ): Map<String, List<SelectableDeck.Deck>> {
     val hierarchy = mutableMapOf<String, MutableList<SelectableDeck.Deck>>()
     val topLevelDecks = mutableListOf<SelectableDeck.Deck>()
 
-    val decksToShow = if (searchQuery.isEmpty()) {
-        decks
-    } else {
-        val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
-        val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
-        val allDecksByName = decks.associateBy { it.name }
+    val decksToShow =
+        if (searchQuery.isEmpty()) {
+            decks
+        } else {
+            val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
+            val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
+            val allDecksByName = decks.associateBy { it.name }
 
-        for (deck in matchingDecks) {
-            requiredDecks.add(deck)
-            var currentName = deck.name
-            while (currentName.contains("::")) {
-                currentName = currentName.substringBeforeLast("::")
-                allDecksByName[currentName]?.let { requiredDecks.add(it) }
+            for (deck in matchingDecks) {
+                requiredDecks.add(deck)
+                var currentName = deck.name
+                while (currentName.contains("::")) {
+                    currentName = currentName.substringBeforeLast("::")
+                    allDecksByName[currentName]?.let { requiredDecks.add(it) }
+                }
             }
+            requiredDecks.toList()
         }
-        requiredDecks.toList()
-    }
 
     for (deck in decksToShow) {
         val parts = deck.name.split("::")
@@ -285,54 +313,54 @@ fun SetDueDateDialog(
     onDismissRequest: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-
     val isValid by viewModel.isValidFlow.collectAsStateWithLifecycle()
     val currentInterval by viewModel.currentInterval.collectAsStateWithLifecycle()
     var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-    var singleDayText by remember { mutableStateOf("") }
-    var startText by remember { mutableStateOf("") }
-    var endText by remember { mutableStateOf("") }
+    val singleDayText by viewModel.singleDayText.collectAsStateWithLifecycle()
+    val startText by viewModel.startText.collectAsStateWithLifecycle()
+    val endText by viewModel.endText.collectAsStateWithLifecycle()
     var updateInterval by remember { mutableStateOf(viewModel.updateIntervalToMatchDueDate) }
 
     LaunchedEffect(selectedTabIndex) {
-        viewModel.currentTab = if (selectedTabIndex == 0) {
-            SetDueDateViewModel.Tab.SINGLE_DAY
-        } else {
-            SetDueDateViewModel.Tab.DATE_RANGE
-        }
+        viewModel.currentTab =
+            if (selectedTabIndex == 0) {
+                SetDueDateViewModel.Tab.SINGLE_DAY
+            } else {
+                SetDueDateViewModel.Tab.DATE_RANGE
+            }
     }
 
     AlertDialog(onDismissRequest = onDismissRequest, title = {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(text = stringResource(R.string.sentence_set_due_date))
             IconButton(onClick = onHelpClicked) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                    contentDescription = stringResource(R.string.help)
+                    contentDescription = stringResource(R.string.help),
                 )
             }
         }
     }, text = {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.verticalScroll(rememberScrollState())
+            modifier = Modifier.verticalScroll(rememberScrollState()),
         ) {
             TabRow(selectedTabIndex = selectedTabIndex) {
                 Tab(selected = selectedTabIndex == 0, onClick = { selectedTabIndex = 0 }, icon = {
                     Icon(
                         painter = painterResource(R.drawable.calendar_single_day),
-                        contentDescription = stringResource(R.string.single_day)
+                        contentDescription = stringResource(R.string.single_day),
                     )
                 }, text = { Text(stringResource(R.string.single_day)) })
                 Tab(selected = selectedTabIndex == 1, onClick = { selectedTabIndex = 1 }, icon = {
                     Icon(
                         painter = painterResource(R.drawable.calendar_date_range),
-                        contentDescription = stringResource(R.string.date_range)
+                        contentDescription = stringResource(R.string.date_range),
                     )
                 }, text = { Text(stringResource(R.string.date_range)) })
             }
@@ -340,78 +368,86 @@ fun SetDueDateDialog(
             if (selectedTabIndex == 0) {
                 OutlinedTextField(
                     value = singleDayText,
-                    onValueChange = {
-                        singleDayText = it
-                        viewModel.nextSingleDayDueDate = it.toIntOrNull()
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            viewModel.singleDayText.value = newValue
+                            viewModel.nextSingleDayDueDate = newValue.toIntOrNull()
+                        }
                     },
                     label = {
                         Text(
                             pluralStringResource(
                                 R.plurals.set_due_date_single_day_label,
                                 viewModel.cardCount,
-                                viewModel.cardCount
-                            )
+                                viewModel.cardCount,
+                            ),
                         )
                     },
                     suffix = {
                         Text(
                             pluralStringResource(
                                 R.plurals.set_due_date_label_suffix,
-                                singleDayText.toIntOrNull() ?: 0
-                            )
+                                singleDayText.toIntOrNull() ?: 0,
+                            ),
                         )
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
             } else {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(
-                        text = pluralStringResource(
-                            R.plurals.set_due_date_range_label,
-                            viewModel.cardCount,
-                            viewModel.cardCount
-                        ), style = MaterialTheme.typography.bodyMedium
+                        text =
+                            pluralStringResource(
+                                R.plurals.set_due_date_range_label,
+                                viewModel.cardCount,
+                                viewModel.cardCount,
+                            ),
+                        style = MaterialTheme.typography.bodyMedium,
                     )
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         OutlinedTextField(
                             value = startText,
-                            onValueChange = {
-                                startText = it
-                                viewModel.setNextDateRangeStart(it.toIntOrNull())
+                            onValueChange = { newValue ->
+                                if (newValue.all { it.isDigit() }) {
+                                    viewModel.startText.value = newValue
+                                    viewModel.setNextDateRangeStart(newValue.toIntOrNull())
+                                }
                             },
                             label = { Text(stringResource(R.string.set_due_date_range_start)) },
                             suffix = {
                                 Text(
                                     pluralStringResource(
                                         R.plurals.set_due_date_label_suffix,
-                                        startText.toIntOrNull() ?: 0
-                                    )
+                                        startText.toIntOrNull() ?: 0,
+                                    ),
                                 )
                             },
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             modifier = Modifier.weight(1f),
-                            singleLine = true
+                            singleLine = true,
                         )
                         OutlinedTextField(
                             value = endText,
-                            onValueChange = {
-                                endText = it
-                                viewModel.setNextDateRangeEnd(it.toIntOrNull())
+                            onValueChange = { newValue ->
+                                if (newValue.all { it.isDigit() }) {
+                                    viewModel.endText.value = newValue
+                                    viewModel.setNextDateRangeEnd(newValue.toIntOrNull())
+                                }
                             },
                             label = { Text(stringResource(R.string.set_due_date_range_end)) },
                             suffix = {
                                 Text(
                                     pluralStringResource(
                                         R.plurals.set_due_date_label_suffix,
-                                        endText.toIntOrNull() ?: 0
-                                    )
+                                        endText.toIntOrNull() ?: 0,
+                                    ),
                                 )
                             },
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                             modifier = Modifier.weight(1f),
-                            singleLine = true
+                            singleLine = true,
                         )
                     }
                 }
@@ -420,13 +456,15 @@ fun SetDueDateDialog(
             if (viewModel.canSetUpdateIntervalToMatchDueDate) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
-                        checked = updateInterval, onCheckedChange = {
+                        checked = updateInterval,
+                        onCheckedChange = {
                             updateInterval = it
                             viewModel.updateIntervalToMatchDueDate = it
-                        })
+                        },
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = stringResource(R.string.set_due_date_match_interval))
                 }
@@ -434,11 +472,14 @@ fun SetDueDateDialog(
 
             currentInterval?.let { interval ->
                 Text(
-                    text = pluralStringResource(
-                        R.plurals.set_due_date_current_interval, interval, interval
-                    ),
+                    text =
+                        pluralStringResource(
+                            R.plurals.set_due_date_current_interval,
+                            interval,
+                            interval,
+                        ),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -447,7 +488,8 @@ fun SetDueDateDialog(
             onClick = {
                 onConfirm()
                 onDismissRequest()
-            }, enabled = isValid
+            },
+            enabled = isValid,
         ) {
             Text(text = stringResource(R.string.dialog_ok))
         }
@@ -464,7 +506,6 @@ fun ForgetCardsDialog(
     onDismissRequest: () -> Unit,
     onConfirm: (restorePosition: Boolean, resetCounts: Boolean) -> Unit,
 ) {
-
     var restorePosition by remember { mutableStateOf(true) }
     var resetCounts by remember { mutableStateOf(false) }
 
@@ -472,13 +513,13 @@ fun ForgetCardsDialog(
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(text = stringResource(R.string.reset_card_dialog_title))
             IconButton(onClick = onHelpClicked) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                    contentDescription = stringResource(R.string.help)
+                    contentDescription = stringResource(R.string.help),
                 )
             }
         }
@@ -486,19 +527,39 @@ fun ForgetCardsDialog(
         val isInspection = LocalInspectionMode.current
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Row(
-                modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .toggleable(
+                            value = restorePosition,
+                            role = Role.Checkbox,
+                            onValueChange = { restorePosition = it },
+                        ).padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Checkbox(
-                    checked = restorePosition, onCheckedChange = { restorePosition = it })
+                    checked = restorePosition,
+                    onCheckedChange = null,
+                )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(text = if (isInspection) "Restore position" else TR.schedulingRestorePosition())
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .toggleable(
+                            value = resetCounts,
+                            role = Role.Checkbox,
+                            onValueChange = { resetCounts = it },
+                        ).padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Checkbox(
-                    checked = resetCounts, onCheckedChange = { resetCounts = it })
+                    checked = resetCounts,
+                    onCheckedChange = null,
+                )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(text = if (isInspection) "Reset counts" else TR.schedulingResetCounts())
             }
@@ -528,52 +589,56 @@ fun GradeNowDialog(
     onConfirm: (Rating) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-
     val isInspection = LocalInspectionMode.current
-    val options = remember(isInspection) {
-        if (isInspection) {
-            listOf(
-                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
-                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
-                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
-                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy")
-            )
-        } else {
-            listOf(
-                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
-                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
-                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
-                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy())
-            )
+    val options =
+        remember(isInspection) {
+            if (isInspection) {
+                listOf(
+                    GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
+                    GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
+                    GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
+                    GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy"),
+                )
+            } else {
+                listOf(
+                    GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+                    GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+                    GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+                    GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
+                )
+            }
         }
-    }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text(text = stringResource(R.string.sentence_grade_now)) },
         text = {
             LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 250.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 250.dp),
             ) {
                 items(options) { option ->
-                    Row(modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            onConfirm(option.rating)
-                            onDismissRequest()
-                        }
-                        .padding(vertical = 12.dp, horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onConfirm(option.rating)
+                                    onDismissRequest()
+                                }.padding(vertical = 12.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         Icon(
                             painter = painterResource(option.iconRes),
                             contentDescription = null,
-                            tint = Color.Unspecified
+                            tint = Color.Unspecified,
                         )
                         Spacer(modifier = Modifier.width(16.dp))
                         Text(
-                            text = option.label, style = MaterialTheme.typography.bodyLarge
+                            text = option.label,
+                            style = MaterialTheme.typography.bodyLarge,
                         )
                     }
                 }
@@ -583,7 +648,8 @@ fun GradeNowDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        })
+        },
+    )
 }
 
 @Composable
@@ -595,12 +661,11 @@ fun RepositionCardDialog(
     onConfirm: (position: Int, step: Int, random: Boolean, shift: Boolean) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-
     val isInspection = LocalInspectionMode.current
-    var startPositionText by remember { mutableStateOf(queueTop.toString()) }
-    var stepText by remember { mutableStateOf("1") }
-    var randomizeOrder by remember { mutableStateOf(initialRandom) }
-    var shiftPosition by remember { mutableStateOf(initialShift) }
+    var startPositionText by rememberSaveable { mutableStateOf(queueTop.toString()) }
+    var stepText by rememberSaveable { mutableStateOf("1") }
+    var randomizeOrder by rememberSaveable { mutableStateOf(initialRandom) }
+    var shiftPosition by rememberSaveable { mutableStateOf(initialShift) }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -608,61 +673,79 @@ fun RepositionCardDialog(
         text = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.verticalScroll(rememberScrollState())
+                modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 Text(
-                    text = if (isInspection) {
-                        "Queue top: $queueTop\nQueue bottom: $queueBottom"
-                    } else {
-                        "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueBottom(queueBottom)}"
-                    },
+                    text =
+                        if (isInspection) {
+                            "Queue top: $queueTop\nQueue bottom: $queueBottom"
+                        } else {
+                            "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueBottom(queueBottom)}"
+                        },
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
 
                 OutlinedTextField(
                     value = startPositionText,
-                    onValueChange = { startPositionText = it },
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            startPositionText = newValue
+                        }
+                    },
                     label = {
                         Text(
-                            if (isInspection) "Start position" else TR.browsingStartPosition()
-                                .removeSuffix(":")
+                            if (isInspection) {
+                                "Start position"
+                            } else {
+                                TR
+                                    .browsingStartPosition()
+                                    .removeSuffix(":")
+                            },
                         )
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
 
                 OutlinedTextField(
                     value = stepText,
-                    onValueChange = { stepText = it },
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            stepText = newValue
+                        }
+                    },
                     label = {
                         Text(
-                            if (isInspection) "Step" else TR.browsingStep().removeSuffix(":")
+                            if (isInspection) "Step" else TR.browsingStep().removeSuffix(":"),
                         )
                     },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
-                        checked = randomizeOrder, onCheckedChange = { randomizeOrder = it })
+                        checked = randomizeOrder,
+                        onCheckedChange = { randomizeOrder = it },
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = if (isInspection) "Randomize order" else TR.browsingRandomizeOrder())
                 }
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
-                        checked = shiftPosition, onCheckedChange = { shiftPosition = it })
+                        checked = shiftPosition,
+                        onCheckedChange = { shiftPosition = it },
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards())
                 }
@@ -676,7 +759,7 @@ fun RepositionCardDialog(
                     onConfirm(pos, step, randomizeOrder, shiftPosition)
                     onDismissRequest()
                 },
-                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null
+                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null,
             ) {
                 Text(text = stringResource(R.string.dialog_ok))
             }
@@ -685,69 +768,86 @@ fun RepositionCardDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        })
+        },
+    )
 }
 
 @Preview(
     name = "Card Browser Deck Selection Dialog",
     widthDp = 400,
     heightDp = 600,
-    showBackground = true
+    showBackground = true,
 )
 @Composable
 private fun CardBrowserDeckSelectionDialogPreview() {
     AnkiDroidTheme {
         CardBrowserDeckSelectionDialog(
-            availableDecks = listOf(
-            SelectableDeck.Deck(1L, "Default"),
-            SelectableDeck.Deck(2L, "Languages"),
-            SelectableDeck.Deck(3L, "Languages::Spanish"),
-            SelectableDeck.Deck(4L, "Languages::French"),
-            SelectableDeck.Deck(5L, "Geography")
-        ), onDeckSelected = {}, onDismissRequest = {}, onCreateDeck = {}, onCreateSubDeck = {})
+            availableDecks =
+                listOf(
+                    SelectableDeck.Deck(1L, "Default"),
+                    SelectableDeck.Deck(2L, "Languages"),
+                    SelectableDeck.Deck(3L, "Languages::Spanish"),
+                    SelectableDeck.Deck(4L, "Languages::French"),
+                    SelectableDeck.Deck(5L, "Geography"),
+                ),
+            onDeckSelected = {},
+            onDismissRequest = {},
+            onCreateDeck = {},
+            onCreateSubDeck = {},
+        )
     }
 }
 
 @Preview(
-    name = "Set Due Date Dialog - Single Day", widthDp = 400, heightDp = 450, showBackground = true
+    name = "Set Due Date Dialog - Single Day",
+    widthDp = 400,
+    heightDp = 450,
+    showBackground = true,
 )
 @Composable
 private fun SetDueDateDialogSingleDayPreview() {
-    val viewModel = remember {
-        SetDueDateViewModel().apply {
-            cardIds = listOf(1L)
-            currentInterval.value = 14
-            nextSingleDayDueDate = 5
+    val viewModel =
+        remember {
+            SetDueDateViewModel().apply {
+                cardIds = listOf(1L)
+                currentInterval.value = 14
+                nextSingleDayDueDate = 5
+            }
         }
-    }
     AnkiDroidTheme {
         SetDueDateDialog(
             viewModel = viewModel,
             onHelpClicked = {},
             onDismissRequest = {},
-            onConfirm = {})
+            onConfirm = {},
+        )
     }
 }
 
 @Preview(
-    name = "Set Due Date Dialog - Date Range", widthDp = 400, heightDp = 450, showBackground = true
+    name = "Set Due Date Dialog - Date Range",
+    widthDp = 400,
+    heightDp = 450,
+    showBackground = true,
 )
 @Composable
 private fun SetDueDateDialogDateRangePreview() {
-    val viewModel = remember {
-        SetDueDateViewModel().apply {
-            cardIds = listOf(1L, 2L, 3L)
-            currentTab = SetDueDateViewModel.Tab.DATE_RANGE
-            setNextDateRangeStart(3)
-            setNextDateRangeEnd(7)
+    val viewModel =
+        remember {
+            SetDueDateViewModel().apply {
+                cardIds = listOf(1L, 2L, 3L)
+                currentTab = SetDueDateViewModel.Tab.DATE_RANGE
+                setNextDateRangeStart(3)
+                setNextDateRangeEnd(7)
+            }
         }
-    }
     AnkiDroidTheme {
         SetDueDateDialog(
             viewModel = viewModel,
             onHelpClicked = {},
             onDismissRequest = {},
-            onConfirm = {})
+            onConfirm = {},
+        )
     }
 }
 
@@ -777,6 +877,7 @@ private fun RepositionCardDialogPreview() {
             initialRandom = true,
             initialShift = false,
             onConfirm = { _, _, _, _ -> },
-            onDismissRequest = {})
+            onDismissRequest = {},
+        )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -32,9 +32,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
@@ -49,6 +49,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,8 +59,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -81,9 +82,10 @@ fun CardBrowserDeckSelectionDialog(
     var searchQuery by remember { mutableStateOf("") }
     val expandedDecks = remember { mutableStateMapOf<String, Boolean>() }
 
-    val deckHierarchy = remember(availableDecks, searchQuery) {
-        buildDeckHierarchyForDialog(availableDecks, searchQuery)
-    }
+    val deckHierarchy =
+        remember(availableDecks, searchQuery) {
+            buildDeckHierarchyForDialog(availableDecks, searchQuery)
+        }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -98,13 +100,13 @@ fun CardBrowserDeckSelectionDialog(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(text = stringResource(R.string.select_deck_title))
                 IconButton(onClick = onCreateDeck) {
                     Icon(
                         imageVector = Icons.Default.Add,
-                        contentDescription = stringResource(R.string.new_deck)
+                        contentDescription = stringResource(R.string.new_deck),
                     )
                 }
             }
@@ -123,13 +125,14 @@ fun CardBrowserDeckSelectionDialog(
                                 Icon(Icons.Default.Close, contentDescription = null)
                             }
                         }
-                    }
+                    },
                 )
 
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 300.dp),
                 ) {
                     val rootChildren = deckHierarchy[""] ?: emptyList()
                     item {
@@ -139,7 +142,7 @@ fun CardBrowserDeckSelectionDialog(
                             expandedDecks = expandedDecks,
                             onDeckSelected = onDeckSelected,
                             onCreateSubDeck = onCreateSubDeck,
-                            searchQuery = searchQuery
+                            searchQuery = searchQuery,
                         )
                     }
                 }
@@ -149,7 +152,7 @@ fun CardBrowserDeckSelectionDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        }
+        },
     )
 }
 
@@ -162,7 +165,7 @@ private fun DeckHierarchyList(
     onDeckSelected: (SelectableDeck.Deck) -> Unit,
     onCreateSubDeck: (DeckId) -> Unit,
     searchQuery: String,
-    parentName: String = ""
+    parentName: String = "",
 ) {
     Column {
         for (deck in children) {
@@ -172,29 +175,35 @@ private fun DeckHierarchyList(
             val depth = parts.size - 1
 
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .combinedClickable(
-                        onClick = { onDeckSelected(deck) },
-                        onLongClick = { onCreateSubDeck(deck.deckId) }
-                    )
-                    .padding(vertical = 8.dp, horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = { onDeckSelected(deck) },
+                            onLongClick = { onCreateSubDeck(deck.deckId) },
+                        ).padding(vertical = 8.dp, horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Spacer(modifier = Modifier.width((depth * 16).dp))
 
                 if (hasChildren) {
                     Icon(
-                        painter = painterResource(
-                            if (isExpanded) R.drawable.keyboard_arrow_down_24px
-                            else R.drawable.keyboard_arrow_right_24px
-                        ),
-                        contentDescription = stringResource(
-                            if (isExpanded) R.string.collapse else R.string.expand
-                        ),
-                        modifier = Modifier
-                            .clickable { expandedDecks[deck.name] = !isExpanded }
-                            .padding(4.dp)
+                        painter =
+                            painterResource(
+                                if (isExpanded) {
+                                    R.drawable.keyboard_arrow_down_24px
+                                } else {
+                                    R.drawable.keyboard_arrow_right_24px
+                                },
+                            ),
+                        contentDescription =
+                            stringResource(
+                                if (isExpanded) R.string.collapse else R.string.expand,
+                            ),
+                        modifier =
+                            Modifier
+                                .clickable { expandedDecks[deck.name] = !isExpanded }
+                                .padding(4.dp),
                     )
                 } else {
                     Spacer(modifier = Modifier.width(32.dp))
@@ -203,7 +212,7 @@ private fun DeckHierarchyList(
                 Text(
                     text = deck.getDisplayName(LocalContext.current),
                     modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyLarge
+                    style = MaterialTheme.typography.bodyLarge,
                 )
             }
 
@@ -216,7 +225,7 @@ private fun DeckHierarchyList(
                     onDeckSelected = onDeckSelected,
                     onCreateSubDeck = onCreateSubDeck,
                     searchQuery = searchQuery,
-                    parentName = deck.name
+                    parentName = deck.name,
                 )
             }
         }
@@ -224,28 +233,30 @@ private fun DeckHierarchyList(
 }
 
 private fun buildDeckHierarchyForDialog(
-    decks: List<SelectableDeck.Deck>, searchQuery: String
+    decks: List<SelectableDeck.Deck>,
+    searchQuery: String,
 ): Map<String, List<SelectableDeck.Deck>> {
     val hierarchy = mutableMapOf<String, MutableList<SelectableDeck.Deck>>()
     val topLevelDecks = mutableListOf<SelectableDeck.Deck>()
 
-    val decksToShow = if (searchQuery.isEmpty()) {
-        decks
-    } else {
-        val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
-        val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
-        val allDecksByName = decks.associateBy { it.name }
+    val decksToShow =
+        if (searchQuery.isEmpty()) {
+            decks
+        } else {
+            val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
+            val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
+            val allDecksByName = decks.associateBy { it.name }
 
-        for (deck in matchingDecks) {
-            requiredDecks.add(deck)
-            var currentName = deck.name
-            while (currentName.contains("::")) {
-                currentName = currentName.substringBeforeLast("::")
-                allDecksByName[currentName]?.let { requiredDecks.add(it) }
+            for (deck in matchingDecks) {
+                requiredDecks.add(deck)
+                var currentName = deck.name
+                while (currentName.contains("::")) {
+                    currentName = currentName.substringBeforeLast("::")
+                    allDecksByName[currentName]?.let { requiredDecks.add(it) }
+                }
             }
+            requiredDecks.toList()
         }
-        requiredDecks.toList()
-    }
 
     for (deck in decksToShow) {
         val parts = deck.name.split("::")
@@ -269,10 +280,9 @@ fun SetDueDateDialog(
     onDismissRequest: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-
     val isValid by viewModel.isValidFlow.collectAsStateWithLifecycle()
     val currentInterval by viewModel.currentInterval.collectAsStateWithLifecycle()
-    var selectedTabIndex by remember { mutableStateOf(0) }
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
 
     var singleDayText by remember { mutableStateOf("") }
     var startText by remember { mutableStateOf("") }
@@ -280,11 +290,12 @@ fun SetDueDateDialog(
     var updateInterval by remember { mutableStateOf(viewModel.updateIntervalToMatchDueDate) }
 
     LaunchedEffect(selectedTabIndex) {
-        viewModel.currentTab = if (selectedTabIndex == 0) {
-            SetDueDateViewModel.Tab.SINGLE_DAY
-        } else {
-            SetDueDateViewModel.Tab.DATE_RANGE
-        }
+        viewModel.currentTab =
+            if (selectedTabIndex == 0) {
+                SetDueDateViewModel.Tab.SINGLE_DAY
+            } else {
+                SetDueDateViewModel.Tab.DATE_RANGE
+            }
     }
 
     AlertDialog(
@@ -293,13 +304,13 @@ fun SetDueDateDialog(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(text = stringResource(R.string.sentence_set_due_date))
                 IconButton(onClick = onHelpClicked) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = stringResource(R.string.help)
+                        contentDescription = stringResource(R.string.help),
                     )
                 }
             }
@@ -307,7 +318,7 @@ fun SetDueDateDialog(
         text = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.verticalScroll(rememberScrollState())
+                modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 TabRow(selectedTabIndex = selectedTabIndex) {
                     Tab(
@@ -316,10 +327,10 @@ fun SetDueDateDialog(
                         icon = {
                             Icon(
                                 painter = painterResource(R.drawable.calendar_single_day),
-                                contentDescription = "Single Day"
+                                contentDescription = "Single Day",
                             )
                         },
-                        text = { Text("Single Day") }
+                        text = { Text("Single Day") },
                     )
                     Tab(
                         selected = selectedTabIndex == 1,
@@ -327,10 +338,10 @@ fun SetDueDateDialog(
                         icon = {
                             Icon(
                                 painter = painterResource(R.drawable.calendar_date_range),
-                                contentDescription = "Date Range"
+                                contentDescription = "Date Range",
                             )
                         },
-                        text = { Text("Date Range") }
+                        text = { Text("Date Range") },
                     )
                 }
 
@@ -346,31 +357,32 @@ fun SetDueDateDialog(
                                 pluralStringResource(
                                     R.plurals.set_due_date_single_day_label,
                                     viewModel.cardCount,
-                                    viewModel.cardCount
-                                )
+                                    viewModel.cardCount,
+                                ),
                             )
                         },
                         suffix = {
                             Text(
                                 pluralStringResource(
                                     R.plurals.set_due_date_label_suffix,
-                                    singleDayText.toIntOrNull() ?: 0
-                                )
+                                    singleDayText.toIntOrNull() ?: 0,
+                                ),
                             )
                         },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         modifier = Modifier.fillMaxWidth(),
-                        singleLine = true
+                        singleLine = true,
                     )
                 } else {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(
-                            text = pluralStringResource(
-                                R.plurals.set_due_date_range_label,
-                                viewModel.cardCount,
-                                viewModel.cardCount
-                            ),
-                            style = MaterialTheme.typography.bodyMedium
+                            text =
+                                pluralStringResource(
+                                    R.plurals.set_due_date_range_label,
+                                    viewModel.cardCount,
+                                    viewModel.cardCount,
+                                ),
+                            style = MaterialTheme.typography.bodyMedium,
                         )
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             OutlinedTextField(
@@ -384,13 +396,13 @@ fun SetDueDateDialog(
                                     Text(
                                         pluralStringResource(
                                             R.plurals.set_due_date_label_suffix,
-                                            startText.toIntOrNull() ?: 0
-                                        )
+                                            startText.toIntOrNull() ?: 0,
+                                        ),
                                     )
                                 },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                                 modifier = Modifier.weight(1f),
-                                singleLine = true
+                                singleLine = true,
                             )
                             OutlinedTextField(
                                 value = endText,
@@ -403,13 +415,13 @@ fun SetDueDateDialog(
                                     Text(
                                         pluralStringResource(
                                             R.plurals.set_due_date_label_suffix,
-                                            endText.toIntOrNull() ?: 0
-                                        )
+                                            endText.toIntOrNull() ?: 0,
+                                        ),
                                     )
                                 },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                                 modifier = Modifier.weight(1f),
-                                singleLine = true
+                                singleLine = true,
                             )
                         }
                     }
@@ -418,14 +430,14 @@ fun SetDueDateDialog(
                 if (viewModel.canSetUpdateIntervalToMatchDueDate) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Checkbox(
                             checked = updateInterval,
                             onCheckedChange = {
                                 updateInterval = it
                                 viewModel.updateIntervalToMatchDueDate = it
-                            }
+                            },
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(text = stringResource(R.string.set_due_date_match_interval))
@@ -434,13 +446,14 @@ fun SetDueDateDialog(
 
                 currentInterval?.let { interval ->
                     Text(
-                        text = LocalContext.current.resources.getQuantityString(
-                            R.plurals.set_due_date_current_interval,
-                            interval,
-                            interval
-                        ),
+                        text =
+                            pluralStringResource(
+                                R.plurals.set_due_date_current_interval,
+                                interval,
+                                interval,
+                            ),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -451,7 +464,7 @@ fun SetDueDateDialog(
                     onConfirm()
                     onDismissRequest()
                 },
-                enabled = isValid
+                enabled = isValid,
             ) {
                 Text(text = stringResource(R.string.dialog_ok))
             }
@@ -460,7 +473,7 @@ fun SetDueDateDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        }
+        },
     )
 }
 
@@ -470,7 +483,6 @@ fun ForgetCardsDialog(
     onDismissRequest: () -> Unit,
     onConfirm: (restorePosition: Boolean, resetCounts: Boolean) -> Unit,
 ) {
-
     var restorePosition by remember { mutableStateOf(true) }
     var resetCounts by remember { mutableStateOf(false) }
 
@@ -480,13 +492,13 @@ fun ForgetCardsDialog(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(text = stringResource(R.string.reset_card_dialog_title))
                 IconButton(onClick = onHelpClicked) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                        contentDescription = stringResource(R.string.help)
+                        contentDescription = stringResource(R.string.help),
                     )
                 }
             }
@@ -495,11 +507,11 @@ fun ForgetCardsDialog(
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
                         checked = restorePosition,
-                        onCheckedChange = { restorePosition = it }
+                        onCheckedChange = { restorePosition = it },
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = TR.schedulingRestorePosition())
@@ -507,11 +519,11 @@ fun ForgetCardsDialog(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
                         checked = resetCounts,
-                        onCheckedChange = { resetCounts = it }
+                        onCheckedChange = { resetCounts = it },
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = TR.schedulingResetCounts())
@@ -530,7 +542,7 @@ fun ForgetCardsDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        }
+        },
     )
 }
 
@@ -545,45 +557,46 @@ fun GradeNowDialog(
     onConfirm: (Rating) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-
-    val options = remember {
-        listOf(
-            GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
-            GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
-            GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
-            GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy())
-        )
-    }
+    val options =
+        remember {
+            listOf(
+                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
+            )
+        }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text(text = stringResource(R.string.sentence_grade_now)) },
         text = {
             LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 250.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 250.dp),
             ) {
                 items(options) { option ->
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                onConfirm(option.rating)
-                                onDismissRequest()
-                            }
-                            .padding(vertical = 12.dp, horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onConfirm(option.rating)
+                                    onDismissRequest()
+                                }.padding(vertical = 12.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
                             painter = painterResource(option.iconRes),
                             contentDescription = null,
-                            tint = Color.Unspecified
+                            tint = Color.Unspecified,
                         )
                         Spacer(modifier = Modifier.width(16.dp))
                         Text(
                             text = option.label,
-                            style = MaterialTheme.typography.bodyLarge
+                            style = MaterialTheme.typography.bodyLarge,
                         )
                     }
                 }
@@ -593,7 +606,7 @@ fun GradeNowDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        }
+        },
     )
 }
 
@@ -606,7 +619,6 @@ fun RepositionCardDialog(
     onConfirm: (position: Int, step: Int, random: Boolean, shift: Boolean) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-
     var startPositionText by remember { mutableStateOf(queueTop.toString()) }
     var stepText by remember { mutableStateOf("1") }
     var randomizeOrder by remember { mutableStateOf(initialRandom) }
@@ -618,12 +630,12 @@ fun RepositionCardDialog(
         text = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.verticalScroll(rememberScrollState())
+                modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 Text(
                     text = "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueTop(queueBottom)}",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
 
                 OutlinedTextField(
@@ -632,7 +644,7 @@ fun RepositionCardDialog(
                     label = { Text(TR.browsingStartPosition().removeSuffix(":")) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
 
                 OutlinedTextField(
@@ -641,16 +653,16 @@ fun RepositionCardDialog(
                     label = { Text(TR.browsingStep().removeSuffix(":")) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
                 )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
                         checked = randomizeOrder,
-                        onCheckedChange = { randomizeOrder = it }
+                        onCheckedChange = { randomizeOrder = it },
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = TR.browsingRandomizeOrder())
@@ -658,11 +670,11 @@ fun RepositionCardDialog(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
                         checked = shiftPosition,
-                        onCheckedChange = { shiftPosition = it }
+                        onCheckedChange = { shiftPosition = it },
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = TR.browsingShiftPositionOfExistingCards())
@@ -677,7 +689,7 @@ fun RepositionCardDialog(
                     onConfirm(pos, step, randomizeOrder, shiftPosition)
                     onDismissRequest()
                 },
-                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null
+                enabled = startPositionText.toIntOrNull() != null && stepText.toIntOrNull() != null,
             ) {
                 Text(text = stringResource(R.string.dialog_ok))
             }
@@ -686,6 +698,6 @@ fun RepositionCardDialog(
             TextButton(onClick = onDismissRequest) {
                 Text(text = stringResource(R.string.dialog_cancel))
             }
-        }
+        },
     )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -15,17 +15,26 @@
  */
 package com.ichi2.anki.browser.compose
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -40,8 +49,10 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -66,6 +77,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
@@ -75,6 +87,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import anki.scheduler.CardAnswer.Rating
 import com.ichi2.anki.CollectionManager.TR
@@ -83,6 +97,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.scheduling.SetDueDateViewModel
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
+import com.ichi2.utils.MorphShape
 
 @Composable
 fun CardBrowserDeckSelectionDialog(
@@ -665,6 +680,14 @@ private data class GradeOption(
     val label: String,
 )
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+private class RatingVisuals(
+    val shape: RoundedPolygon,
+    val containerColor: @Composable () -> Color,
+    val contentColor: @Composable () -> Color,
+)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun GradeNowDialog(
     onConfirm: (Rating) -> Unit,
@@ -689,6 +712,27 @@ fun GradeNowDialog(
         }
     }
 
+    val ratingVisuals = remember {
+        mapOf(
+            Rating.AGAIN to RatingVisuals(
+                shape = MaterialShapes.Arch,
+                containerColor = { MaterialTheme.colorScheme.errorContainer },
+                contentColor = { MaterialTheme.colorScheme.onErrorContainer }),
+            Rating.HARD to RatingVisuals(
+                shape = MaterialShapes.Slanted,
+                containerColor = { MaterialTheme.colorScheme.tertiaryContainer },
+                contentColor = { MaterialTheme.colorScheme.onTertiaryContainer }),
+            Rating.GOOD to RatingVisuals(
+                shape = MaterialShapes.Ghostish,
+                containerColor = { MaterialTheme.colorScheme.secondaryContainer },
+                contentColor = { MaterialTheme.colorScheme.onSecondaryContainer }),
+            Rating.EASY to RatingVisuals(
+                shape = MaterialShapes.Clover4Leaf,
+                containerColor = { MaterialTheme.colorScheme.primaryContainer },
+                contentColor = { MaterialTheme.colorScheme.onPrimaryContainer })
+        )
+    }
+
     AlertDialog(
         onDismissRequest = onDismissRequest,
         shape = MaterialTheme.shapes.extraLarge,
@@ -699,33 +743,29 @@ fun GradeNowDialog(
             )
         },
         text = {
-            LazyColumn(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(max = 250.dp),
+                    .heightIn(max = 300.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                items(options) { option ->
+                options.chunked(2).forEach { rowOptions ->
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(MaterialTheme.shapes.medium)
-                            .clickable {
-                                onConfirm(option.rating)
-                                onDismissRequest()
-                            }
-                            .padding(vertical = 12.dp, horizontal = 16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        Icon(
-                            painter = painterResource(option.iconRes),
-                            contentDescription = null,
-                            tint = Color.Unspecified,
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Text(
-                            text = option.label,
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
+                        rowOptions.forEach { option ->
+                            val visuals = ratingVisuals[option.rating]
+                            if (visuals != null) {
+                                GradeCard(
+                                    option = option,
+                                    visuals = visuals,
+                                    modifier = Modifier.weight(1f),
+                                    onConfirm = onConfirm,
+                                    onDismissRequest = onDismissRequest
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -736,6 +776,90 @@ fun GradeNowDialog(
             }
         },
     )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun GradeCard(
+    option: GradeOption,
+    visuals: RatingVisuals,
+    modifier: Modifier = Modifier,
+    onConfirm: (Rating) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val slowSpatialSpec = MaterialTheme.motionScheme.slowSpatialSpec<Float>()
+
+    // Intro animation state
+    val mountProgress = remember { Animatable(0f) }
+    LaunchedEffect(Unit) {
+        mountProgress.animateTo(targetValue = 1f, animationSpec = slowSpatialSpec)
+    }
+
+    // Dynamic scale/morph state based on press interactions
+    val animatedScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.92f else 1.0f,
+        animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
+        label = "GradeCardScale"
+    )
+
+    val animatedMorphProgress by animateFloatAsState(
+        targetValue = 1f, animationSpec = slowSpatialSpec, label = "GradeCardMorph"
+    )
+
+    // Combined morph progress (intro animation scaled by interaction factor)
+    val finalMorphProgress = mountProgress.value * animatedMorphProgress
+
+    // Set up normalized Morph from Circle to target shape
+    val morph = remember(visuals.shape) {
+        Morph(MaterialShapes.Circle.normalized(), visuals.shape.normalized())
+    }
+    val morphingShape = MorphShape(morph, finalMorphProgress)
+
+    Surface(
+        onClick = {
+            onConfirm(option.rating)
+            onDismissRequest()
+        },
+        modifier = modifier
+            .graphicsLayer {
+                scaleX = animatedScale
+                scaleY = animatedScale
+            }
+            .aspectRatio(1.1f),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        interactionSource = interactionSource,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(morphingShape)
+                    .background(visuals.containerColor()), contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(option.iconRes),
+                    contentDescription = null,
+                    tint = visuals.contentColor(),
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = option.label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
 }
 
 private enum class HelpTopic {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -42,8 +42,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -88,10 +89,9 @@ fun CardBrowserDeckSelectionDialog(
     var searchQuery by remember { mutableStateOf("") }
     val expandedDecks = remember { mutableStateMapOf<String, Boolean>() }
 
-    val deckHierarchy =
-        remember(availableDecks, searchQuery) {
-            buildDeckHierarchyForDialog(availableDecks, searchQuery)
-        }
+    val deckHierarchy = remember(availableDecks, searchQuery) {
+        buildDeckHierarchyForDialog(availableDecks, searchQuery)
+    }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -132,21 +132,19 @@ fun CardBrowserDeckSelectionDialog(
             )
 
             val rootChildren = deckHierarchy[""] ?: emptyList()
-            val flatDeckList =
-                remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
-                    buildFlatDeckList(
-                        deckHierarchy = deckHierarchy,
-                        children = rootChildren,
-                        expandedDecks = expandedDecks,
-                        searchQuery = searchQuery,
-                    )
-                }
+            val flatDeckList = remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
+                buildFlatDeckList(
+                    deckHierarchy = deckHierarchy,
+                    children = rootChildren,
+                    expandedDecks = expandedDecks,
+                    searchQuery = searchQuery,
+                )
+            }
 
             LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp),
             ) {
                 items(
                     items = flatDeckList,
@@ -223,35 +221,32 @@ private fun DeckRow(
 ) {
     val deck = flatItem.deck
     Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .combinedClickable(
-                    onClick = { onDeckSelected(deck) },
-                    onLongClick = { onCreateSubDeck(deck.deckId) },
-                ).padding(vertical = 8.dp, horizontal = 16.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = { onDeckSelected(deck) },
+                onLongClick = { onCreateSubDeck(deck.deckId) },
+            )
+            .padding(vertical = 8.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
 
         if (flatItem.hasChildren) {
             Icon(
-                painter =
-                    painterResource(
-                        if (flatItem.isExpanded) {
-                            R.drawable.keyboard_arrow_down_24px
-                        } else {
-                            R.drawable.keyboard_arrow_right_24px
-                        },
-                    ),
-                contentDescription =
-                    stringResource(
-                        if (flatItem.isExpanded) R.string.collapse else R.string.expand,
-                    ),
-                modifier =
-                    Modifier
-                        .clickable { onToggleExpand(deck.name) }
-                        .padding(4.dp),
+                painter = painterResource(
+                    if (flatItem.isExpanded) {
+                        R.drawable.keyboard_arrow_down_24px
+                    } else {
+                        R.drawable.keyboard_arrow_right_24px
+                    },
+                ),
+                contentDescription = stringResource(
+                    if (flatItem.isExpanded) R.string.collapse else R.string.expand,
+                ),
+                modifier = Modifier
+                    .clickable { onToggleExpand(deck.name) }
+                    .padding(4.dp),
             )
         } else {
             Spacer(modifier = Modifier.width(32.dp))
@@ -272,24 +267,23 @@ private fun buildDeckHierarchyForDialog(
     val hierarchy = mutableMapOf<String, MutableList<SelectableDeck.Deck>>()
     val topLevelDecks = mutableListOf<SelectableDeck.Deck>()
 
-    val decksToShow =
-        if (searchQuery.isEmpty()) {
-            decks
-        } else {
-            val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
-            val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
-            val allDecksByName = decks.associateBy { it.name }
+    val decksToShow = if (searchQuery.isEmpty()) {
+        decks
+    } else {
+        val matchingDecks = decks.filter { it.name.contains(searchQuery, ignoreCase = true) }
+        val requiredDecks = mutableSetOf<SelectableDeck.Deck>()
+        val allDecksByName = decks.associateBy { it.name }
 
-            for (deck in matchingDecks) {
-                requiredDecks.add(deck)
-                var currentName = deck.name
-                while (currentName.contains("::")) {
-                    currentName = currentName.substringBeforeLast("::")
-                    allDecksByName[currentName]?.let { requiredDecks.add(it) }
-                }
+        for (deck in matchingDecks) {
+            requiredDecks.add(deck)
+            var currentName = deck.name
+            while (currentName.contains("::")) {
+                currentName = currentName.substringBeforeLast("::")
+                allDecksByName[currentName]?.let { requiredDecks.add(it) }
             }
-            requiredDecks.toList()
         }
+        requiredDecks.toList()
+    }
 
     for (deck in decksToShow) {
         val parts = deck.name.split("::")
@@ -306,7 +300,6 @@ private fun buildDeckHierarchyForDialog(
 }
 
 @Composable
-@Suppress("DEPRECATION")
 fun SetDueDateDialog(
     viewModel: SetDueDateViewModel,
     onHelpClicked: () -> Unit,
@@ -323,12 +316,11 @@ fun SetDueDateDialog(
     var updateInterval by remember { mutableStateOf(viewModel.updateIntervalToMatchDueDate) }
 
     LaunchedEffect(selectedTabIndex) {
-        viewModel.currentTab =
-            if (selectedTabIndex == 0) {
-                SetDueDateViewModel.Tab.SINGLE_DAY
-            } else {
-                SetDueDateViewModel.Tab.DATE_RANGE
-            }
+        viewModel.currentTab = if (selectedTabIndex == 0) {
+            SetDueDateViewModel.Tab.SINGLE_DAY
+        } else {
+            SetDueDateViewModel.Tab.DATE_RANGE
+        }
     }
 
     AlertDialog(onDismissRequest = onDismissRequest, title = {
@@ -350,19 +342,37 @@ fun SetDueDateDialog(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier.verticalScroll(rememberScrollState()),
         ) {
-            TabRow(selectedTabIndex = selectedTabIndex) {
-                Tab(selected = selectedTabIndex == 0, onClick = { selectedTabIndex = 0 }, icon = {
-                    Icon(
-                        painter = painterResource(R.drawable.calendar_single_day),
-                        contentDescription = stringResource(R.string.single_day),
-                    )
-                }, text = { Text(stringResource(R.string.single_day)) })
-                Tab(selected = selectedTabIndex == 1, onClick = { selectedTabIndex = 1 }, icon = {
-                    Icon(
-                        painter = painterResource(R.drawable.calendar_date_range),
-                        contentDescription = stringResource(R.string.date_range),
-                    )
-                }, text = { Text(stringResource(R.string.date_range)) })
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                SegmentedButton(
+                    selected = selectedTabIndex == 0,
+                    onClick = { selectedTabIndex = 0 },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                    icon = {
+                        SegmentedButtonDefaults.Icon(active = selectedTabIndex == 0) {
+                            Icon(
+                                painter = painterResource(R.drawable.calendar_single_day),
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                ) {
+                    Text(stringResource(R.string.single_day))
+                }
+                SegmentedButton(
+                    selected = selectedTabIndex == 1,
+                    onClick = { selectedTabIndex = 1 },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                    icon = {
+                        SegmentedButtonDefaults.Icon(active = selectedTabIndex == 1) {
+                            Icon(
+                                painter = painterResource(R.drawable.calendar_date_range),
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                ) {
+                    Text(stringResource(R.string.date_range))
+                }
             }
 
             if (selectedTabIndex == 0) {
@@ -398,12 +408,11 @@ fun SetDueDateDialog(
             } else {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(
-                        text =
-                            pluralStringResource(
-                                R.plurals.set_due_date_range_label,
-                                viewModel.cardCount,
-                                viewModel.cardCount,
-                            ),
+                        text = pluralStringResource(
+                            R.plurals.set_due_date_range_label,
+                            viewModel.cardCount,
+                            viewModel.cardCount,
+                        ),
                         style = MaterialTheme.typography.bodyMedium,
                     )
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -472,12 +481,11 @@ fun SetDueDateDialog(
 
             currentInterval?.let { interval ->
                 Text(
-                    text =
-                        pluralStringResource(
-                            R.plurals.set_due_date_current_interval,
-                            interval,
-                            interval,
-                        ),
+                    text = pluralStringResource(
+                        R.plurals.set_due_date_current_interval,
+                        interval,
+                        interval,
+                    ),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -526,14 +534,14 @@ fun ForgetCardsDialog(
         val isInspection = LocalInspectionMode.current
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .toggleable(
-                            value = restorePosition,
-                            role = Role.Checkbox,
-                            onValueChange = { restorePosition = it },
-                        ).padding(vertical = 8.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .toggleable(
+                        value = restorePosition,
+                        role = Role.Checkbox,
+                        onValueChange = { restorePosition = it },
+                    )
+                    .padding(vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Checkbox(
@@ -545,14 +553,14 @@ fun ForgetCardsDialog(
             }
 
             Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .toggleable(
-                            value = resetCounts,
-                            role = Role.Checkbox,
-                            onValueChange = { resetCounts = it },
-                        ).padding(vertical = 8.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .toggleable(
+                        value = resetCounts,
+                        role = Role.Checkbox,
+                        onValueChange = { resetCounts = it },
+                    )
+                    .padding(vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Checkbox(
@@ -589,44 +597,42 @@ fun GradeNowDialog(
     onDismissRequest: () -> Unit,
 ) {
     val isInspection = LocalInspectionMode.current
-    val options =
-        remember(isInspection) {
-            if (isInspection) {
-                listOf(
-                    GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
-                    GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
-                    GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
-                    GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy"),
-                )
-            } else {
-                listOf(
-                    GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
-                    GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
-                    GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
-                    GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
-                )
-            }
+    val options = remember(isInspection) {
+        if (isInspection) {
+            listOf(
+                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, "Again"),
+                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, "Hard"),
+                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, "Good"),
+                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, "Easy"),
+            )
+        } else {
+            listOf(
+                GradeOption(Rating.AGAIN, R.drawable.ic_ease_again, TR.studyingAgain()),
+                GradeOption(Rating.HARD, R.drawable.ic_ease_hard, TR.studyingHard()),
+                GradeOption(Rating.GOOD, R.drawable.ic_ease_good, TR.studyingGood()),
+                GradeOption(Rating.EASY, R.drawable.ic_ease_easy, TR.studyingEasy()),
+            )
         }
+    }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text(text = stringResource(R.string.sentence_grade_now)) },
         text = {
             LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 250.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 250.dp),
             ) {
                 items(options) { option ->
                     Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    onConfirm(option.rating)
-                                    onDismissRequest()
-                                }.padding(vertical = 12.dp, horizontal = 8.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                onConfirm(option.rating)
+                                onDismissRequest()
+                            }
+                            .padding(vertical = 12.dp, horizontal = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -675,12 +681,11 @@ fun RepositionCardDialog(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 Text(
-                    text =
-                        if (isInspection) {
-                            "Queue top: $queueTop\nQueue bottom: $queueBottom"
-                        } else {
-                            "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueBottom(queueBottom)}"
-                        },
+                    text = if (isInspection) {
+                        "Queue top: $queueTop\nQueue bottom: $queueBottom"
+                    } else {
+                        "${TR.browsingQueueTop(queueTop)}\n${TR.browsingQueueBottom(queueBottom)}"
+                    },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -697,9 +702,7 @@ fun RepositionCardDialog(
                             if (isInspection) {
                                 "Start position"
                             } else {
-                                TR
-                                    .browsingStartPosition()
-                                    .removeSuffix(":")
+                                TR.browsingStartPosition().removeSuffix(":")
                             },
                         )
                     },
@@ -781,14 +784,13 @@ fun RepositionCardDialog(
 private fun CardBrowserDeckSelectionDialogPreview() {
     AnkiDroidTheme {
         CardBrowserDeckSelectionDialog(
-            availableDecks =
-                listOf(
-                    SelectableDeck.Deck(1L, "Default"),
-                    SelectableDeck.Deck(2L, "Languages"),
-                    SelectableDeck.Deck(3L, "Languages::Spanish"),
-                    SelectableDeck.Deck(4L, "Languages::French"),
-                    SelectableDeck.Deck(5L, "Geography"),
-                ),
+            availableDecks = listOf(
+                SelectableDeck.Deck(1L, "Default"),
+                SelectableDeck.Deck(2L, "Languages"),
+                SelectableDeck.Deck(3L, "Languages::Spanish"),
+                SelectableDeck.Deck(4L, "Languages::French"),
+                SelectableDeck.Deck(5L, "Geography"),
+            ),
             onDeckSelected = {},
             onDismissRequest = {},
             onCreateDeck = {},
@@ -805,14 +807,13 @@ private fun CardBrowserDeckSelectionDialogPreview() {
 )
 @Composable
 private fun SetDueDateDialogSingleDayPreview() {
-    val viewModel =
-        remember {
-            SetDueDateViewModel().apply {
-                cardIds = listOf(1L)
-                currentInterval.value = 14
-                nextSingleDayDueDate = 5
-            }
+    val viewModel = remember {
+        SetDueDateViewModel().apply {
+            cardIds = listOf(1L)
+            currentInterval.value = 14
+            nextSingleDayDueDate = 5
         }
+    }
     AnkiDroidTheme {
         SetDueDateDialog(
             viewModel = viewModel,
@@ -831,15 +832,14 @@ private fun SetDueDateDialogSingleDayPreview() {
 )
 @Composable
 private fun SetDueDateDialogDateRangePreview() {
-    val viewModel =
-        remember {
-            SetDueDateViewModel().apply {
-                cardIds = listOf(1L, 2L, 3L)
-                currentTab = SetDueDateViewModel.Tab.DATE_RANGE
-                setNextDateRangeStart(3)
-                setNextDateRangeEnd(7)
-            }
+    val viewModel = remember {
+        SetDueDateViewModel().apply {
+            cardIds = listOf(1L, 2L, 3L)
+            currentTab = SetDueDateViewModel.Tab.DATE_RANGE
+            setNextDateRangeStart(3)
+            setNextDateRangeEnd(7)
         }
+    }
     AnkiDroidTheme {
         SetDueDateDialog(
             viewModel = viewModel,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -15,7 +15,9 @@
  */
 package com.ichi2.anki.browser.compose
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -151,6 +153,7 @@ fun CardBrowserDeckSelectionDialog(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DeckHierarchyList(
     deckHierarchy: Map<String, List<SelectableDeck.Deck>>,
@@ -171,8 +174,11 @@ private fun DeckHierarchyList(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onDeckSelected(deck) }
-                    .padding(vertical = 4.dp),
+                    .combinedClickable(
+                        onClick = { onDeckSelected(deck) },
+                        onLongClick = { onCreateSubDeck(deck.deckId) }
+                    )
+                    .padding(vertical = 8.dp, horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Spacer(modifier = Modifier.width((depth * 16).dp))
@@ -199,14 +205,6 @@ private fun DeckHierarchyList(
                     modifier = Modifier.weight(1f),
                     style = MaterialTheme.typography.bodyLarge
                 )
-
-                IconButton(onClick = { onCreateSubDeck(deck.deckId) }) {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = stringResource(R.string.create_subdeck),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                }
             }
 
             if (isExpanded && hasChildren) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -63,7 +63,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -113,13 +112,6 @@ fun CardBrowserDeckSelectionDialog(
         remember(availableDecks, searchQuery) {
             buildDeckHierarchyForDialog(availableDecks, searchQuery)
         }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            searchQuery = ""
-            expandedDecks.clear()
-        }
-    }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -487,7 +487,6 @@ fun SetDueDateDialog(
         TextButton(
             onClick = {
                 onConfirm()
-                onDismissRequest()
             },
             enabled = isValid,
         ) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -59,6 +60,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -100,72 +102,88 @@ fun CardBrowserDeckSelectionDialog(
         }
     }
 
-    AlertDialog(onDismissRequest = onDismissRequest, title = {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(text = stringResource(R.string.select_deck_title))
-            IconButton(onClick = onCreateDeck) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.new_deck),
-                )
-            }
-        }
-    }, text = {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = { searchQuery = it },
-                placeholder = { Text(stringResource(R.string.search_deck)) },
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        shape = MaterialTheme.shapes.extraLarge,
+        title = {
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                trailingIcon = {
-                    if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { searchQuery = "" }) {
-                            Icon(Icons.Default.Close, contentDescription = null)
-                        }
-                    }
-                },
-            )
-
-            val rootChildren = deckHierarchy[""] ?: emptyList()
-            val flatDeckList = remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
-                buildFlatDeckList(
-                    deckHierarchy = deckHierarchy,
-                    children = rootChildren,
-                    expandedDecks = expandedDecks,
-                    searchQuery = searchQuery,
-                )
-            }
-
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 300.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                items(
-                    items = flatDeckList,
-                    key = { it.deck.deckId },
-                ) { flatItem ->
-                    DeckRow(
-                        flatItem = flatItem,
-                        onDeckSelected = onDeckSelected,
-                        onCreateSubDeck = onCreateSubDeck,
-                        onToggleExpand = { deckName ->
-                            expandedDecks[deckName] = !flatItem.isExpanded
-                        },
+                Text(
+                    text = stringResource(R.string.select_deck_title),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                IconButton(onClick = onCreateDeck) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(R.string.new_deck),
                     )
                 }
             }
-        }
-    }, confirmButton = {
-        TextButton(onClick = onDismissRequest) {
-            Text(text = stringResource(R.string.dialog_cancel))
-        }
-    })
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text(stringResource(R.string.search_deck)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = MaterialTheme.shapes.medium,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = Color.Transparent,
+                    ),
+                    trailingIcon = {
+                        if (searchQuery.isNotEmpty()) {
+                            IconButton(onClick = { searchQuery = "" }) {
+                                Icon(Icons.Default.Close, contentDescription = null)
+                            }
+                        }
+                    },
+                )
+
+                val rootChildren = deckHierarchy[""] ?: emptyList()
+                val flatDeckList = remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
+                    buildFlatDeckList(
+                        deckHierarchy = deckHierarchy,
+                        children = rootChildren,
+                        expandedDecks = expandedDecks,
+                        searchQuery = searchQuery,
+                    )
+                }
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp),
+                ) {
+                    items(
+                        items = flatDeckList,
+                        key = { it.deck.deckId },
+                    ) { flatItem ->
+                        DeckRow(
+                            flatItem = flatItem,
+                            onDeckSelected = onDeckSelected,
+                            onCreateSubDeck = onCreateSubDeck,
+                            onToggleExpand = { deckName ->
+                                expandedDecks[deckName] = !flatItem.isExpanded
+                            },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
 }
 
 private data class FlatDeckItem(
@@ -223,6 +241,7 @@ private fun DeckRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
             .combinedClickable(
                 onClick = { onDeckSelected(deck) },
                 onLongClick = { onCreateSubDeck(deck.deckId) },
@@ -323,188 +342,227 @@ fun SetDueDateDialog(
         }
     }
 
-    AlertDialog(onDismissRequest = onDismissRequest, title = {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(text = stringResource(R.string.sentence_set_due_date))
-            IconButton(onClick = onHelpClicked) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                    contentDescription = stringResource(R.string.help),
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        shape = MaterialTheme.shapes.extraLarge,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.sentence_set_due_date),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleLarge,
                 )
-            }
-        }
-    }, text = {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.verticalScroll(rememberScrollState()),
-        ) {
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                SegmentedButton(
-                    selected = selectedTabIndex == 0,
-                    onClick = { selectedTabIndex = 0 },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                    icon = {
-                        SegmentedButtonDefaults.Icon(active = selectedTabIndex == 0) {
-                            Icon(
-                                painter = painterResource(R.drawable.calendar_single_day),
-                                contentDescription = null,
-                            )
-                        }
-                    },
-                ) {
-                    Text(stringResource(R.string.single_day))
-                }
-                SegmentedButton(
-                    selected = selectedTabIndex == 1,
-                    onClick = { selectedTabIndex = 1 },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                    icon = {
-                        SegmentedButtonDefaults.Icon(active = selectedTabIndex == 1) {
-                            Icon(
-                                painter = painterResource(R.drawable.calendar_date_range),
-                                contentDescription = null,
-                            )
-                        }
-                    },
-                ) {
-                    Text(stringResource(R.string.date_range))
-                }
-            }
-
-            if (selectedTabIndex == 0) {
-                OutlinedTextField(
-                    value = singleDayText,
-                    onValueChange = { newValue ->
-                        if (newValue.all { it.isDigit() }) {
-                            viewModel.setSingleDayText(newValue)
-                            viewModel.nextSingleDayDueDate = newValue.toIntOrNull()
-                        }
-                    },
-                    label = {
-                        Text(
-                            pluralStringResource(
-                                R.plurals.set_due_date_single_day_label,
-                                viewModel.cardCount,
-                                viewModel.cardCount,
-                            ),
-                        )
-                    },
-                    suffix = {
-                        Text(
-                            pluralStringResource(
-                                R.plurals.set_due_date_label_suffix,
-                                singleDayText.toIntOrNull() ?: 0,
-                            ),
-                        )
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                        text = pluralStringResource(
-                            R.plurals.set_due_date_range_label,
-                            viewModel.cardCount,
-                            viewModel.cardCount,
-                        ),
-                        style = MaterialTheme.typography.bodyMedium,
+                IconButton(onClick = onHelpClicked) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                        contentDescription = stringResource(R.string.help),
                     )
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        OutlinedTextField(
-                            value = startText,
-                            onValueChange = { newValue ->
-                                if (newValue.all { it.isDigit() }) {
-                                    viewModel.setStartText(newValue)
-                                    viewModel.setNextDateRangeStart(newValue.toIntOrNull())
-                                }
-                            },
-                            label = { Text(stringResource(R.string.set_due_date_range_start)) },
-                            suffix = {
-                                Text(
-                                    pluralStringResource(
-                                        R.plurals.set_due_date_label_suffix,
-                                        startText.toIntOrNull() ?: 0,
-                                    ),
+                }
+            }
+        },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+            ) {
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    SegmentedButton(
+                        selected = selectedTabIndex == 0,
+                        onClick = { selectedTabIndex = 0 },
+                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                        icon = {
+                            SegmentedButtonDefaults.Icon(active = selectedTabIndex == 0) {
+                                Icon(
+                                    painter = painterResource(R.drawable.calendar_single_day),
+                                    contentDescription = null,
                                 )
-                            },
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                            modifier = Modifier.weight(1f),
-                            singleLine = true,
-                        )
-                        OutlinedTextField(
-                            value = endText,
-                            onValueChange = { newValue ->
-                                if (newValue.all { it.isDigit() }) {
-                                    viewModel.setEndText(newValue)
-                                    viewModel.setNextDateRangeEnd(newValue.toIntOrNull())
-                                }
-                            },
-                            label = { Text(stringResource(R.string.set_due_date_range_end)) },
-                            suffix = {
-                                Text(
-                                    pluralStringResource(
-                                        R.plurals.set_due_date_label_suffix,
-                                        endText.toIntOrNull() ?: 0,
-                                    ),
+                            }
+                        },
+                    ) {
+                        Text(stringResource(R.string.single_day))
+                    }
+                    SegmentedButton(
+                        selected = selectedTabIndex == 1,
+                        onClick = { selectedTabIndex = 1 },
+                        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                        icon = {
+                            SegmentedButtonDefaults.Icon(active = selectedTabIndex == 1) {
+                                Icon(
+                                    painter = painterResource(R.drawable.calendar_date_range),
+                                    contentDescription = null,
                                 )
-                            },
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                            modifier = Modifier.weight(1f),
-                            singleLine = true,
-                        )
+                            }
+                        },
+                    ) {
+                        Text(stringResource(R.string.date_range))
                     }
                 }
-            }
 
-            if (viewModel.canSetUpdateIntervalToMatchDueDate) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Checkbox(
-                        checked = updateInterval,
-                        onCheckedChange = {
-                            updateInterval = it
-                            viewModel.updateIntervalToMatchDueDate = it
+                if (selectedTabIndex == 0) {
+                    OutlinedTextField(
+                        value = singleDayText,
+                        onValueChange = { newValue ->
+                            if (newValue.all { it.isDigit() }) {
+                                viewModel.setSingleDayText(newValue)
+                                viewModel.nextSingleDayDueDate = newValue.toIntOrNull()
+                            }
                         },
+                        label = {
+                            Text(
+                                pluralStringResource(
+                                    R.plurals.set_due_date_single_day_label,
+                                    viewModel.cardCount,
+                                    viewModel.cardCount,
+                                ),
+                            )
+                        },
+                        suffix = {
+                            Text(
+                                pluralStringResource(
+                                    R.plurals.set_due_date_label_suffix,
+                                    singleDayText.toIntOrNull() ?: 0,
+                                ),
+                            )
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        shape = MaterialTheme.shapes.medium,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = Color.Transparent,
+                        ),
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = stringResource(R.string.set_due_date_match_interval))
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = pluralStringResource(
+                                R.plurals.set_due_date_range_label,
+                                viewModel.cardCount,
+                                viewModel.cardCount,
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedTextField(
+                                value = startText,
+                                onValueChange = { newValue ->
+                                    if (newValue.all { it.isDigit() }) {
+                                        viewModel.setStartText(newValue)
+                                        viewModel.setNextDateRangeStart(newValue.toIntOrNull())
+                                    }
+                                },
+                                label = { Text(stringResource(R.string.set_due_date_range_start)) },
+                                suffix = {
+                                    Text(
+                                        pluralStringResource(
+                                            R.plurals.set_due_date_label_suffix,
+                                            startText.toIntOrNull() ?: 0,
+                                        ),
+                                    )
+                                },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.weight(1f),
+                                singleLine = true,
+                                shape = MaterialTheme.shapes.medium,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                    unfocusedBorderColor = Color.Transparent,
+                                ),
+                            )
+                            OutlinedTextField(
+                                value = endText,
+                                onValueChange = { newValue ->
+                                    if (newValue.all { it.isDigit() }) {
+                                        viewModel.setEndText(newValue)
+                                        viewModel.setNextDateRangeEnd(newValue.toIntOrNull())
+                                    }
+                                },
+                                label = { Text(stringResource(R.string.set_due_date_range_end)) },
+                                suffix = {
+                                    Text(
+                                        pluralStringResource(
+                                            R.plurals.set_due_date_label_suffix,
+                                            endText.toIntOrNull() ?: 0,
+                                        ),
+                                    )
+                                },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.weight(1f),
+                                singleLine = true,
+                                shape = MaterialTheme.shapes.medium,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                    unfocusedBorderColor = Color.Transparent,
+                                ),
+                            )
+                        }
+                    }
+                }
+
+                if (viewModel.canSetUpdateIntervalToMatchDueDate) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.medium)
+                            .toggleable(
+                                value = updateInterval,
+                                role = Role.Checkbox,
+                                onValueChange = {
+                                    updateInterval = it
+                                    viewModel.updateIntervalToMatchDueDate = it
+                                },
+                            )
+                            .padding(vertical = 8.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = updateInterval,
+                            onCheckedChange = null,
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = stringResource(R.string.set_due_date_match_interval))
+                    }
+                }
+
+                currentInterval?.let { interval ->
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.set_due_date_current_interval,
+                            interval,
+                            interval,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
-
-            currentInterval?.let { interval ->
-                Text(
-                    text = pluralStringResource(
-                        R.plurals.set_due_date_current_interval,
-                        interval,
-                        interval,
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm()
+                },
+                enabled = isValid,
+            ) {
+                Text(text = stringResource(R.string.dialog_ok))
             }
-        }
-    }, confirmButton = {
-        TextButton(
-            onClick = {
-                onConfirm()
-            },
-            enabled = isValid,
-        ) {
-            Text(text = stringResource(R.string.dialog_ok))
-        }
-    }, dismissButton = {
-        TextButton(onClick = onDismissRequest) {
-            Text(text = stringResource(R.string.dialog_cancel))
-        }
-    })
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
 }
 
 @Composable
@@ -516,73 +574,85 @@ fun ForgetCardsDialog(
     var restorePosition by remember { mutableStateOf(true) }
     var resetCounts by remember { mutableStateOf(false) }
 
-    AlertDialog(onDismissRequest = onDismissRequest, title = {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(text = stringResource(R.string.reset_card_dialog_title))
-            IconButton(onClick = onHelpClicked) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                    contentDescription = stringResource(R.string.help),
-                )
-            }
-        }
-    }, text = {
-        val isInspection = LocalInspectionMode.current
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        shape = MaterialTheme.shapes.extraLarge,
+        title = {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .toggleable(
-                        value = restorePosition,
-                        role = Role.Checkbox,
-                        onValueChange = { restorePosition = it },
-                    )
-                    .padding(vertical = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Checkbox(
-                    checked = restorePosition,
-                    onCheckedChange = null,
+                Text(
+                    text = stringResource(R.string.reset_card_dialog_title),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleLarge,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(text = if (isInspection) "Restore position" else TR.schedulingRestorePosition())
+                IconButton(onClick = onHelpClicked) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                        contentDescription = stringResource(R.string.help),
+                    )
+                }
             }
+        },
+        text = {
+            val isInspection = LocalInspectionMode.current
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .toggleable(
+                            value = restorePosition,
+                            role = Role.Checkbox,
+                            onValueChange = { restorePosition = it },
+                        )
+                        .padding(vertical = 8.dp, horizontal = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Checkbox(
+                        checked = restorePosition,
+                        onCheckedChange = null,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = if (isInspection) "Restore position" else TR.schedulingRestorePosition())
+                }
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .toggleable(
-                        value = resetCounts,
-                        role = Role.Checkbox,
-                        onValueChange = { resetCounts = it },
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .toggleable(
+                            value = resetCounts,
+                            role = Role.Checkbox,
+                            onValueChange = { resetCounts = it },
+                        )
+                        .padding(vertical = 8.dp, horizontal = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Checkbox(
+                        checked = resetCounts,
+                        onCheckedChange = null,
                     )
-                    .padding(vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Checkbox(
-                    checked = resetCounts,
-                    onCheckedChange = null,
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(text = if (isInspection) "Reset counts" else TR.schedulingResetCounts())
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = if (isInspection) "Reset counts" else TR.schedulingResetCounts())
+                }
             }
-        }
-    }, confirmButton = {
-        TextButton(onClick = {
-            onConfirm(restorePosition, resetCounts)
-            onDismissRequest()
-        }) {
-            Text(text = stringResource(R.string.dialog_ok))
-        }
-    }, dismissButton = {
-        TextButton(onClick = onDismissRequest) {
-            Text(text = stringResource(R.string.dialog_cancel))
-        }
-    })
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm(restorePosition, resetCounts)
+                onDismissRequest()
+            }) {
+                Text(text = stringResource(R.string.dialog_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.dialog_cancel))
+            }
+        })
 }
 
 private data class GradeOption(
@@ -617,7 +687,13 @@ fun GradeNowDialog(
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
-        title = { Text(text = stringResource(R.string.sentence_grade_now)) },
+        shape = MaterialTheme.shapes.extraLarge,
+        title = {
+            Text(
+                text = stringResource(R.string.sentence_grade_now),
+                style = MaterialTheme.typography.titleLarge,
+            )
+        },
         text = {
             LazyColumn(
                 modifier = Modifier
@@ -628,11 +704,12 @@ fun GradeNowDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.medium)
                             .clickable {
                                 onConfirm(option.rating)
                                 onDismissRequest()
                             }
-                            .padding(vertical = 12.dp, horizontal = 8.dp),
+                            .padding(vertical = 12.dp, horizontal = 16.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -674,7 +751,13 @@ fun RepositionCardDialog(
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
-        title = { Text(text = stringResource(R.string.sentence_reposition_new_cards)) },
+        shape = MaterialTheme.shapes.extraLarge,
+        title = {
+            Text(
+                text = stringResource(R.string.sentence_reposition_new_cards),
+                style = MaterialTheme.typography.titleLarge,
+            )
+        },
         text = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -709,6 +792,13 @@ fun RepositionCardDialog(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
+                    shape = MaterialTheme.shapes.medium,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = Color.Transparent,
+                    ),
                 )
 
                 OutlinedTextField(
@@ -726,27 +816,50 @@ fun RepositionCardDialog(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
+                    shape = MaterialTheme.shapes.medium,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = Color.Transparent,
+                    ),
                 )
 
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .toggleable(
+                            value = randomizeOrder,
+                            role = Role.Checkbox,
+                            onValueChange = { randomizeOrder = it },
+                        )
+                        .padding(vertical = 8.dp, horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
                         checked = randomizeOrder,
-                        onCheckedChange = { randomizeOrder = it },
+                        onCheckedChange = null,
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = if (isInspection) "Randomize order" else TR.browsingRandomizeOrder())
                 }
 
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .toggleable(
+                            value = shiftPosition,
+                            role = Role.Checkbox,
+                            onValueChange = { shiftPosition = it },
+                        )
+                        .padding(horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(
                         checked = shiftPosition,
-                        onCheckedChange = { shiftPosition = it },
+                        onCheckedChange = null,
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = if (isInspection) "Shift position of existing cards" else TR.browsingShiftPositionOfExistingCards())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -176,6 +176,9 @@ fun CardBrowserDeckSelectionDialog(
                         searchQuery = searchQuery,
                     )
                 }
+                val hasAnySubDecks = remember(flatDeckList) {
+                    flatDeckList.any { it.depth > 0 || it.hasChildren }
+                }
 
                 LazyColumn(
                     modifier = Modifier
@@ -188,6 +191,7 @@ fun CardBrowserDeckSelectionDialog(
                     ) { flatItem ->
                         DeckRow(
                             flatItem = flatItem,
+                            hasAnySubDecks = hasAnySubDecks,
                             onDeckSelected = onDeckSelected,
                             onCreateSubDeck = onCreateSubDeck,
                             onToggleExpand = { deckName ->
@@ -252,6 +256,7 @@ private fun buildFlatDeckList(
 @Composable
 private fun DeckRow(
     flatItem: FlatDeckItem,
+    hasAnySubDecks: Boolean,
     onDeckSelected: (SelectableDeck.Deck) -> Unit,
     onCreateSubDeck: (DeckId) -> Unit,
     onToggleExpand: (String) -> Unit,
@@ -260,6 +265,7 @@ private fun DeckRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .heightIn(min = 48.dp)
             .clip(MaterialTheme.shapes.medium)
             .combinedClickable(
                 onClick = { onDeckSelected(deck) },
@@ -268,33 +274,38 @@ private fun DeckRow(
             .padding(vertical = 8.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
 
-        if (flatItem.hasChildren) {
-            Icon(
-                painter = painterResource(
-                    if (flatItem.isExpanded) {
-                        R.drawable.keyboard_arrow_down_24px
-                    } else {
-                        R.drawable.keyboard_arrow_right_24px
-                    },
-                ),
-                contentDescription = stringResource(
-                    if (flatItem.isExpanded) R.string.collapse else R.string.expand,
-                ),
-                modifier = Modifier
-                    .clickable { onToggleExpand(deck.name) }
-                    .padding(4.dp),
-            )
-        } else {
-            Spacer(modifier = Modifier.width(32.dp))
-        }
+
+        Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
 
         Text(
             text = deck.getDisplayName(LocalContext.current),
             modifier = Modifier.weight(1f),
             style = MaterialTheme.typography.bodyLarge,
         )
+
+        if (hasAnySubDecks) {
+            if (flatItem.hasChildren) {
+                Icon(
+                    painter = painterResource(
+                        if (flatItem.isExpanded) {
+                            R.drawable.keyboard_arrow_down_24px
+                        } else {
+                            R.drawable.keyboard_arrow_right_24px
+                        },
+                    ),
+                    contentDescription = stringResource(
+                        if (flatItem.isExpanded) R.string.collapse else R.string.expand,
+                    ),
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clickable { onToggleExpand(deck.name) }
+                        .padding(4.dp),
+                )
+            } else if (flatItem.depth > 0) {
+                Spacer(modifier = Modifier.size(32.dp))
+            }
+        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -19,7 +19,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -274,8 +273,6 @@ private fun DeckRow(
             .padding(vertical = 8.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-
-
         Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
 
         Text(
@@ -286,22 +283,20 @@ private fun DeckRow(
 
         if (hasAnySubDecks) {
             if (flatItem.hasChildren) {
-                Icon(
-                    painter = painterResource(
-                        if (flatItem.isExpanded) {
-                            R.drawable.keyboard_arrow_down_24px
-                        } else {
-                            R.drawable.keyboard_arrow_right_24px
-                        },
-                    ),
-                    contentDescription = stringResource(
-                        if (flatItem.isExpanded) R.string.collapse else R.string.expand,
-                    ),
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clickable { onToggleExpand(deck.name) }
-                        .padding(4.dp),
-                )
+                IconButton(onClick = { onToggleExpand(deck.name) }) {
+                    Icon(
+                        painter = painterResource(
+                            if (flatItem.isExpanded) {
+                                R.drawable.keyboard_arrow_down_24px
+                            } else {
+                                R.drawable.keyboard_arrow_right_24px
+                            },
+                        ),
+                        contentDescription = stringResource(
+                            if (flatItem.isExpanded) R.string.collapse else R.string.expand,
+                        ),
+                    )
+                }
             } else if (flatItem.depth > 0) {
                 Spacer(modifier = Modifier.size(32.dp))
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserDialogs.kt
@@ -126,21 +126,30 @@ fun CardBrowserDeckSelectionDialog(
                     }
                 })
 
+            val rootChildren = deckHierarchy[""] ?: emptyList()
+            val flatDeckList = remember(deckHierarchy, expandedDecks.toMap(), searchQuery) {
+                buildFlatDeckList(
+                    deckHierarchy = deckHierarchy,
+                    children = rootChildren,
+                    expandedDecks = expandedDecks,
+                    searchQuery = searchQuery
+                )
+            }
+
             LazyColumn(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(max = 300.dp)
             ) {
-                val rootChildren = deckHierarchy[""] ?: emptyList()
-                item {
-                    DeckHierarchyList(
-                        deckHierarchy = deckHierarchy,
-                        children = rootChildren,
-                        expandedDecks = expandedDecks,
+                items(
+                    items = flatDeckList, key = { it.deck.deckId }) { flatItem ->
+                    DeckRow(
+                        flatItem = flatItem,
                         onDeckSelected = onDeckSelected,
                         onCreateSubDeck = onCreateSubDeck,
-                        searchQuery = searchQuery
-                    )
+                        onToggleExpand = { deckName ->
+                            expandedDecks[deckName] = !flatItem.isExpanded
+                        })
                 }
             }
         }
@@ -151,71 +160,82 @@ fun CardBrowserDeckSelectionDialog(
     })
 }
 
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun DeckHierarchyList(
+private data class FlatDeckItem(
+    val deck: SelectableDeck.Deck, val depth: Int, val hasChildren: Boolean, val isExpanded: Boolean
+)
+
+private fun buildFlatDeckList(
     deckHierarchy: Map<String, List<SelectableDeck.Deck>>,
     children: List<SelectableDeck.Deck>,
-    expandedDecks: MutableMap<String, Boolean>,
+    expandedDecks: Map<String, Boolean>,
+    searchQuery: String,
+    flatList: MutableList<FlatDeckItem> = mutableListOf()
+): List<FlatDeckItem> {
+    for (deck in children) {
+        val isExpanded = expandedDecks[deck.name] ?: (searchQuery.isNotEmpty())
+        val hasChildren = deckHierarchy.containsKey(deck.name)
+        val parts = deck.name.split("::")
+        val depth = parts.size - 1
+
+        flatList.add(
+            FlatDeckItem(
+                deck = deck, depth = depth, hasChildren = hasChildren, isExpanded = isExpanded
+            )
+        )
+
+        if (isExpanded && hasChildren) {
+            val subChildren = deckHierarchy[deck.name] ?: emptyList()
+            buildFlatDeckList(
+                deckHierarchy = deckHierarchy,
+                children = subChildren,
+                expandedDecks = expandedDecks,
+                searchQuery = searchQuery,
+                flatList = flatList
+            )
+        }
+    }
+    return flatList
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun DeckRow(
+    flatItem: FlatDeckItem,
     onDeckSelected: (SelectableDeck.Deck) -> Unit,
     onCreateSubDeck: (DeckId) -> Unit,
-    searchQuery: String,
-    parentName: String = ""
+    onToggleExpand: (String) -> Unit
 ) {
-    Column {
-        for (deck in children) {
-            val isExpanded = expandedDecks[deck.name] ?: (searchQuery.isNotEmpty())
-            val hasChildren = deckHierarchy.containsKey(deck.name)
-            val parts = deck.name.split("::")
-            val depth = parts.size - 1
+    val deck = flatItem.deck
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = { onDeckSelected(deck) },
+                onLongClick = { onCreateSubDeck(deck.deckId) })
+            .padding(vertical = 8.dp, horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Spacer(modifier = Modifier.width((flatItem.depth * 16).dp))
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .combinedClickable(
-                        onClick = { onDeckSelected(deck) },
-                        onLongClick = { onCreateSubDeck(deck.deckId) })
-                    .padding(vertical = 8.dp, horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Spacer(modifier = Modifier.width((depth * 16).dp))
-
-                if (hasChildren) {
-                    Icon(
-                        painter = painterResource(
-                        if (isExpanded) R.drawable.keyboard_arrow_down_24px
-                        else R.drawable.keyboard_arrow_right_24px
-                    ),
-                        contentDescription = stringResource(
-                            if (isExpanded) R.string.collapse else R.string.expand
-                        ),
-                        modifier = Modifier
-                            .clickable { expandedDecks[deck.name] = !isExpanded }
-                            .padding(4.dp))
-                } else {
-                    Spacer(modifier = Modifier.width(32.dp))
-                }
-
-                Text(
-                    text = deck.getDisplayName(LocalContext.current),
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            }
-
-            if (isExpanded && hasChildren) {
-                val subChildren = deckHierarchy[deck.name] ?: emptyList()
-                DeckHierarchyList(
-                    deckHierarchy = deckHierarchy,
-                    children = subChildren,
-                    expandedDecks = expandedDecks,
-                    onDeckSelected = onDeckSelected,
-                    onCreateSubDeck = onCreateSubDeck,
-                    searchQuery = searchQuery,
-                    parentName = deck.name
-                )
-            }
+        if (flatItem.hasChildren) {
+            Icon(
+                painter = painterResource(
+                if (flatItem.isExpanded) R.drawable.keyboard_arrow_down_24px
+                else R.drawable.keyboard_arrow_right_24px
+            ), contentDescription = stringResource(
+                if (flatItem.isExpanded) R.string.collapse else R.string.expand
+            ), modifier = Modifier
+                    .clickable { onToggleExpand(deck.name) }
+                    .padding(4.dp))
+        } else {
+            Spacer(modifier = Modifier.width(32.dp))
         }
+
+        Text(
+            text = deck.getDisplayName(LocalContext.current),
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyLarge
+        )
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -70,6 +70,7 @@ import com.ichi2.anki.ui.compose.navigation.AnkiNavigationRail
 import com.ichi2.anki.ui.compose.navigation.AppNavigationItem
 import com.ichi2.anki.utils.ext.showDialogFragment
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @OptIn(
     ExperimentalMaterial3Api::class,
@@ -154,15 +155,30 @@ fun CardBrowserLayout(
             viewModel.showDeckSelectionDialog(false)
             val did = deck.deckId
             coroutineScope.launch {
-                val changed = viewModel.moveSelectedCardsToDeck(did).await()
-                viewModel.launchSearchForCards()
-                val message = activity?.resources?.getQuantityString(
-                    R.plurals.card_browser_cards_moved, changed.count, changed.count
-                ) ?: ""
-                viewModel.emitSnackbarMessage(
-                    message, activity?.getString(R.string.undo)
-                ) {
-                    viewModel.undo()
+                try {
+                    val changed = viewModel.moveSelectedCardsToDeck(did).await()
+                    viewModel.launchSearchForCards()
+                    if (activity != null) {
+                        val message =
+                            activity.resources.getQuantityString(
+                                R.plurals.card_browser_cards_moved,
+                                changed.count,
+                                changed.count,
+                            )
+                        viewModel.emitSnackbarMessage(
+                            message,
+                            activity.getString(R.string.undo),
+                        ) {
+                            viewModel.undo()
+                        }
+                    }
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to move cards to deck")
+                    if (activity != null) {
+                        viewModel.emitSnackbarMessage(
+                            activity.getString(R.string.card_browser_move_cards_failed),
+                        )
+                    }
                 }
             }
         }, onDismissRequest = { viewModel.showDeckSelectionDialog(false) }, onCreateDeck = {
@@ -204,12 +220,13 @@ fun CardBrowserLayout(
     if (showForgetCardsDialog) {
         ForgetCardsDialog(
             onHelpClicked = {
-            (activity as? AnkiActivity)?.openUrl(R.string.link_help_forget_cards)
-        },
+                (activity as? AnkiActivity)?.openUrl(R.string.link_help_forget_cards)
+            },
             onDismissRequest = { viewModel.showForgetCardsDialog(false) },
             onConfirm = { restorePosition, resetCounts ->
                 viewModel.forgetSelectedCards(restorePosition, resetCounts)
-            })
+            },
+        )
     }
 
     // Grade Now Dialog
@@ -232,7 +249,8 @@ fun CardBrowserLayout(
                 onConfirm = { position, step, random, shift ->
                     viewModel.repositionSelectedCards(position, step, random, shift)
                 },
-                onDismissRequest = { viewModel.showRepositionDialog(CardBrowserViewModel.RepositionDialogState.Hidden) })
+                onDismissRequest = { viewModel.showRepositionDialog(CardBrowserViewModel.RepositionDialogState.Hidden) },
+            )
         }
 
         CardBrowserViewModel.RepositionDialogState.Hidden -> {}
@@ -248,21 +266,24 @@ fun CardBrowserLayout(
                         AppNavigationItem.CardBrowser -> { // Already here
                         }
 
-                        AppNavigationItem.Statistics -> activity?.startActivity(
-                            Statistics.getIntent(
-                                activity,
-                            ),
-                        )
+                        AppNavigationItem.Statistics ->
+                            activity?.startActivity(
+                                Statistics.getIntent(
+                                    activity,
+                                ),
+                            )
 
-                        AppNavigationItem.Settings -> activity?.startActivity(
-                            PreferencesActivity.getIntent(
-                                activity,
-                            ),
-                        )
+                        AppNavigationItem.Settings ->
+                            activity?.startActivity(
+                                PreferencesActivity.getIntent(
+                                    activity,
+                                ),
+                            )
 
-                        AppNavigationItem.Help -> (activity as? AnkiActivity)?.showDialogFragment(
-                            HelpDialog.newHelpInstance(),
-                        )
+                        AppNavigationItem.Help ->
+                            (activity as? AnkiActivity)?.showDialogFragment(
+                                HelpDialog.newHelpInstance(),
+                            )
 
                         AppNavigationItem.Support -> {
                             val uri =
@@ -278,14 +299,17 @@ fun CardBrowserLayout(
             topBar = {
                 TopAppBar(title = {
                     Row(
-                        modifier = Modifier.graphicsLayer {
-                            alpha = 1f - searchAnim
-                        },
+                        modifier =
+                            Modifier.graphicsLayer {
+                                alpha = 1f - searchAnim
+                            },
                     ) {
                         DeckSelector(
-                            selectedDeck = viewModel.flowOfDeckSelection.collectAsStateWithLifecycle(
-                                null,
-                            ).value,
+                            selectedDeck =
+                                viewModel.flowOfDeckSelection
+                                    .collectAsStateWithLifecycle(
+                                        null,
+                                    ).value,
                             availableDecks = availableDecks,
                             onDeckSelected = { deck ->
                                 coroutineScope.launch {
@@ -298,10 +322,11 @@ fun CardBrowserLayout(
                     if (!isSearchOpen) {
                         FilledIconButton(
                             onClick = onNavigateUp,
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            ),
+                            colors =
+                                IconButtonDefaults.filledIconButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                ),
                         ) {
                             Icon(
                                 painter = painterResource(R.drawable.arrow_back_24px),
@@ -324,10 +349,11 @@ fun CardBrowserLayout(
                             placeholder = stringResource(R.string.card_browser_search_hint),
                             focusRequester = focusRequester,
                             searchAnim = searchAnim,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(start = 10.dp, end = 6.dp, bottom = 16.dp),
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(start = 10.dp, end = 6.dp, bottom = 16.dp),
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                         )
                     } else {
                         FilledTonalIconButton(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -125,9 +125,7 @@ fun CardBrowserLayout(
     }
 
     LaunchedEffect(showDeckSelectionDialog, createDeckDialogState) {
-        if (showDeckSelectionDialog) {
-            availableDecks = viewModel.getAvailableDecks()
-        }
+        availableDecks = viewModel.getAvailableDecks()
     }
 
     BackHandler(isSearchOpen) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -51,7 +51,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.BrowserRowWithId
 import com.ichi2.anki.browser.CardBrowserViewModel
@@ -60,6 +62,7 @@ import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.Statistics
 import com.ichi2.anki.preferences.PreferencesActivity
+import com.ichi2.anki.scheduling.SetDueDateViewModel
 import com.ichi2.anki.ui.compose.components.AnkiSearchBar
 import com.ichi2.anki.ui.compose.components.DeckSelector
 import com.ichi2.anki.ui.compose.navigation.AnkiNavigationRail
@@ -141,6 +144,96 @@ fun CardBrowserLayout(
         }
 
         CardBrowserViewModel.CreateDeckDialogState.Hidden -> {}
+    }
+
+    // Deck Selection Dialog
+    val showDeckSelectionDialog by viewModel.showDeckSelectionDialog.collectAsStateWithLifecycle()
+    if (showDeckSelectionDialog) {
+        CardBrowserDeckSelectionDialog(availableDecks = availableDecks, onDeckSelected = { deck ->
+            viewModel.showDeckSelectionDialog(false)
+            val did = deck.deckId
+            coroutineScope.launch {
+                val changed = viewModel.moveSelectedCardsToDeck(did).await()
+                viewModel.launchSearchForCards()
+                val message = activity?.resources?.getQuantityString(
+                    R.plurals.card_browser_cards_moved, changed.count, changed.count
+                ) ?: ""
+                viewModel.emitSnackbarMessage(
+                    message, activity?.getString(R.string.undo)
+                ) {
+                    viewModel.undo()
+                }
+            }
+        }, onDismissRequest = { viewModel.showDeckSelectionDialog(false) }, onCreateDeck = {
+            viewModel.showDeckSelectionDialog(false)
+            viewModel.showCreateDeckDialog()
+        }, onCreateSubDeck = { parentId ->
+            viewModel.showDeckSelectionDialog(false)
+            viewModel.showCreateSubDeckDialog(parentId)
+        })
+    }
+
+    // Set Due Date Dialog
+    val showSetDueDateDialog by viewModel.showSetDueDateDialog.collectAsStateWithLifecycle()
+    if (showSetDueDateDialog) {
+        val setDueDateViewModel = viewModel<SetDueDateViewModel>()
+        LaunchedEffect(Unit) {
+            val cardIds = viewModel.queryAllSelectedCardIds()
+            val fsrsEnabled = com.ichi2.anki.servicelayer.getFSRSStatus() ?: false
+            setDueDateViewModel.init(cardIds.toLongArray(), fsrsEnabled)
+        }
+
+        SetDueDateDialog(viewModel = setDueDateViewModel, onHelpClicked = {
+            (activity as? AnkiActivity)?.openUrl(R.string.link_set_due_date_help)
+        }, onDismissRequest = { viewModel.showSetDueDateDialog(false) }, onConfirm = {
+            coroutineScope.launch {
+                val count = setDueDateViewModel.updateDueDateAsync().await()
+                if (count != null) {
+                    val message = TR.schedulingSetDueDateDone(count)
+                    viewModel.emitSnackbarMessage(message)
+                    viewModel.launchSearchForCards()
+                }
+            }
+        })
+    }
+
+    // Forget Cards Dialog
+    val showForgetCardsDialog by viewModel.showForgetCardsDialog.collectAsStateWithLifecycle()
+    if (showForgetCardsDialog) {
+        ForgetCardsDialog(
+            onHelpClicked = {
+            (activity as? AnkiActivity)?.openUrl(R.string.link_help_forget_cards)
+        },
+            onDismissRequest = { viewModel.showForgetCardsDialog(false) },
+            onConfirm = { restorePosition, resetCounts ->
+                viewModel.forgetSelectedCards(restorePosition, resetCounts)
+            })
+    }
+
+    // Grade Now Dialog
+    val showGradeNowDialog by viewModel.showGradeNowDialog.collectAsStateWithLifecycle()
+    if (showGradeNowDialog) {
+        GradeNowDialog(onConfirm = { rating ->
+            viewModel.gradeSelectedCards(rating)
+        }, onDismissRequest = { viewModel.showGradeNowDialog(false) })
+    }
+
+    // Reposition Cards Dialog
+    val repositionDialogState by viewModel.repositionDialogState.collectAsStateWithLifecycle()
+    when (val state = repositionDialogState) {
+        is CardBrowserViewModel.RepositionDialogState.Visible -> {
+            RepositionCardDialog(
+                queueTop = state.queueTop,
+                queueBottom = state.queueBottom,
+                initialRandom = state.random,
+                initialShift = state.shift,
+                onConfirm = { position, step, random, shift ->
+                    viewModel.repositionSelectedCards(position, step, random, shift)
+                },
+                onDismissRequest = { viewModel.showRepositionDialog(CardBrowserViewModel.RepositionDialogState.Hidden) })
+        }
+
+        CardBrowserViewModel.RepositionDialogState.Hidden -> {}
     }
 
     Row(modifier = Modifier.fillMaxSize()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -63,6 +63,7 @@ import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.Statistics
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.scheduling.SetDueDateViewModel
+import com.ichi2.anki.servicelayer.getFSRSStatus
 import com.ichi2.anki.ui.compose.components.AnkiSearchBar
 import com.ichi2.anki.ui.compose.components.DeckSelector
 import com.ichi2.anki.ui.compose.navigation.AnkiNavigationRail
@@ -179,7 +180,7 @@ fun CardBrowserLayout(
         val setDueDateViewModel = viewModel<SetDueDateViewModel>()
         LaunchedEffect(Unit) {
             val cardIds = viewModel.queryAllSelectedCardIds()
-            val fsrsEnabled = com.ichi2.anki.servicelayer.getFSRSStatus() ?: false
+            val fsrsEnabled = getFSRSStatus() ?: false
             setDueDateViewModel.init(cardIds.toLongArray(), fsrsEnabled)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -102,6 +102,8 @@ fun CardBrowserLayout(
     val isSearchOpen by viewModel.flowOfSearchQueryExpanded.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     var availableDecks by remember { mutableStateOf<List<SelectableDeck.Deck>>(emptyList()) }
+    val createDeckDialogState by viewModel.createDeckDialogState.collectAsStateWithLifecycle()
+    val showDeckSelectionDialog by viewModel.showDeckSelectionDialog.collectAsStateWithLifecycle()
     val searchAnim by animateFloatAsState(
         targetValue = if (isSearchOpen) 1f else 0f,
         animationSpec = motionScheme.defaultEffectsSpec(),
@@ -122,8 +124,10 @@ fun CardBrowserLayout(
         }
     }
 
-    LaunchedEffect(Unit) {
-        availableDecks = viewModel.getAvailableDecks()
+    LaunchedEffect(showDeckSelectionDialog, createDeckDialogState) {
+        if (showDeckSelectionDialog) {
+            availableDecks = viewModel.getAvailableDecks()
+        }
     }
 
     BackHandler(isSearchOpen) {
@@ -131,7 +135,6 @@ fun CardBrowserLayout(
     }
 
     // Create Deck Dialog
-    val createDeckDialogState by viewModel.createDeckDialogState.collectAsStateWithLifecycle()
     when (val state = createDeckDialogState) {
         is CardBrowserViewModel.CreateDeckDialogState.Visible -> {
             CreateDeckDialog(
@@ -148,7 +151,6 @@ fun CardBrowserLayout(
     }
 
     // Deck Selection Dialog
-    val showDeckSelectionDialog by viewModel.showDeckSelectionDialog.collectAsStateWithLifecycle()
     if (showDeckSelectionDialog) {
         CardBrowserDeckSelectionDialog(availableDecks = availableDecks, onDeckSelected = { deck ->
             viewModel.showDeckSelectionDialog(false)
@@ -169,7 +171,6 @@ fun CardBrowserLayout(
             viewModel.showDeckSelectionDialog(false)
             viewModel.showCreateDeckDialog()
         }, onCreateSubDeck = { parentId ->
-            viewModel.showDeckSelectionDialog(false)
             viewModel.showCreateSubDeckDialog(parentId)
         })
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/compose/CardBrowserLayout.kt
@@ -169,6 +169,7 @@ fun CardBrowserLayout(
             viewModel.showDeckSelectionDialog(false)
             viewModel.showCreateDeckDialog()
         }, onCreateSubDeck = { parentId ->
+            viewModel.showDeckSelectionDialog(false)
             viewModel.showCreateSubDeckDialog(parentId)
         })
     }
@@ -192,6 +193,7 @@ fun CardBrowserLayout(
                     val message = TR.schedulingSetDueDateDone(count)
                     viewModel.emitSnackbarMessage(message)
                     viewModel.launchSearchForCards()
+                    viewModel.showSetDueDateDialog(false)
                 }
             }
         })

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -53,7 +53,7 @@ class SetDueDateViewModel : ViewModel() {
     val isValidFlow = MutableStateFlow(false)
 
     /** The cards to change the due date of */
-    lateinit var cardIds: List<CardId>
+    var cardIds: List<CardId> = emptyList()
 
     /** Whether the Free Spaced Repetition Scheduler is enabled */
     // initialized in init()
@@ -85,12 +85,11 @@ class SetDueDateViewModel : ViewModel() {
     /** The number of days in the future if we are on [Tab.SINGLE_DAY] */
     var nextSingleDayDueDate: NumberOfDaysInFuture? = null
         set(value) {
-            field =
-                if (value != null && value >= 0) {
-                    value
-                } else {
-                    null
-                }
+            field = if (value != null && value >= 0) {
+                value
+            } else {
+                null
+            }
             Timber.d("update SINGLE_DAY to %s", field)
             refreshIsValid()
         }
@@ -172,20 +171,18 @@ class SetDueDateViewModel : ViewModel() {
     }
 
     private fun refreshIsValid() {
-        val isValid =
-            when (currentTab) {
-                Tab.SINGLE_DAY -> nextSingleDayDueDate.let { it != null && it >= 0 }
-                Tab.DATE_RANGE -> dateRange.isValid()
-            }
+        val isValid = when (currentTab) {
+            Tab.SINGLE_DAY -> nextSingleDayDueDate.let { it != null && it >= 0 }
+            Tab.DATE_RANGE -> dateRange.isValid()
+        }
         isValidFlow.update { isValid }
     }
 
     fun calculateDaysParameter(): SetDueDateDays? {
-        val dateRange =
-            when (currentTab) {
-                Tab.SINGLE_DAY -> nextSingleDayDueDate?.let { "$it" }
-                Tab.DATE_RANGE -> dateRange.toDaysParameter()
-            } ?: return null
+        val dateRange = when (currentTab) {
+            Tab.SINGLE_DAY -> nextSingleDayDueDate?.let { "$it" }
+            Tab.DATE_RANGE -> dateRange.toDaysParameter()
+        } ?: return null
 
         // add a "!" suffix if necessary
         val param = if (this.updateIntervalToMatchDueDate) "$dateRange!" else dateRange
@@ -196,14 +193,13 @@ class SetDueDateViewModel : ViewModel() {
      * Updates the due date of [cardIds] based on the current state.
      * @return The number of cards affected, or `null` if an error occurred
      */
-    fun updateDueDateAsync() =
-        viewModelScope.async {
-            val days = calculateDaysParameter() ?: return@async null
-            // TODO: Provide a config parameter - we can use this to set a 'last used value' in the UI
-            // when the screen is opened
-            undoableOp { sched.setDueDate(cardIds, days) }
-            return@async cardIds.size
-        }
+    fun updateDueDateAsync() = viewModelScope.async {
+        val days = calculateDaysParameter() ?: return@async null
+        // TODO: Provide a config parameter - we can use this to set a 'last used value' in the UI
+        // when the screen is opened
+        undoableOp { sched.setDueDate(cardIds, days) }
+        return@async cardIds.size
+    }
 
     enum class Tab(
         val position: Int,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.libanki.sched.SetDueDateDays
 import com.ichi2.anki.observability.undoableOp
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -52,9 +53,14 @@ class SetDueDateViewModel : ViewModel() {
     /** Whether the value may be submitted */
     val isValidFlow = MutableStateFlow(false)
 
-    val singleDayText = MutableStateFlow("")
-    val startText = MutableStateFlow("")
-    val endText = MutableStateFlow("")
+    private val _singleDayText = MutableStateFlow("")
+    val singleDayText = _singleDayText.asStateFlow()
+
+    private val _startText = MutableStateFlow("")
+    val startText = _startText.asStateFlow()
+
+    private val _endText = MutableStateFlow("")
+    val endText = _endText.asStateFlow()
 
     /** The cards to change the due date of */
     var cardIds: List<CardId> = emptyList()
@@ -145,9 +151,9 @@ class SetDueDateViewModel : ViewModel() {
         this.nextSingleDayDueDate = null
         this.dateRange = DateRange()
         this.currentTab = Tab.SINGLE_DAY
-        this.singleDayText.value = ""
-        this.startText.value = ""
-        this.endText.value = ""
+        this._singleDayText.value = ""
+        this._startText.value = ""
+        this._endText.value = ""
         this.updateIntervalToMatchDueDate = fsrsEnabled
 
         initCurrentInterval(cardIds)
@@ -180,6 +186,18 @@ class SetDueDateViewModel : ViewModel() {
         Timber.d("updated date range end to %s", value)
         dateRange.end = value
         refreshIsValid()
+    }
+
+    fun setSingleDayText(text: String) {
+        _singleDayText.value = text
+    }
+
+    fun setStartText(text: String) {
+        _startText.value = text
+    }
+
+    fun setEndText(text: String) {
+        _endText.value = text
     }
 
     private fun refreshIsValid() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -52,6 +52,10 @@ class SetDueDateViewModel : ViewModel() {
     /** Whether the value may be submitted */
     val isValidFlow = MutableStateFlow(false)
 
+    val singleDayText = MutableStateFlow("")
+    val startText = MutableStateFlow("")
+    val endText = MutableStateFlow("")
+
     /** The cards to change the due date of */
     var cardIds: List<CardId> = emptyList()
 
@@ -85,11 +89,12 @@ class SetDueDateViewModel : ViewModel() {
     /** The number of days in the future if we are on [Tab.SINGLE_DAY] */
     var nextSingleDayDueDate: NumberOfDaysInFuture? = null
         set(value) {
-            field = if (value != null && value >= 0) {
-                value
-            } else {
-                null
-            }
+            field =
+                if (value != null && value >= 0) {
+                    value
+                } else {
+                    null
+                }
             Timber.d("update SINGLE_DAY to %s", field)
             refreshIsValid()
         }
@@ -137,6 +142,13 @@ class SetDueDateViewModel : ViewModel() {
     ) {
         this.cardIds = cardIds.toList()
         this.fsrsEnabled = fsrsEnabled
+        this.nextSingleDayDueDate = null
+        this.dateRange = DateRange()
+        this.currentTab = Tab.SINGLE_DAY
+        this.singleDayText.value = ""
+        this.startText.value = ""
+        this.endText.value = ""
+        this.updateIntervalToMatchDueDate = fsrsEnabled
 
         initCurrentInterval(cardIds)
     }
@@ -171,18 +183,20 @@ class SetDueDateViewModel : ViewModel() {
     }
 
     private fun refreshIsValid() {
-        val isValid = when (currentTab) {
-            Tab.SINGLE_DAY -> nextSingleDayDueDate.let { it != null && it >= 0 }
-            Tab.DATE_RANGE -> dateRange.isValid()
-        }
+        val isValid =
+            when (currentTab) {
+                Tab.SINGLE_DAY -> nextSingleDayDueDate.let { it != null && it >= 0 }
+                Tab.DATE_RANGE -> dateRange.isValid()
+            }
         isValidFlow.update { isValid }
     }
 
     fun calculateDaysParameter(): SetDueDateDays? {
-        val dateRange = when (currentTab) {
-            Tab.SINGLE_DAY -> nextSingleDayDueDate?.let { "$it" }
-            Tab.DATE_RANGE -> dateRange.toDaysParameter()
-        } ?: return null
+        val dateRange =
+            when (currentTab) {
+                Tab.SINGLE_DAY -> nextSingleDayDueDate?.let { "$it" }
+                Tab.DATE_RANGE -> dateRange.toDaysParameter()
+            } ?: return null
 
         // add a "!" suffix if necessary
         val param = if (this.updateIntervalToMatchDueDate) "$dateRange!" else dateRange
@@ -193,13 +207,14 @@ class SetDueDateViewModel : ViewModel() {
      * Updates the due date of [cardIds] based on the current state.
      * @return The number of cards affected, or `null` if an error occurred
      */
-    fun updateDueDateAsync() = viewModelScope.async {
-        val days = calculateDaysParameter() ?: return@async null
-        // TODO: Provide a config parameter - we can use this to set a 'last used value' in the UI
-        // when the screen is opened
-        undoableOp { sched.setDueDate(cardIds, days) }
-        return@async cardIds.size
-    }
+    fun updateDueDateAsync() =
+        viewModelScope.async {
+            val days = calculateDaysParameter() ?: return@async null
+            // TODO: Provide a config parameter - we can use this to set a 'last used value' in the UI
+            // when the screen is opened
+            undoableOp { sched.setDueDate(cardIds, days) }
+            return@async cardIds.size
+        }
 
     enum class Tab(
         val position: Int,

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -496,4 +496,11 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <string name="history">History</string>
     <string name="heatmap_widget_description">A widget displaying your review heatmap.</string>
     <string name="heatmap_widget_label">Review Heatmap</string>
+    <string name="reposition_description">Change when these new cards will be shown for review. Cards with lower queue numbers are shown sooner.</string>
+    <string name="reposition_current_queue_bounds">Current Queue Bounds</string>
+    <string name="reposition_start_position_help">The queue position assigned to the first card. Values closer to %1$d appear sooner.</string>
+    <string name="reposition_step_help">Spacing between cards in the queue. 1 places them next to each other; higher numbers spread them out.</string>
+    <string name="reposition_randomize_order_help">Shuffle cards randomly instead of keeping their current sequence.</string>
+    <string name="reposition_shift_position_help">Push existing cards down the queue to insert these cards cleanly. Otherwise, positions are shared.</string>
+    <string name="card_browser_move_cards_failed">Failed to move cards to deck</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -110,4 +110,6 @@
         <item>https://ankiweb.net/account/verify-email</item>
     </string-array>
     <string name="image_occlusion_notetype_missing">No Image Occlusion note type found</string>
+    <string name="single_day">Single Day</string>
+    <string name="date_range">Date Range</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateViewModelTest.kt
@@ -166,6 +166,31 @@ class SetDueDateViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `init resets state`() =
+        runViewModelTest {
+            nextSingleDayDueDate = 5
+            setNextDateRangeStart(2)
+            setNextDateRangeEnd(4)
+            currentTab = Tab.DATE_RANGE
+            singleDayText.value = "5"
+            startText.value = "2"
+            endText.value = "4"
+            updateIntervalToMatchDueDate = true
+
+            // Re-init
+            init(longArrayOf(1, 2), fsrsEnabled = false)
+
+            assertThat(nextSingleDayDueDate, equalTo(null))
+            assertThat(dateRange.start, equalTo(null))
+            assertThat(dateRange.end, equalTo(null))
+            assertThat(currentTab, equalTo(Tab.SINGLE_DAY))
+            assertThat(singleDayText.value, equalTo(""))
+            assertThat(startText.value, equalTo(""))
+            assertThat(endText.value, equalTo(""))
+            assertThat(updateIntervalToMatchDueDate, equalTo(false))
+        }
+
     private fun runViewModelTest(
         cardIds: List<CardId> = listOf(1, 2, 3),
         fsrsEnabled: Boolean = false,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateViewModelTest.kt
@@ -173,9 +173,9 @@ class SetDueDateViewModelTest : JvmTest() {
             setNextDateRangeStart(2)
             setNextDateRangeEnd(4)
             currentTab = Tab.DATE_RANGE
-            singleDayText.value = "5"
-            startText.value = "2"
-            endText.value = "4"
+            setSingleDayText("5")
+            setStartText("2")
+            setEndText("4")
             updateIntervalToMatchDueDate = true
 
             // Re-init


### PR DESCRIPTION
This pull request refactors the card browser and deck picker flows to remove legacy dialog interfaces and move dialog state management into the `CardBrowserViewModel`. Dialogs such as deck selection, set due date, forget cards, grade now, and reposition cards are now managed via Compose state flows, making the UI more modular and testable. The changes also remove now-unnecessary interface implementations and method overrides from `CardBrowser` and `DeckPicker`.

Key changes include:

**Dialog and Listener Refactoring:**
* Removed `DeckSelectionDialog.DeckSelectionListener` and `TagsDialogListener` implementations and related method overrides from `CardBrowser` and `DeckPicker`, as dialog interactions are now managed via Compose state flows. [[1]](diffhunk://#diff-91eab2cd3fb46766a8140f7ec139f5517303160babd3cd1d869c5763c992ca82L68-R64) [[2]](diffhunk://#diff-91eab2cd3fb46766a8140f7ec139f5517303160babd3cd1d869c5763c992ca82L345-L355) [[3]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL207-R207) [[4]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL1733-L1744)
* Removed unused imports and code related to legacy dialog interfaces and models in `CardBrowser.kt`, `DeckPicker.kt`, and `CardBrowserActionHandler.kt`. [[1]](diffhunk://#diff-91eab2cd3fb46766a8140f7ec139f5517303160babd3cd1d869c5763c992ca82L49-L54) [[2]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L23-L37)

**Dialog State Management in ViewModel:**
* Added Compose dialog state flows (`showDeckSelectionDialog`, `showSetDueDateDialog`, `showForgetCardsDialog`, `showGradeNowDialog`, `showExportDialog`, and `repositionDialogState`) to `CardBrowserViewModel`, with corresponding show/hide methods.
* Added Compose database operations (`forgetSelectedCards`, `gradeSelectedCards`, `repositionSelectedCards`) to `CardBrowserViewModel` for dialog actions.

**Action Handler Updates:**
* Updated `CardBrowserActionHandler` to trigger dialog state in the ViewModel instead of showing dialogs directly, e.g., `showDeckSelectionDialog`, `showSetDueDateDialog`, `showForgetCardsDialog`, `showGradeNowDialog`, and `showRepositionDialog`. [[1]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L51-R57) [[2]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L150-R96) [[3]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L165-R111)

**Compose UI Integration:**
* Updated `CardBrowserLayout` to observe the new dialog state flows from the ViewModel, ensuring dialogs are shown/hidden reactively in Compose. [[1]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970R54-R56) [[2]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970R65-R66) [[3]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970R105-R106) [[4]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970L121-R127) [[5]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970L130)

These changes modernize dialog handling in the card browser, improve code separation, and pave the way for a more robust and maintainable Compose-based UI.

**References:** [[1]](diffhunk://#diff-91eab2cd3fb46766a8140f7ec139f5517303160babd3cd1d869c5763c992ca82L68-R64) [[2]](diffhunk://#diff-91eab2cd3fb46766a8140f7ec139f5517303160babd3cd1d869c5763c992ca82L345-L355) [[3]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL207-R207) [[4]](diffhunk://#diff-1c9f8440ee3813eda89e500bf5db95d90730eda462a22fb54b2d832e8fb06e2cL1733-L1744) [[5]](diffhunk://#diff-91eab2cd3fb46766a8140f7ec139f5517303160babd3cd1d869c5763c992ca82L49-L54) [[6]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L23-L37) [[7]](diffhunk://#diff-8459cb71629465788433e97cf5345ec34b3d592924ff46fd59514dcdcac3877bR284-R414) [[8]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L51-R57) [[9]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L150-R96) [[10]](diffhunk://#diff-9773d1c8eb9423548b5ce0acfe40d2ac4689899aaa014cc9ee465b34a7c1d947L165-R111) [[11]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970R54-R56) [[12]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970R65-R66) [[13]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970R105-R106) [[14]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970L121-R127) [[15]](diffhunk://#diff-a62c1e3c30aa0e4faf7a2f48ae633d29f250b19546a3ea77b3d5cf825b1ae970L130)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Compose-based dialogs in the card browser for deck selection, due date setting (Single Day/Date Range), forgetting cards, “grade now,” and repositioning cards, including reposition help prompts and undo-capable feedback.
* **Refactor**
  * Card browser actions now route dialog display and selection-based operations through the browser’s view model for more consistent user feedback.
* **Bug Fixes**
  * Due-date dialog initialization now reliably resets all fields to prevent stale inputs.
* **Documentation**
  * Added new “Single Day”/“Date Range” labels and reposition help/error text.
* **Tests**
  * Added a unit test covering due-date initialization state reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->