### PR TITLE
Fix flashcard pinch-to-zoom

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/Flashcard.kt
@@ -285,6 +285,9 @@ fun Flashcard(
                 settings.allowFileAccess = true
                 settings.domStorageEnabled = true
                 settings.mediaPlaybackRequiresUserGesture = !isMediaAutoplayEnabled
+                settings.setSupportZoom(true)
+                settings.builtInZoomControls = true
+                settings.displayZoomControls = false
 
                 webChromeClient = object : WebChromeClient() {
                     override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {


### PR DESCRIPTION
# Feature: Add Pinch-to-Zoom Support for Flashcards

## Summary
This PR introduces pinch-to-zoom functionality and built-in zoom controls to the flashcard view, improving overall readability and accessibility during spaced repetition review sessions. 

> **Note:** This PR was split from the original PR #126 by @DV0612 to isolate the flashcard UI enhancements from the card browser updates, allowing for a cleaner review process. 

## Changes Made
* **`Flashcard.kt`**: Updated the WebView settings to explicitly support pinch-to-zoom gestures.
* Enabled built-in zoom controls while keeping the default UI controls hidden to prevent screen clutter.

## Testing Instructions
1. Open a study deck and initiate a review session.
2. Use pinch gestures on the front and back of the flashcards to verify that scaling works smoothly.
3. Confirm that zooming does not interfere with standard card interactions (e.g., tapping to reveal answers or utilizing grading buttons).

Closes #125 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved flashcard viewing by enabling zoom gestures and built-in zoom controls.
  * Zoom controls remain available without displaying additional on-screen control buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->