### PR TITLE
Migrate reviewer Set Due Date dialog to Jetpack Compose

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -36,8 +36,6 @@ import androidx.activity.viewModels
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntDef
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.TooltipCompat
@@ -49,10 +47,12 @@ import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
 import anki.frontend.SetSchedulingStatesRequest
 import anki.scheduler.CardAnswer.Rating
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -84,7 +84,6 @@ import com.ichi2.anki.reviewer.ReviewerViewModel
 import com.ichi2.anki.reviewer.VoicePlaybackViewModel
 import com.ichi2.anki.reviewer.WhiteboardController
 import com.ichi2.anki.scheduling.ForgetCardsDialog
-import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.snackbar.showSnackbar
@@ -108,7 +107,6 @@ import com.ichi2.utils.show
 import com.ichi2.utils.tintOverflowMenuIcons
 import com.ichi2.utils.title
 import com.ichi2.widget.WidgetStatus.updateInBackground
-import com.ichi2.anki.cardviewer.CardMediaPlayer
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -213,29 +211,20 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                     is ReviewerEffect.NavigateToEditCard -> {
                         // Handled in Compose
                     }
-
                     is ReviewerEffect.ShowSnackbar -> {
                         // Handled in Compose
                     }
-
                     is ReviewerEffect.PerformRedo -> redo()
                     is ReviewerEffect.ToggleWhiteboard -> toggleWhiteboard()
                     is ReviewerEffect.ShowDeleteNoteDialog -> {
                         // Handled in Compose via ViewModel-backed delete dialog state
                     }
-                    // TagsDialog is now handled in Compose via ViewModel state
-                    is ReviewerEffect.ShowDueDateDialog -> {
-                        showDueDateDialog()
-                    }
-
                     is ReviewerEffect.ReplayMedia -> {
                         playMedia(true)
                     }
-
                     is ReviewerEffect.ShowTimeboxReachedDialog -> {
                         dealWithTimeBox(effect.timebox)
                     }
-
                     is ReviewerEffect.ToggleVoicePlayback -> {
                         if (!canRecordAudio(this@Reviewer)) {
                             Timber.i("requesting 'RECORD_AUDIO' permission")
@@ -253,7 +242,6 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                             }
                         }
                     }
