### PR TITLE
fix(previewer): prevent deadlock in CardViewerViewModel during teardown

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -45,8 +45,8 @@ import timber.log.Timber
 
 abstract class CardViewerViewModel : ViewModel(), OnErrorListener, PostRequestHandler {
     override val onError = MutableSharedFlow<String>()
-    val onMediaError = MutableSharedFlow<String>()
-    val onTtsError = MutableSharedFlow<TtsPlayer.TtsError>()
+    val onMediaError = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val onTtsError = MutableSharedFlow<TtsPlayer.TtsError>(extraBufferCapacity = 1)
     val mediaErrorHandler = MediaErrorHandler()
 
     val eval = MutableSharedFlow<String>()
@@ -166,7 +166,7 @@ abstract class CardViewerViewModel : ViewModel(), OnErrorListener, PostRequestHa
                 // Retrying fixes most of these
                 if (file.exists()) return MediaErrorBehavior.RETRY_MEDIA
                 mediaErrorHandler.processMissingMedia(file) { fileName ->
-                    viewModelScope.launch { onMediaError.emit(fileName) }
+                    onMediaError.tryEmit(fileName)
                 }
                 return MediaErrorBehavior.CONTINUE_MEDIA
             }
@@ -186,7 +186,7 @@ abstract class CardViewerViewModel : ViewModel(), OnErrorListener, PostRequestHa
                 isAutomaticPlayback: Boolean,
             ) {
                 mediaErrorHandler.processTtsFailure(error, isAutomaticPlayback) {
-                    viewModelScope.launch { onTtsError.emit(error) }
+                    onTtsError.tryEmit(error)
                 }
             }
         }


### PR DESCRIPTION
### Summary
Fixes an Application Not Responding (ANR) / deadlock issue that occurs when `CardViewerViewModel` is cleared while a background `SoundTagPlayer` thread is handling a media playback or TTS error.

### Cause of the Deadlock
1. **Main Thread**: Runs `ViewModelImpl.clear()` (holding the internal ViewModel lock) and calls `CardMediaPlayer.close()`, which synchronously blocks waiting for the `SoundTagPlayer` handler thread to stop/release resources.
2. **SoundTagPlayer Thread**: Simultanously, a media or TTS error callback fires, which attempts to access the `viewModelScope` extension property to launch a coroutine to emit the error to the UI. Accessing `viewModelScope` calls `ViewModelImpl.getCloseable()`, which blocks trying to acquire the internal ViewModel lock.
3. This creates a circular dependency and deadlocks both threads.

### Solution
Redefined the `onMediaError` and `onTtsError` flows as buffered flows (`extraBufferCapacity = 1`), allowing the background thread callbacks in `CardViewerViewModel` to emit events synchronously and thread-safely using `tryEmit()`. 

This completely removes the dependency on `viewModelScope` inside background callbacks, resolving the deadlock without introducing memory leaks, thread-safety violations, or asynchronous release hazards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of media and text-to-speech error reporting during card preview, reducing the chance of missed error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->