### PR TITLE
feat(progress-dialog): display sync progress in MB

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -21,6 +21,7 @@ import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.net.Uri
+import android.text.format.Formatter
 import android.view.WindowManager
 import android.view.WindowManager.BadTokenException
 import androidx.annotation.StringRes
@@ -334,6 +335,7 @@ suspend fun HelpAction.execute(context: Context): Boolean {
  * progress UI.
  */
 suspend fun <T> Backend.withProgress(
+    progressContext: ProgressContext,
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
     block: suspend CoroutineScope.() -> T,
@@ -341,7 +343,7 @@ suspend fun <T> Backend.withProgress(
     coroutineScope {
         val monitor =
             launch {
-                monitorProgress(this@withProgress, extractProgress, updateUi)
+                progressContext.monitorProgress(this@withProgress, extractProgress, updateUi)
             }
         try {
             block()
@@ -358,6 +360,7 @@ suspend fun <T> Backend.withProgress(
  * flashes of a dialog.
  */
 suspend fun <T> FragmentActivity.withProgress(
+    progressContext: ProgressContext = ProgressContext(),
     extractProgress: ProgressContext.() -> Unit,
     onCancel: ((Backend) -> Unit)? = { it.setWantsAbort() },
     @StringRes manualCancelButton: Int? = null,
@@ -377,6 +380,7 @@ suspend fun <T> FragmentActivity.withProgress(
         manualCancelButton = manualCancelButton,
     ) { dialog ->
         backend.withProgress(
+            progressContext = progressContext,
             extractProgress = extractProgress,
             updateUi = { updateDialog(dialog) },
         ) {
@@ -506,12 +510,12 @@ private fun dismissDialogIfShowing(dialog: Dialog) {
  * [ProgressContext]. Calls updateUi() to update the UI with the extracted
  * progress.
  */
-private suspend fun monitorProgress(
+private suspend fun ProgressContext.monitorProgress(
     backend: Backend,
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
 ) {
-    val state = ProgressContext(Progress.getDefaultInstance())
+    val state = this
     while (true) {
         state.progress =
             withContext(Dispatchers.IO) {
@@ -526,28 +530,56 @@ private suspend fun monitorProgress(
     }
 }
 
-/** Holds the current backend progress, and text/amount properties
+/**
+ * Holds the current backend progress, and text/amount properties
  * that can be written to in order to update the UI.
  */
 data class ProgressContext(
-    var progress: Progress,
-    var text: String = "",
-    /** If set, shows progress bar with a of b complete. */
-    var amount: Pair<Int, Int>? = null,
-)
-
-@Suppress("Deprecation") // ProgressDialog deprecation
-private fun ProgressContext.updateDialog(dialog: android.app.ProgressDialog) {
-    // ideally this would show a progress bar, but MaterialDialog does not support
-    // setting progress after starting with indeterminate progress, so we just use
-    // this for now
-    // this code has since been updated to ProgressDialog, and the above not rechecked
-    val progressText =
-        amount?.let {
-            " ${it.first}/${it.second}"
-        } ?: ""
+    var progress: Progress = Progress.getDefaultInstance(),
+    var text: String? = null,
+    /** If set, shows a progress bar with `current` of `max` complete. */
+    var amount: Amount? = null,
+    val formatAmount: (Amount) -> String = { (current, max) -> "$current/$max" },
+    /** Separator between [text] and [amount] */
+    val separator: String = " ",
+) {
     @Suppress("Deprecation") // ProgressDialog deprecation
-    dialog.setMessage(text + progressText)
+    fun updateDialog(dialog: android.app.ProgressDialog) {
+        val message =
+            listOfNotNull(
+                text,
+                amount?.let { formatAmount(it) },
+            ).joinToString(separator)
+        dialog.setMessage(message)
+    }
+
+    companion object {
+        /**
+         * A [com.ichi2.anki.ProgressContext] which formats progress as bytes:
+         *
+         * `28 MB/141 MB`
+         */
+        fun ofBytes(context: Context) =
+            ProgressContext(
+                formatAmount = { (current, max) ->
+                    // replace spaces with NBSP so newlines are handled better
+                    val curStr = Formatter.formatShortFileSize(context, current).replace(' ', '\u00A0')
+                    val maxStr = Formatter.formatShortFileSize(context, max).replace(' ', '\u00A0')
+                    context.getString(R.string.progress_amount_bytes, curStr, maxStr)
+                },
+            )
+    }
+
+    /**
+     * Represents a progress value and a maximum limit.
+     *
+     * @see ProgressContext
+     */
+    // values are 'Long' as this can represent bytes.
+    data class Amount(
+        val current: Long,
+        val max: Long,
+    )
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -25,7 +25,6 @@ import android.text.format.Formatter
 import android.view.WindowManager
 import android.view.WindowManager.BadTokenException
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
@@ -69,6 +68,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import net.ankiweb.rsdroid.Backend
@@ -81,8 +81,8 @@ import timber.log.Timber
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /** Overridable reference to [Dispatchers.IO]. Useful if tests can't use it */
 // COULD_BE_BETTER: this shouldn't be necessary, but TestClass::runWith needs it
@@ -289,7 +289,7 @@ fun Context.showError(
                     setOnDismissListener { crashReportData.sendCrashReport() }
                 }
             }.apply {
-                // setup the help link. Link is non-null if neutralButton exists.
+                // set up the help link. Link is non-null if neutralButton exists.
                 setOnShowListener {
                     neutralButton?.setOnClickListener {
                         lifecycle.coroutineScope.launch {
@@ -460,7 +460,7 @@ suspend fun <T> withProgressDialog(
         var dialogIsOurs = false
         val dialogJob =
             launch {
-                delay(delayMillis)
+                delay(delayMillis.milliseconds)
                 if (!AnkiDroidApp.instance.progressDialogShown) {
                     Timber.i(
                         """Displaying progress dialog: ${delayMillis}ms elapsed; 
@@ -526,7 +526,7 @@ private suspend fun ProgressContext.monitorProgress(
         withContext(Dispatchers.Main) {
             state.updateUi()
         }
-        delay(100)
+        delay(100.milliseconds)
     }
 }
 
@@ -591,7 +591,7 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(col: Collection): Boolean {
     if (col.schemaChanged()) {
         return true
     }
-    return suspendCoroutine { coroutine ->
+    return suspendCancellableCoroutine { coroutine ->
         MaterialAlertDialogBuilder(this).show {
             message(text = col.tr.deckConfigWillRequireFullSync()) // generic message
             positiveButton(R.string.dialog_ok) {
@@ -615,7 +615,7 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(): Boolean {
         return true
     }
     val hasAcceptedSchemaChange =
-        suspendCoroutine { coroutine ->
+        suspendCancellableCoroutine { coroutine ->
             MaterialAlertDialogBuilder(this).show {
                 message(text = TR.deckConfigWillRequireFullSync().replace("\\s+".toRegex(), " "))
                 positiveButton(R.string.dialog_ok) { coroutine.resume(true) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -514,16 +514,18 @@ private suspend fun ProgressContext.monitorProgress(
     backend: Backend,
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
+    ioDispatcher: CoroutineDispatcher = com.ichi2.anki.ioDispatcher,
+    mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) {
     val state = this
     while (true) {
         state.progress =
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 backend.latestProgress()
             }
         state.extractProgress()
         // on main thread, so op can update UI
-        withContext(Dispatchers.Main) {
+        withContext(mainDispatcher) {
             state.updateUi()
         }
         delay(100.milliseconds)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -335,7 +335,7 @@ suspend fun HelpAction.execute(context: Context): Boolean {
  * progress UI.
  */
 suspend fun <T> Backend.withProgress(
-    progressContext: ProgressContext,
+    progressContext: ProgressContext = ProgressContext(),
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
     block: suspend CoroutineScope.() -> T,
@@ -559,15 +559,21 @@ data class ProgressContext(
          *
          * `28 MB/141 MB`
          */
-        fun ofBytes(context: Context) =
-            ProgressContext(
+        fun ofBytes(context: Context): ProgressContext {
+            val appContext = context.applicationContext
+            return ProgressContext(
                 formatAmount = { (current, max) ->
                     // replace spaces with NBSP so newlines are handled better
-                    val curStr = Formatter.formatShortFileSize(context, current).replace(' ', '\u00A0')
-                    val maxStr = Formatter.formatShortFileSize(context, max).replace(' ', '\u00A0')
-                    context.getString(R.string.progress_amount_bytes, curStr, maxStr)
+                    val curStr = Formatter.formatShortFileSize(appContext, current)
+                        .replace(' ', '\u00A0')
+                        .replace('\u202F', '\u00A0')
+                    val maxStr = Formatter.formatShortFileSize(appContext, max)
+                        .replace(' ', '\u00A0')
+                        .replace('\u202F', '\u00A0')
+                    appContext.getString(R.string.progress_amount_bytes, curStr, maxStr)
                 },
             )
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt
@@ -16,10 +16,17 @@
 
 package com.ichi2.anki
 
+import anki.collection.Progress
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 
 fun DeckPicker.handleDatabaseCheck() {
+    fun Progress.DatabaseCheck.toAmount() =
+        if (stageTotal > 0) {
+            ProgressContext.Amount(stageCurrent.toLong(), stageTotal.toLong())
+        } else {
+            null
+        }
     launchCatchingTask {
         val problems =
             withProgress(
@@ -27,12 +34,7 @@ fun DeckPicker.handleDatabaseCheck() {
                     if (progress.hasDatabaseCheck()) {
                         progress.databaseCheck.let {
                             text = it.stage
-                            amount =
-                                if (it.stageTotal > 0) {
-                                    Pair(it.stageCurrent, it.stageTotal)
-                                } else {
-                                    null
-                                }
+                            amount = it.toAmount()
                         }
                     }
                 },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 import androidx.annotation.StringRes
 import androidx.lifecycle.lifecycleScope
 import anki.backend.backendError
+import anki.collection.Progress
 import anki.sync.SyncAuth
 import anki.sync.SyncCollectionResponse
 import anki.sync.SyncStatusResponse
@@ -278,9 +279,10 @@ private suspend fun handleNormalSync(
 }
 
 private fun fullDownloadProgress(title: String): ProgressContext.() -> Unit = {
-    if (progress.hasFullSync()) {
-        text = title
-        amount = progress.fullSync.run { Pair(transferred, total) }
+    fun Progress.FullSync.toAmount() = ProgressContext.Amount(transferred.toLong(), total.toLong())
+    text = title
+    if (progress.hasFullSync() && progress.fullSync.total > 0) {
+        amount = progress.fullSync.toAmount()
     }
 }
 
@@ -291,8 +293,10 @@ private suspend fun handleDownload(
 ) {
     Timber.i("Sync: Full collection download requested")
     deckPicker.withProgress(
+        progressContext = ProgressContext.ofBytes(context = deckPicker).copy(separator = "\n"),
         extractProgress = fullDownloadProgress(TR.syncDownloadingFromAnkiweb()),
         onCancel = ::cancelSync,
+        manualCancelButton = R.string.dialog_cancel,
     ) {
         withCol {
             try {
@@ -323,8 +327,10 @@ private suspend fun handleUpload(
 ) {
     Timber.i("Sync: Full collection upload requested")
     deckPicker.withProgress(
+        progressContext = ProgressContext.ofBytes(context = deckPicker).copy(separator = "\n"),
         extractProgress = fullDownloadProgress(TR.syncUploadingToAnkiweb()),
         onCancel = ::cancelSync,
+        manualCancelButton = R.string.dialog_cancel,
     ) {
         withCol {
             close(downgrade = false, forFullSync = true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -281,8 +281,10 @@ private suspend fun handleNormalSync(
 private fun fullDownloadProgress(title: String): ProgressContext.() -> Unit = {
     fun Progress.FullSync.toAmount() = ProgressContext.Amount(transferred.toLong(), total.toLong())
     text = title
-    if (progress.hasFullSync() && progress.fullSync.total > 0) {
-        amount = progress.fullSync.toAmount()
+    amount = if (progress.hasFullSync() && progress.fullSync.total > 0) {
+        progress.fullSync.toAmount()
+    } else {
+        null
     }
 }
 
@@ -384,7 +386,7 @@ suspend fun monitorMediaSync(deckPicker: DeckPicker) {
                 }
                 val text = resp.progress.run { "$added\n$removed\n$checked" }
                 viewModel.updateSyncDialog(text)
-                delay(100)
+                delay(100.milliseconds)
             }
             showMessage(TR.syncMediaComplete())
         } catch (_: BackendInterruptedException) {

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -223,6 +223,8 @@
     <string name="white_board_eraser_enabled">Eraser mode activated</string>
     <string name="white_board_eraser_disabled">Eraser mode deactivated</string>
 
+    <string comment="Progress amount e.g. '28 MB/141 MB'. %1$s is the current amount, %2$s is the max." name="progress_amount_bytes">%1$s/%2$s</string>
+
     <!-- Whiteboard save image message in the Study Screen -->
     <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>


### PR DESCRIPTION
This pull request refactors and improves how progress is tracked and displayed in AnkiDroid, especially for operations that involve measurable amounts (like bytes transferred during sync). The main changes include generalizing the `ProgressContext` to support different formats, adding a specialized format for byte-based progress, and updating UI handling and usage throughout the codebase.

Progress tracking and formatting improvements:

* Refactored `ProgressContext` to support customizable formatting for progress amounts, including a new `Amount` data class to represent progress as `(current, max)` values, and a `formatAmount` function for flexible display. Added a companion method `ofBytes` to format progress as bytes (e.g., "28 MB/141 MB") using Android's `Formatter`. (`AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt`)
* Updated the `withProgress` functions to accept and propagate a customizable `ProgressContext`, allowing different progress formatting and display options in various UI flows. (`AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt`) [[1]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73R338-R346) [[2]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73R363) [[3]](diffhunk://#diff-ab2a7a47110cd7660b276c059e8612c4586f636533d31b36f631808c6558cc73R383)
* Changed `monitorProgress` to operate on the provided `ProgressContext` rather than creating a new one, ensuring state and formatting are preserved. (`AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt`)

Usage and UI updates:

* Updated sync and database check flows to use the new `Amount` type and byte-based formatting for progress, providing clearer and more user-friendly progress messages (including newlines and cancel buttons where appropriate). (`AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt`, `AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt`) [[1]](diffhunk://#diff-b0d26729ac105cdbf85ced3f5e903192e2b18f13fb785e90a5dc85a9363dc031R19-R37) [[2]](diffhunk://#diff-053adb7a22e5f0596dccfa5160bf06efcfa5f3971c1065bd5034dcdb916f3044L281-R285) [[3]](diffhunk://#diff-053adb7a22e5f0596dccfa5160bf06efcfa5f3971c1065bd5034dcdb916f3044R296-R299) [[4]](diffhunk://#diff-053adb7a22e5f0596dccfa5160bf06efcfa5f3971c1065bd5034dcdb916f3044R330-R333)
* Added a new string resource for formatting byte-based progress amounts. (`AnkiDroid/src/main/res/values/02-strings.xml`)

These changes make progress dialogs more informative and adaptable, especially for operations involving large data transfers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced progress display formatting during sync and database check operations with improved byte amount rendering and non-breaking spaces for better readability.

* **Refactor**
  * Refactored progress tracking system for improved flexibility and configurability of progress handling across background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->