-
                     is ReviewerEffect.NavigateToDeckOptions -> {
                         val i = DeckOptions.getIntent(
                             this@Reviewer,
@@ -458,7 +446,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
             R.id.action_bury_note -> buryNote()
             R.id.action_suspend_card -> suspendCard()
             R.id.action_suspend_note -> suspendNote()
-            R.id.action_reschedule_card -> showDueDateDialog()
+            R.id.action_reschedule_card -> viewModel.onEvent(ReviewerEvent.RescheduleCard)
             R.id.action_delete -> {
                 Timber.i("Reviewer:: Delete note button pressed")
                 viewModel.onEvent(ReviewerEvent.DeleteNote)
@@ -636,13 +624,6 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
             // Audio permission granted, start recording
             voicePlaybackViewModel.toggleRecording(this)
         }
-    }
-
-    private fun showDueDateDialog() = launchCatchingTask {
-        Timber.i("showing due date dialog")
-        val cardId = currentCardId ?: return@launchCatchingTask
-        val dialog = SetDueDateDialog.newInstance(listOf(cardId))
-        showDialogFragment(dialog)
     }
 
     private fun showResetCardDialog() {
@@ -1095,7 +1076,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
             }
 
             ViewerCommand.RESCHEDULE_NOTE -> {
-                showDueDateDialog()
+                viewModel.onEvent(ReviewerEvent.RescheduleCard)
                 return true
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -198,8 +198,8 @@ class ReviewerViewModel(
     private val _showTagsDialog = MutableStateFlow(false)
     val showTagsDialog: StateFlow<Boolean> = _showTagsDialog.asStateFlow()
 
-    private val _showSetDueDateDialog = MutableStateFlow(false)
-    val showSetDueDateDialog: StateFlow<Boolean> = _showSetDueDateDialog.asStateFlow()
+    private val _setDueDateCardId = MutableStateFlow<Long?>(null)
+    val setDueDateCardId: StateFlow<Long?> = _setDueDateCardId.asStateFlow()
 
     private val _flowOfDeleteResult = MutableSharedFlow<Int>()
     val flowOfDeleteResult: SharedFlow<Int> = _flowOfDeleteResult.asSharedFlow()
@@ -384,19 +384,19 @@ class ReviewerViewModel(
     }
 
     private fun rescheduleCard() {
-        currentCard ?: return
-        _showSetDueDateDialog.value = true
+        val card = currentCard ?: return
+        _setDueDateCardId.value = card.id
     }
 
     private fun dismissSetDueDateDialog() {
-        _showSetDueDateDialog.value = false
+        _setDueDateCardId.value = null
     }
 
     private fun setDueDateConfirmed(count: Int) {
         val message = TR.schedulingSetDueDateDone(count)
         viewModelScope.launch { _effect.emit(ReviewerEffect.ShowSnackbar(message)) }
         reloadCard()
-        _showSetDueDateDialog.value = false
+        _setDueDateCardId.value = null
     }
 
     private fun deleteNote() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import anki.scheduler.CardAnswer
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.CardMediaPlayer
@@ -129,6 +130,8 @@ sealed class ReviewerEvent {
     object EditTags : ReviewerEvent()
     object DeleteNote : ReviewerEvent()
     object RescheduleCard : ReviewerEvent()
+    object DismissSetDueDateDialog : ReviewerEvent()
+    data class SetDueDateConfirmed(val count: Int) : ReviewerEvent()
     object ReplayMedia : ReviewerEvent()
     object ToggleVoicePlayback : ReviewerEvent()
     data class OnVoicePlaybackStateChanged(val enabled: Boolean) : ReviewerEvent()
@@ -198,9 +201,6 @@ class ReviewerViewModel(
     private val _showSetDueDateDialog = MutableStateFlow(false)
     val showSetDueDateDialog: StateFlow<Boolean> = _showSetDueDateDialog.asStateFlow()
 
-    fun showSetDueDateDialog(show: Boolean) {
-        _showSetDueDateDialog.value = show
-    }
     private val _flowOfDeleteResult = MutableSharedFlow<Int>()
     val flowOfDeleteResult: SharedFlow<Int> = _flowOfDeleteResult.asSharedFlow()
     private val nextJavascriptCommandId = AtomicInteger(0)
@@ -347,6 +347,8 @@ class ReviewerViewModel(
             is ReviewerEvent.EditTags -> editTags()
             is ReviewerEvent.DeleteNote -> deleteNote()
             is ReviewerEvent.RescheduleCard -> rescheduleCard()
+            is ReviewerEvent.DismissSetDueDateDialog -> dismissSetDueDateDialog()
+            is ReviewerEvent.SetDueDateConfirmed -> setDueDateConfirmed(event.count)
             is ReviewerEvent.ReplayMedia -> replayMedia()
             is ReviewerEvent.ToggleVoicePlayback -> toggleVoicePlayback()
             is ReviewerEvent.OnVoicePlaybackStateChanged -> onVoicePlaybackStateChanged(event.enabled)
@@ -383,7 +385,18 @@ class ReviewerViewModel(
 
     private fun rescheduleCard() {
         currentCard ?: return
-        showSetDueDateDialog(true)
+        _showSetDueDateDialog.value = true
+    }
+
+    private fun dismissSetDueDateDialog() {
+        _showSetDueDateDialog.value = false
+    }
+
+    private fun setDueDateConfirmed(count: Int) {
+        val message = TR.schedulingSetDueDateDone(count)
+        viewModelScope.launch { _effect.emit(ReviewerEffect.ShowSnackbar(message)) }
+        reloadCard()
+        _showSetDueDateDialog.value = false
     }
 
     private fun deleteNote() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -145,7 +145,6 @@ sealed class ReviewerEffect {
     object PerformRedo : ReviewerEffect()
     object ToggleWhiteboard : ReviewerEffect()
     data class ShowDeleteNoteDialog(val card: Card) : ReviewerEffect()
-    data class ShowDueDateDialog(val card: Card) : ReviewerEffect()
     data class ReplayMedia(val card: Card) : ReviewerEffect()
     object ToggleVoicePlayback : ReviewerEffect()
     object NavigateToDeckOptions : ReviewerEffect()
@@ -195,6 +194,13 @@ class ReviewerViewModel(
 
     private val _showTagsDialog = MutableStateFlow(false)
     val showTagsDialog: StateFlow<Boolean> = _showTagsDialog.asStateFlow()
+
+    private val _showSetDueDateDialog = MutableStateFlow(false)
+    val showSetDueDateDialog: StateFlow<Boolean> = _showSetDueDateDialog.asStateFlow()
+
+    fun showSetDueDateDialog(show: Boolean) {
+        _showSetDueDateDialog.value = show
+    }
     private val _flowOfDeleteResult = MutableSharedFlow<Int>()
     val flowOfDeleteResult: SharedFlow<Int> = _flowOfDeleteResult.asSharedFlow()
     private val nextJavascriptCommandId = AtomicInteger(0)
@@ -376,8 +382,8 @@ class ReviewerViewModel(
     }
 
     private fun rescheduleCard() {
-        val card = currentCard ?: return
-        viewModelScope.launch { _effect.emit(ReviewerEffect.ShowDueDateDialog(card)) }
+        currentCard ?: return
+        showSetDueDateDialog(true)
     }
 
     private fun deleteNote() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -195,8 +195,10 @@ fun ReviewerContent(
     val layoutDirection = LocalLayoutDirection.current
     val undoLabel = stringResource(R.string.undo)
 
-    // Tags dialog state
+    // Due date state
     val setDueDateCardId by viewModel.setDueDateCardId.collectAsStateWithLifecycle()
+
+    // Tags dialog state
     val showTagsDialog by viewModel.showTagsDialog.collectAsStateWithLifecycle()
     val tagsState by viewModel.tagsState.collectAsStateWithLifecycle()
     val currentNoteTags by viewModel.currentNoteTags.collectAsStateWithLifecycle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -54,6 +54,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -61,10 +62,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberBottomSheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -93,9 +92,13 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import anki.scheduler.CardAnswer
 import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
+import com.ichi2.anki.browser.compose.SetDueDateDialog
 import com.ichi2.anki.dialogs.compose.DeleteConfirmationDialog
 import com.ichi2.anki.dialogs.compose.TagsDialog
 import com.ichi2.anki.libanki.CardId
@@ -105,6 +108,8 @@ import com.ichi2.anki.reviewer.ReviewerEffect
 import com.ichi2.anki.reviewer.ReviewerEvent
 import com.ichi2.anki.reviewer.ReviewerViewModel
 import com.ichi2.anki.reviewer.VoicePlaybackViewModel
+import com.ichi2.anki.scheduling.SetDueDateViewModel
+import com.ichi2.anki.servicelayer.getFSRSStatus
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.ToolbarAlignment
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardViewModel
@@ -188,6 +193,7 @@ fun ReviewerContent(
     val undoLabel = stringResource(R.string.undo)
 
     // Tags dialog state
+    val showSetDueDateDialog by viewModel.showSetDueDateDialog.collectAsStateWithLifecycle()
     val showTagsDialog by viewModel.showTagsDialog.collectAsStateWithLifecycle()
     val tagsState by viewModel.tagsState.collectAsStateWithLifecycle()
     val currentNoteTags by viewModel.currentNoteTags.collectAsStateWithLifecycle()
@@ -466,34 +472,34 @@ fun ReviewerContent(
                     remember(state.isWhiteboardEnabled, state.isVoicePlaybackEnabled) {
                         listOf(
                             Triple(R.string.undo, Icons.AutoMirrored.Filled.Undo) {
-                            viewModel.onEvent(ReviewerEvent.Undo)
-                        }, Triple(
-                            if (state.isWhiteboardEnabled) R.string.disable_whiteboard else R.string.enable_whiteboard,
-                            Icons.Filled.Edit
-                        ) {
-                            viewModel.onEvent(ReviewerEvent.ToggleWhiteboard)
-                        }, Triple(R.string.cardeditor_title_edit_card, Icons.Filled.EditNote) {
-                            viewModel.onEvent(ReviewerEvent.EditCard)
-                        }, Triple(R.string.menu_edit_tags, Icons.AutoMirrored.Filled.Label) {
-                            viewModel.onEvent(ReviewerEvent.EditTags)
-                        }, Triple(R.string.menu_bury_card, Icons.Filled.VisibilityOff) {
-                            viewModel.onEvent(ReviewerEvent.BuryCard)
-                        }, Triple(R.string.menu_suspend_card, Icons.Filled.Pause) {
-                            viewModel.onEvent(ReviewerEvent.SuspendCard)
-                        }, Triple(R.string.menu_delete_note, Icons.Filled.Delete) {
-                            viewModel.onEvent(ReviewerEvent.DeleteNote)
-                        }, Triple(R.string.card_editor_reschedule_card, Icons.Filled.Schedule) {
-                            viewModel.onEvent(ReviewerEvent.RescheduleCard)
-                        }, Triple(R.string.replay_media, Icons.Filled.Replay) {
-                            viewModel.onEvent(ReviewerEvent.ReplayMedia)
-                        }, Triple(
-                            if (state.isVoicePlaybackEnabled) R.string.menu_disable_voice_playback else R.string.menu_enable_voice_playback,
-                            Icons.Filled.RecordVoiceOver
-                        ) {
-                            viewModel.onEvent(ReviewerEvent.ToggleVoicePlayback)
-                        }, Triple(R.string.deck_options, Icons.Filled.Tune) {
-                            viewModel.onEvent(ReviewerEvent.DeckOptions)
-                        })
+                                viewModel.onEvent(ReviewerEvent.Undo)
+                            }, Triple(
+                                if (state.isWhiteboardEnabled) R.string.disable_whiteboard else R.string.enable_whiteboard,
+                                Icons.Filled.Edit
+                            ) {
+                                viewModel.onEvent(ReviewerEvent.ToggleWhiteboard)
+                            }, Triple(R.string.cardeditor_title_edit_card, Icons.Filled.EditNote) {
+                                viewModel.onEvent(ReviewerEvent.EditCard)
+                            }, Triple(R.string.menu_edit_tags, Icons.AutoMirrored.Filled.Label) {
+                                viewModel.onEvent(ReviewerEvent.EditTags)
+                            }, Triple(R.string.menu_bury_card, Icons.Filled.VisibilityOff) {
+                                viewModel.onEvent(ReviewerEvent.BuryCard)
+                            }, Triple(R.string.menu_suspend_card, Icons.Filled.Pause) {
+                                viewModel.onEvent(ReviewerEvent.SuspendCard)
+                            }, Triple(R.string.menu_delete_note, Icons.Filled.Delete) {
+                                viewModel.onEvent(ReviewerEvent.DeleteNote)
+                            }, Triple(R.string.card_editor_reschedule_card, Icons.Filled.Schedule) {
+                                viewModel.onEvent(ReviewerEvent.RescheduleCard)
+                            }, Triple(R.string.replay_media, Icons.Filled.Replay) {
+                                viewModel.onEvent(ReviewerEvent.ReplayMedia)
+                            }, Triple(
+                                if (state.isVoicePlaybackEnabled) R.string.menu_disable_voice_playback else R.string.menu_enable_voice_playback,
+                                Icons.Filled.RecordVoiceOver
+                            ) {
+                                viewModel.onEvent(ReviewerEvent.ToggleVoicePlayback)
+                            }, Triple(R.string.deck_options, Icons.Filled.Tune) {
+                                viewModel.onEvent(ReviewerEvent.DeckOptions)
+                            })
                     }
                 menuOptions.forEach { (textRes, icon, action) ->
                     ListItem(
@@ -558,6 +564,32 @@ fun ReviewerContent(
         if (showEraserOptions && whiteboardViewModel != null) {
             EraserOptionsDialog(
                 viewModel = whiteboardViewModel, onDismissRequest = { showEraserOptions = false })
+        }
+
+        // Set Due Date Dialog
+        if (showSetDueDateDialog) {
+            val setDueDateViewModel = viewModel<SetDueDateViewModel>()
+            LaunchedEffect(Unit) {
+                val cardId = viewModel.currentCardFlow.value?.id
+                if (cardId != null) {
+                    val fsrsEnabled = getFSRSStatus() ?: false
+                    setDueDateViewModel.init(longArrayOf(cardId), fsrsEnabled)
+                }
+            }
+
+            SetDueDateDialog(viewModel = setDueDateViewModel, onHelpClicked = {
+                (currentContext as? AnkiActivity)?.openUrl(R.string.link_set_due_date_help)
+            }, onDismissRequest = { viewModel.showSetDueDateDialog(false) }, onConfirm = {
+                scope.launch {
+                    val count = setDueDateViewModel.updateDueDateAsync().await()
+                    if (count != null) {
+                        val message = TR.schedulingSetDueDateDone(count)
+                        snackbarHostState.showSnackbar(message)
+                        viewModel.onEvent(ReviewerEvent.ReloadCard)
+                        viewModel.showSetDueDateDialog(false)
+                    }
+                }
+            })
         }
 
         // Tags dialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -110,6 +110,7 @@ import com.ichi2.anki.reviewer.VoicePlaybackViewModel
 import com.ichi2.anki.scheduling.SetDueDateViewModel
 import com.ichi2.anki.servicelayer.getFSRSStatus
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.ToolbarAlignment
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardViewModel
 import kotlinx.coroutines.delay
@@ -581,10 +582,19 @@ fun ReviewerContent(
                 },
                 onDismissRequest = { viewModel.onEvent(ReviewerEvent.DismissSetDueDateDialog) },
                 onConfirm = {
+                    val activity = currentContext as? AnkiActivity ?: return@SetDueDateDialog
                     scope.launch {
-                        val count = setDueDateViewModel.updateDueDateAsync().await()
-                        if (count != null) {
-                            viewModel.onEvent(ReviewerEvent.SetDueDateConfirmed(count))
+                        try {
+                            val count = setDueDateViewModel.updateDueDateAsync().await()
+                            if (count != null) {
+                                viewModel.onEvent(ReviewerEvent.SetDueDateConfirmed(count))
+                            } else {
+                                timber.log.Timber.w("unable to update due date")
+                                showThemedToast(activity, R.string.something_wrong, true)
+                            }
+                        } catch (e: Exception) {
+                            timber.log.Timber.w(e, "unable to update due date")
+                            showThemedToast(activity, R.string.something_wrong, true)
                         }
                     }
                 })

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -113,6 +113,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.ToolbarAlignment
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -592,6 +593,8 @@ fun ReviewerContent(
                                 timber.log.Timber.w("unable to update due date")
                                 showThemedToast(activity, R.string.something_wrong, true)
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             timber.log.Timber.w(e, "unable to update due date")
                             showThemedToast(activity, R.string.something_wrong, true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -193,7 +193,7 @@ fun ReviewerContent(
     val undoLabel = stringResource(R.string.undo)
 
     // Tags dialog state
-    val showSetDueDateDialog by viewModel.showSetDueDateDialog.collectAsStateWithLifecycle()
+    val setDueDateCardId by viewModel.setDueDateCardId.collectAsStateWithLifecycle()
     val showTagsDialog by viewModel.showTagsDialog.collectAsStateWithLifecycle()
     val tagsState by viewModel.tagsState.collectAsStateWithLifecycle()
     val currentNoteTags by viewModel.currentNoteTags.collectAsStateWithLifecycle()
@@ -567,14 +567,11 @@ fun ReviewerContent(
         }
 
         // Set Due Date Dialog
-        if (showSetDueDateDialog) {
+        setDueDateCardId?.let { cardId ->
             val setDueDateViewModel = viewModel<SetDueDateViewModel>()
-            LaunchedEffect(Unit) {
-                val cardId = viewModel.currentCardFlow.value?.id
-                if (cardId != null) {
-                    val fsrsEnabled = getFSRSStatus() ?: false
-                    setDueDateViewModel.init(longArrayOf(cardId), fsrsEnabled)
-                }
+            LaunchedEffect(cardId) {
+                val fsrsEnabled = getFSRSStatus() ?: false
+                setDueDateViewModel.init(longArrayOf(cardId), fsrsEnabled)
             }
 
             SetDueDateDialog(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -96,7 +96,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import anki.scheduler.CardAnswer
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.compose.SetDueDateDialog
 import com.ichi2.anki.dialogs.compose.DeleteConfirmationDialog
@@ -116,6 +115,7 @@ import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 private val WhiteboardToolbarWidth = 56.dp
 private val WhiteboardBottomBarOffset = 48.dp
@@ -577,19 +577,20 @@ fun ReviewerContent(
                 }
             }
 
-            SetDueDateDialog(viewModel = setDueDateViewModel, onHelpClicked = {
-                (currentContext as? AnkiActivity)?.openUrl(R.string.link_set_due_date_help)
-            }, onDismissRequest = { viewModel.showSetDueDateDialog(false) }, onConfirm = {
-                scope.launch {
-                    val count = setDueDateViewModel.updateDueDateAsync().await()
-                    if (count != null) {
-                        val message = TR.schedulingSetDueDateDone(count)
-                        snackbarHostState.showSnackbar(message)
-                        viewModel.onEvent(ReviewerEvent.ReloadCard)
-                        viewModel.showSetDueDateDialog(false)
+            SetDueDateDialog(
+                viewModel = setDueDateViewModel,
+                onHelpClicked = {
+                    (currentContext as? AnkiActivity)?.openUrl(R.string.link_set_due_date_help)
+                },
+                onDismissRequest = { viewModel.onEvent(ReviewerEvent.DismissSetDueDateDialog) },
+                onConfirm = {
+                    scope.launch {
+                        val count = setDueDateViewModel.updateDueDateAsync().await()
+                        if (count != null) {
+                            viewModel.onEvent(ReviewerEvent.SetDueDateConfirmed(count))
+                        }
                     }
-                }
-            })
+                })
         }
 
         // Tags dialog
@@ -623,7 +624,7 @@ fun AnswerIndicator(
     LaunchedEffect(feedback) {
         if (feedback != null) {
             lastFeedback = feedback
-            delay(AnswerIndicatorDuration)
+            delay(AnswerIndicatorDuration.milliseconds)
             currentOnDismissed()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -117,6 +117,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 
 private val WhiteboardToolbarWidth = 56.dp
@@ -590,13 +591,13 @@ fun ReviewerContent(
                             if (count != null) {
                                 viewModel.onEvent(ReviewerEvent.SetDueDateConfirmed(count))
                             } else {
-                                timber.log.Timber.w("unable to update due date")
+                                Timber.w("unable to update due date")
                                 showThemedToast(activity, R.string.something_wrong, true)
                             }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {
-                            timber.log.Timber.w(e, "unable to update due date")
+                            Timber.w(e, "unable to update due date")
                             showThemedToast(activity, R.string.something_wrong, true)
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -155,6 +155,8 @@ class SetDueDateViewModel : ViewModel() {
         this._startText.value = ""
         this._endText.value = ""
         this.updateIntervalToMatchDueDate = fsrsEnabled
+        this.isValidFlow.value = false
+        this.currentInterval.value = null
 
         initCurrentInterval(cardIds)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Set Due Date” dialog to the reviewer flow, including help, confirm, and dismiss actions.
  * Confirming shows a success snackbar and refreshes the card automatically.
* **Bug Fixes**
  * Improved due-date dialog reliability by switching to persistent reviewer state.
  * More consistently resets due-date dialog UI when it opens.
* **UI / Minor Improvements**
  * Updated reviewer bottom-sheet handling and refined answer indicator timing for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->