### PR TITLE
feat: add setting to move 'More Options' menu to top app bar & expand answer buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -540,6 +540,7 @@ object UsageAnalytics {
             R.string.show_audio_play_buttons_key, // Show play buttons on cards with audio (reversed in collection: HIDE_AUDIO_PLAY_BUTTONS)
             R.string.pref_display_filenames_in_browser_key, // Display filenames in card browser
             R.string.show_deck_title_key, // Show deck title
+            R.string.more_options_in_top_app_bar_key, // More options in top app bar
             // ******************************** Controls *********************************************
             R.string.gestures_preference, // Enable gestures
             R.string.gestures_corner_touch_preference, // 9-point touch

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
@@ -91,6 +92,7 @@ fun AnswerButtons(
     onMoreOptionsClick: () -> Unit
 ) {
     val view = LocalView.current
+    val adjustButtonStylesForBadges = showAnswerFeedback && moreOptionsInTopAppBar
 
     Column(
         modifier = modifier.imePadding(),
@@ -151,14 +153,16 @@ fun AnswerButtons(
                     if (!isAnswerShown) {
                         val interactionSource = remember { MutableInteractionSource() }
                         val isPressed by interactionSource.collectIsPressedAsState()
-                        val defaultHorizontalPadding =
+                        val baseHorizontalPadding =
                             ButtonDefaults.MediumContentPadding.calculateLeftPadding(
                                 layoutDirection = LocalLayoutDirection.current
-                            )
+                            ) + if (moreOptionsInTopAppBar) 24.dp else 0.dp
                         val horizontalPadding by animateDpAsState(
-                            if (isPressed) defaultHorizontalPadding + 4.dp else defaultHorizontalPadding,
+                            if (isPressed) baseHorizontalPadding + 4.dp else baseHorizontalPadding,
                             motionScheme.fastSpatialSpec()
                         )
+
+
                         Button(
                             onClick = {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
@@ -203,12 +207,14 @@ fun AnswerButtons(
                                                     .height(56.dp)
                                                     .fillMaxWidth()
                                                     .then(
-                                                        if (showAnswerFeedback) Modifier.padding(
+                                                        if (showAnswerFeedback && !adjustButtonStylesForBadges) Modifier.padding(
                                                             bottom = 6.dp
                                                         )
                                                         else Modifier
                                                     ), // add slight padding so the badge doesn't overlap excessively
-                                                contentPadding = ButtonDefaults.ExtraSmallContentPadding,
+                                                contentPadding = if (adjustButtonStylesForBadges) PaddingValues(
+                                                    horizontal = 28.dp,
+                                                ) else ButtonDefaults.ExtraSmallContentPadding,
                                                 shape = when (index) {
                                                     0 -> ButtonGroupDefaults.connectedLeadingButtonShape
                                                     ratings.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShape
@@ -221,7 +227,10 @@ fun AnswerButtons(
                                                 )
                                             ) {
                                                 Text(
-                                                    nextTimes.getOrElse(index) { "" },
+                                                    modifier = if (adjustButtonStylesForBadges) Modifier
+                                                        .fillMaxHeight()
+                                                        .padding(top = 14.dp) else Modifier,
+                                                    text = nextTimes.getOrElse(index) { "" },
                                                     softWrap = false,
                                                     overflow = TextOverflow.Visible
                                                 )
@@ -229,6 +238,9 @@ fun AnswerButtons(
 
                                             if (showAnswerFeedback) {
                                                 Badge(
+                                                    modifier = if (adjustButtonStylesForBadges) Modifier.padding(
+                                                        bottom = 2.dp
+                                                    ) else Modifier,
                                                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                                                     contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                                                 ) {
@@ -316,6 +328,42 @@ fun AnswerButtonsTypeInPreview() {
             onShowAnswer = {},
             onRateCard = {},
             nextTimes = emptyList(),
+            onMoreOptionsClick = {})
+    }
+}
+
+@Preview(name = "Expanded Rating Buttons (More Options in Top Bar)", showBackground = true)
+@Composable
+fun AnswerButtonsExpandedRatingPreview() {
+    AnkiDroidTheme {
+        AnswerButtons(
+            isAnswerShown = true,
+            showAnswerFeedback = true,
+            showTypeInAnswer = false,
+            typedAnswer = "",
+            onTypedAnswerChanged = {},
+            onShowAnswer = {},
+            onRateCard = {},
+            nextTimes = listOf("1m", "2d", "4d", "7d"),
+            moreOptionsInTopAppBar = true,
+            onMoreOptionsClick = {})
+    }
+}
+
+@Preview(name = "Expanded Show Answer (More Options in Top Bar)", showBackground = true)
+@Composable
+fun AnswerButtonsExpandedShowAnswerPreview() {
+    AnkiDroidTheme {
+        AnswerButtons(
+            isAnswerShown = false,
+            showAnswerFeedback = true,
+            showTypeInAnswer = false,
+            typedAnswer = "",
+            onTypedAnswerChanged = {},
+            onShowAnswer = {},
+            onRateCard = {},
+            nextTimes = emptyList(),
+            moreOptionsInTopAppBar = true,
             onMoreOptionsClick = {})
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -61,6 +61,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -69,7 +71,22 @@ import anki.scheduler.CardAnswer
 import com.ichi2.anki.R
 import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 
-val ratings = listOf(
+private object AnswerButtonsConstants {
+    val ColumnSpacing = 12.dp
+    val TextFieldBorderWidth = 2.dp
+    val TextFieldMaxWidthFraction = 0.8f
+    val ToolbarIconHeight = 48.dp
+    val MainButtonHeight = 56.dp
+    val RatingButtonGroupSpacing = 2.dp
+    val ExpandedButtonHorizontalPadding = 24.dp
+    val PressedAnimationExtraPadding = 4.dp
+    val BadgeBottomPadding = 6.dp
+    val AdjustedBadgeBottomPadding = 2.dp
+    val AdjustedTextTopPadding = 14.dp
+    val AdjustedButtonHorizontalPadding = 28.dp
+}
+
+private val ratings = listOf(
     R.string.ease_button_again to CardAnswer.Rating.AGAIN,
     R.string.ease_button_hard to CardAnswer.Rating.HARD,
     R.string.ease_button_good to CardAnswer.Rating.GOOD,
@@ -91,43 +108,19 @@ fun AnswerButtons(
     moreOptionsInTopAppBar: Boolean = false,
     onMoreOptionsClick: () -> Unit
 ) {
-    val view = LocalView.current
     val adjustButtonStylesForBadges = showButtonBadges && moreOptionsInTopAppBar
 
     Column(
         modifier = modifier.imePadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(AnswerButtonsConstants.ColumnSpacing)
     ) {
         if (showTypeInAnswer) {
-            val interactionSource = remember { MutableInteractionSource() }
-            val isFocused by interactionSource.collectIsFocusedAsState()
-
-            TextField(
-                value = typedAnswer,
-                onValueChange = onTypedAnswerChanged,
-                label = { Text(stringResource(R.string.type_in_the_answer)) },
-                modifier = Modifier
-                    .fillMaxWidth(0.8f)
-                    .border(
-                        2.dp,
-                        if (isFocused) MaterialTheme.colorScheme.tertiary else Color.Transparent,
-                        MaterialTheme.shapes.extraLargeIncreased
-                    ),
-                shape = MaterialTheme.shapes.extraLargeIncreased,
-                interactionSource = interactionSource,
-                readOnly = isAnswerShown, // when answer shown, don't allow typing
-                singleLine = true,
-                colors = TextFieldDefaults.colors(
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                ),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = {
-                    if (!isAnswerShown) {
-                        onShowAnswer()
-                    }
-                }),
+            AnswerTypeInTextField(
+                typedAnswer = typedAnswer,
+                onTypedAnswerChanged = onTypedAnswerChanged,
+                isAnswerShown = isAnswerShown,
+                onShowAnswer = onShowAnswer
             )
         }
 
@@ -139,7 +132,7 @@ fun AnswerButtons(
                 if (!moreOptionsInTopAppBar) {
                     IconButton(
                         onClick = onMoreOptionsClick,
-                        modifier = Modifier.height(48.dp),
+                        modifier = Modifier.height(AnswerButtonsConstants.ToolbarIconHeight),
                     ) {
                         Icon(
                             Icons.Filled.MoreVert,
@@ -151,115 +144,187 @@ fun AnswerButtons(
                     modifier = Modifier.animateContentSize(motionScheme.fastSpatialSpec())
                 ) {
                     if (!isAnswerShown) {
-                        val interactionSource = remember { MutableInteractionSource() }
-                        val isPressed by interactionSource.collectIsPressedAsState()
-                        val baseHorizontalPadding =
-                            ButtonDefaults.MediumContentPadding.calculateLeftPadding(
-                                layoutDirection = LocalLayoutDirection.current
-                            ) + if (moreOptionsInTopAppBar) 24.dp else 0.dp
-                        val horizontalPadding by animateDpAsState(
-                            if (isPressed) baseHorizontalPadding + 4.dp else baseHorizontalPadding,
-                            motionScheme.fastSpatialSpec()
+                        ShowAnswerButton(
+                            moreOptionsInTopAppBar = moreOptionsInTopAppBar,
+                            onShowAnswer = onShowAnswer
                         )
+                    } else {
+                        RatingButtons(
+                            showButtonBadges = showButtonBadges,
+                            adjustButtonStylesForBadges = adjustButtonStylesForBadges,
+                            onRateCard = onRateCard,
+                            nextTimes = nextTimes
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
+@Composable
+private fun AnswerTypeInTextField(
+    typedAnswer: String,
+    onTypedAnswerChanged: (String) -> Unit,
+    isAnswerShown: Boolean,
+    onShowAnswer: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
 
+    TextField(
+        value = typedAnswer,
+        onValueChange = onTypedAnswerChanged,
+        label = { Text(stringResource(R.string.type_in_the_answer)) },
+        modifier = Modifier
+            .fillMaxWidth(AnswerButtonsConstants.TextFieldMaxWidthFraction)
+            .border(
+                AnswerButtonsConstants.TextFieldBorderWidth,
+                if (isFocused) MaterialTheme.colorScheme.tertiary else Color.Transparent,
+                MaterialTheme.shapes.extraLargeIncreased
+            ),
+        shape = MaterialTheme.shapes.extraLargeIncreased,
+        interactionSource = interactionSource,
+        readOnly = isAnswerShown,
+        singleLine = true,
+        colors = TextFieldDefaults.colors(
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+        ),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = {
+            if (!isAnswerShown) {
+                onShowAnswer()
+            }
+        }),
+    )
+}
+
+@Composable
+private fun ShowAnswerButton(
+    moreOptionsInTopAppBar: Boolean,
+    onShowAnswer: () -> Unit
+) {
+    val view = LocalView.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val baseHorizontalPadding = ButtonDefaults.MediumContentPadding.calculateLeftPadding(
+        layoutDirection = LocalLayoutDirection.current
+    ) + if (moreOptionsInTopAppBar) AnswerButtonsConstants.ExpandedButtonHorizontalPadding else 0.dp
+
+    val horizontalPadding by animateDpAsState(
+        if (isPressed) baseHorizontalPadding + AnswerButtonsConstants.PressedAnimationExtraPadding else baseHorizontalPadding,
+        motionScheme.fastSpatialSpec(),
+        label = "ShowAnswerButtonPadding"
+    )
+
+    Button(
+        onClick = {
+            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            onShowAnswer()
+        },
+        modifier = Modifier.height(AnswerButtonsConstants.MainButtonHeight),
+        interactionSource = interactionSource,
+        contentPadding = PaddingValues(horizontal = horizontalPadding),
+        colors = ButtonDefaults.buttonColors(
+            MaterialTheme.colorScheme.primary,
+            MaterialTheme.colorScheme.onPrimary
+        )
+    ) {
+        Text(
+            text = stringResource(R.string.show_answer),
+            softWrap = false,
+            overflow = TextOverflow.Clip
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun RatingButtons(
+    showButtonBadges: Boolean,
+    adjustButtonStylesForBadges: Boolean,
+    onRateCard: (CardAnswer.Rating) -> Unit,
+    nextTimes: List<String>
+) {
+    val view = LocalView.current
+    ButtonGroup(
+        horizontalArrangement = Arrangement.spacedBy(AnswerButtonsConstants.RatingButtonGroupSpacing),
+        overflowIndicator = { }
+    ) {
+        ratings.forEachIndexed { index, (labelResId, rating) ->
+            customItem(
+                buttonGroupContent = {
+                    val interactionSource = remember { MutableInteractionSource() }
+                    val labelText = stringResource(labelResId)
+                    val nextTime = nextTimes.getOrElse(index) { "" }
+
+                    Box(
+                        modifier = Modifier
+                            .animateWidth(interactionSource)
+                            .semantics {
+                                contentDescription = "$labelText, $nextTime"
+                            },
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
                         Button(
                             onClick = {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                                onShowAnswer()
+                                onRateCard(rating)
                             },
-                            modifier = Modifier.height(56.dp),
+                            modifier = Modifier
+                                .height(AnswerButtonsConstants.MainButtonHeight)
+                                .fillMaxWidth()
+                                .then(
+                                    if (showButtonBadges && !adjustButtonStylesForBadges) {
+                                        Modifier.padding(bottom = AnswerButtonsConstants.BadgeBottomPadding)
+                                    } else Modifier
+                                ),
+                            contentPadding = if (adjustButtonStylesForBadges) {
+                                PaddingValues(horizontal = AnswerButtonsConstants.AdjustedButtonHorizontalPadding)
+                            } else ButtonDefaults.ExtraSmallContentPadding,
+                            shape = when (index) {
+                                0 -> ButtonGroupDefaults.connectedLeadingButtonShape
+                                ratings.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShape
+                                else -> ButtonGroupDefaults.connectedMiddleButtonShapes().shape
+                            },
                             interactionSource = interactionSource,
-                            contentPadding = PaddingValues(horizontal = horizontalPadding),
                             colors = ButtonDefaults.buttonColors(
                                 MaterialTheme.colorScheme.primary,
                                 MaterialTheme.colorScheme.onPrimary
                             )
                         ) {
                             Text(
-                                text = stringResource(R.string.show_answer),
+                                modifier = if (adjustButtonStylesForBadges) {
+                                    Modifier
+                                        .fillMaxHeight()
+                                        .padding(top = AnswerButtonsConstants.AdjustedTextTopPadding)
+                                } else Modifier,
+                                text = nextTime,
                                 softWrap = false,
-                                overflow = TextOverflow.Clip
+                                overflow = TextOverflow.Visible
                             )
                         }
-                    } else {
-                        ButtonGroup(
-                            horizontalArrangement = Arrangement.spacedBy(2.dp),
-                            overflowIndicator = { }) {
-                            ratings.forEachIndexed { index, (labelResId, rating) ->
-                                customItem(
-                                    buttonGroupContent = {
-                                        val interactionSource =
-                                            remember { MutableInteractionSource() }
 
-                                        Box(
-                                            modifier = Modifier.animateWidth(interactionSource),
-                                            contentAlignment = Alignment.BottomCenter
-                                        ) {
-                                            Button(
-                                                onClick = {
-                                                    view.performHapticFeedback(
-                                                        HapticFeedbackConstants.KEYBOARD_TAP
-                                                    )
-                                                    onRateCard(rating)
-                                                },
-                                                modifier = Modifier
-                                                    .height(56.dp)
-                                                    .fillMaxWidth()
-                                                    .then(
-                                                        if (showButtonBadges && !adjustButtonStylesForBadges) Modifier.padding(
-                                                            bottom = 6.dp
-                                                        )
-                                                        else Modifier
-                                                    ), // add slight padding so the badge doesn't overlap excessively
-                                                contentPadding = if (adjustButtonStylesForBadges) PaddingValues(
-                                                    horizontal = 28.dp,
-                                                ) else ButtonDefaults.ExtraSmallContentPadding,
-                                                shape = when (index) {
-                                                    0 -> ButtonGroupDefaults.connectedLeadingButtonShape
-                                                    ratings.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShape
-                                                    else -> ButtonGroupDefaults.connectedMiddleButtonShapes().shape
-                                                },
-                                                interactionSource = interactionSource,
-                                                colors = ButtonDefaults.buttonColors(
-                                                    MaterialTheme.colorScheme.primary,
-                                                    MaterialTheme.colorScheme.onPrimary
-                                                )
-                                            ) {
-                                                Text(
-                                                    modifier = if (adjustButtonStylesForBadges) Modifier
-                                                        .fillMaxHeight()
-                                                        .padding(top = 14.dp) else Modifier,
-                                                    text = nextTimes.getOrElse(index) { "" },
-                                                    softWrap = false,
-                                                    overflow = TextOverflow.Visible
-                                                )
-                                            }
-
-                                            if (showButtonBadges) {
-                                                Badge(
-                                                    modifier = if (adjustButtonStylesForBadges) Modifier.padding(
-                                                        bottom = 2.dp
-                                                    ) else Modifier,
-                                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                                ) {
-                                                    Text(
-                                                        modifier = Modifier.padding(1.dp),
-                                                        text = stringResource(labelResId),
-                                                        style = MaterialTheme.typography.labelSmall
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    },
-                                    menuContent = {},
+                        if (showButtonBadges) {
+                            Badge(
+                                modifier = if (adjustButtonStylesForBadges) {
+                                    Modifier.padding(bottom = AnswerButtonsConstants.AdjustedBadgeBottomPadding)
+                                } else Modifier,
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ) {
+                                Text(
+                                    modifier = Modifier.padding(1.dp),
+                                    text = labelText,
+                                    style = MaterialTheme.typography.labelSmall
                                 )
                             }
                         }
                     }
-                }
-            }
+                },
+                menuContent = {},
+            )
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -81,7 +81,7 @@ val ratings = listOf(
 fun AnswerButtons(
     modifier: Modifier = Modifier,
     isAnswerShown: Boolean,
-    showAnswerFeedback: Boolean,
+    showButtonBadges: Boolean,
     showTypeInAnswer: Boolean,
     typedAnswer: String,
     onTypedAnswerChanged: (String) -> Unit,
@@ -92,7 +92,7 @@ fun AnswerButtons(
     onMoreOptionsClick: () -> Unit
 ) {
     val view = LocalView.current
-    val adjustButtonStylesForBadges = showAnswerFeedback && moreOptionsInTopAppBar
+    val adjustButtonStylesForBadges = showButtonBadges && moreOptionsInTopAppBar
 
     Column(
         modifier = modifier.imePadding(),
@@ -207,7 +207,7 @@ fun AnswerButtons(
                                                     .height(56.dp)
                                                     .fillMaxWidth()
                                                     .then(
-                                                        if (showAnswerFeedback && !adjustButtonStylesForBadges) Modifier.padding(
+                                                        if (showButtonBadges && !adjustButtonStylesForBadges) Modifier.padding(
                                                             bottom = 6.dp
                                                         )
                                                         else Modifier
@@ -236,7 +236,7 @@ fun AnswerButtons(
                                                 )
                                             }
 
-                                            if (showAnswerFeedback) {
+                                            if (showButtonBadges) {
                                                 Badge(
                                                     modifier = if (adjustButtonStylesForBadges) Modifier.padding(
                                                         bottom = 2.dp
@@ -270,7 +270,7 @@ fun AnswerButtonsShowAnswerPreview() {
     AnkiDroidTheme {
         AnswerButtons(
             isAnswerShown = false,
-            showAnswerFeedback = true,
+            showButtonBadges = true,
             showTypeInAnswer = false,
             typedAnswer = "",
             onTypedAnswerChanged = {},
@@ -287,7 +287,7 @@ fun AnswerButtonsRatingPreview() {
     AnkiDroidTheme {
         AnswerButtons(
             isAnswerShown = true,
-            showAnswerFeedback = true,
+            showButtonBadges = true,
             showTypeInAnswer = false,
             typedAnswer = "",
             onTypedAnswerChanged = {},
@@ -304,7 +304,7 @@ fun AnswerButtonsNoFeedbackPreview() {
     AnkiDroidTheme {
         AnswerButtons(
             isAnswerShown = true,
-            showAnswerFeedback = false,
+            showButtonBadges = false,
             showTypeInAnswer = false,
             typedAnswer = "",
             onTypedAnswerChanged = {},
@@ -321,7 +321,7 @@ fun AnswerButtonsTypeInPreview() {
     AnkiDroidTheme {
         AnswerButtons(
             isAnswerShown = false,
-            showAnswerFeedback = true,
+            showButtonBadges = true,
             showTypeInAnswer = true,
             typedAnswer = "Typed Answer",
             onTypedAnswerChanged = {},
@@ -338,7 +338,7 @@ fun AnswerButtonsExpandedRatingPreview() {
     AnkiDroidTheme {
         AnswerButtons(
             isAnswerShown = true,
-            showAnswerFeedback = true,
+            showButtonBadges = true,
             showTypeInAnswer = false,
             typedAnswer = "",
             onTypedAnswerChanged = {},
@@ -356,7 +356,7 @@ fun AnswerButtonsExpandedShowAnswerPreview() {
     AnkiDroidTheme {
         AnswerButtons(
             isAnswerShown = false,
-            showAnswerFeedback = true,
+            showButtonBadges = true,
             showTypeInAnswer = false,
             typedAnswer = "",
             onTypedAnswerChanged = {},

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -87,6 +87,7 @@ fun AnswerButtons(
     onShowAnswer: () -> Unit,
     onRateCard: (CardAnswer.Rating) -> Unit,
     nextTimes: List<String>,
+    moreOptionsInTopAppBar: Boolean = false,
     onMoreOptionsClick: () -> Unit
 ) {
     val view = LocalView.current
@@ -133,14 +134,16 @@ fun AnswerButtons(
             colors = FloatingToolbarDefaults.vibrantFloatingToolbarColors(),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(
-                    onClick = onMoreOptionsClick,
-                    modifier = Modifier.height(48.dp),
-                ) {
-                    Icon(
-                        Icons.Filled.MoreVert,
-                        contentDescription = stringResource(R.string.more_options)
-                    )
+                if (!moreOptionsInTopAppBar) {
+                    IconButton(
+                        onClick = onMoreOptionsClick,
+                        modifier = Modifier.height(48.dp),
+                    ) {
+                        Icon(
+                            Icons.Filled.MoreVert,
+                            contentDescription = stringResource(R.string.more_options)
+                        )
+                    }
                 }
                 Box(
                     modifier = Modifier.animateContentSize(motionScheme.fastSpatialSpec())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/AnswerButtons.kt
@@ -74,7 +74,7 @@ import com.ichi2.anki.ui.compose.theme.AnkiDroidTheme
 private object AnswerButtonsConstants {
     val ColumnSpacing = 12.dp
     val TextFieldBorderWidth = 2.dp
-    val TextFieldMaxWidthFraction = 0.8f
+    const val TEXT_FIELD_MAX_WIDTH_FRACTION = 0.8f
     val ToolbarIconHeight = 48.dp
     val MainButtonHeight = 56.dp
     val RatingButtonGroupSpacing = 2.dp
@@ -177,7 +177,7 @@ private fun AnswerTypeInTextField(
         onValueChange = onTypedAnswerChanged,
         label = { Text(stringResource(R.string.type_in_the_answer)) },
         modifier = Modifier
-            .fillMaxWidth(AnswerButtonsConstants.TextFieldMaxWidthFraction)
+            .fillMaxWidth(AnswerButtonsConstants.TEXT_FIELD_MAX_WIDTH_FRACTION)
             .border(
                 AnswerButtonsConstants.TextFieldBorderWidth,
                 if (isFocused) MaterialTheme.colorScheme.tertiary else Color.Transparent,
@@ -202,8 +202,7 @@ private fun AnswerTypeInTextField(
 
 @Composable
 private fun ShowAnswerButton(
-    moreOptionsInTopAppBar: Boolean,
-    onShowAnswer: () -> Unit
+    moreOptionsInTopAppBar: Boolean, onShowAnswer: () -> Unit
 ) {
     val view = LocalView.current
     val interactionSource = remember { MutableInteractionSource() }
@@ -227,8 +226,7 @@ private fun ShowAnswerButton(
         interactionSource = interactionSource,
         contentPadding = PaddingValues(horizontal = horizontalPadding),
         colors = ButtonDefaults.buttonColors(
-            MaterialTheme.colorScheme.primary,
-            MaterialTheme.colorScheme.onPrimary
+            MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.onPrimary
         )
     ) {
         Text(
@@ -250,8 +248,7 @@ private fun RatingButtons(
     val view = LocalView.current
     ButtonGroup(
         horizontalArrangement = Arrangement.spacedBy(AnswerButtonsConstants.RatingButtonGroupSpacing),
-        overflowIndicator = { }
-    ) {
+        overflowIndicator = { }) {
         ratings.forEachIndexed { index, (labelResId, rating) ->
             customItem(
                 buttonGroupContent = {
@@ -264,8 +261,7 @@ private fun RatingButtons(
                             .animateWidth(interactionSource)
                             .semantics {
                                 contentDescription = "$labelText, $nextTime"
-                            },
-                        contentAlignment = Alignment.BottomCenter
+                            }, contentAlignment = Alignment.BottomCenter
                     ) {
                         Button(
                             onClick = {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -306,7 +306,9 @@ fun ReviewerContent(
                 flag = state.flag,
                 onToggleMark = { viewModel.onEvent(ReviewerEvent.ToggleMark) },
                 onSetFlag = { viewModel.onEvent(ReviewerEvent.SetFlag(it)) },
-                isAnswerShown = state.isAnswerShown
+                isAnswerShown = state.isAnswerShown,
+                showMoreOptions = Prefs.moreOptionsInTopAppBar,
+                onMoreOptionsClick = { showBottomSheet = true }
             ) { viewModel.onEvent(ReviewerEvent.UnanswerCard) }
         }) { paddingValues ->
             Box(
@@ -452,6 +454,7 @@ fun ReviewerContent(
                         onShowAnswer = { viewModel.onEvent(ReviewerEvent.ShowAnswer) },
                         onRateCard = { viewModel.onEvent(ReviewerEvent.RateCard(it)) },
                         nextTimes = state.nextTimes,
+                        moreOptionsInTopAppBar = Prefs.moreOptionsInTopAppBar,
                         onMoreOptionsClick = { showBottomSheet = true })
 
                     AnswerIndicator(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -443,7 +443,7 @@ fun ReviewerContent(
                             .padding(bottom = paddingValues.calculateBottomPadding())
                             .onSizeChanged { toolbarHeight = it.height },
                         isAnswerShown = state.isAnswerShown,
-                        showAnswerFeedback = Prefs.showAnswerButtonBadges,
+                        showButtonBadges = Prefs.showAnswerButtonBadges,
                         showTypeInAnswer = state.showTypeInAnswer,
                         typedAnswer = state.typedAnswer,
                         onTypedAnswerChanged = {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerTopBar.kt
@@ -20,6 +20,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -68,6 +71,8 @@ fun ReviewerTopBar(
     onSetFlag: (Int) -> Unit,
     modifier: Modifier = Modifier,
     isAnswerShown: Boolean,
+    showMoreOptions: Boolean = false,
+    onMoreOptionsClick: () -> Unit = {},
     onUnanswerCard: () -> Unit
 ) {
     CenterAlignedTopAppBar(
@@ -90,6 +95,14 @@ fun ReviewerTopBar(
                     Icon(
                         painterResource(R.drawable.undo_24px),
                         contentDescription = stringResource(id = R.string.unanswer_card),
+                    )
+                }
+            }
+            if (showMoreOptions) {
+                IconButton(onClick = onMoreOptionsClick) {
+                    Icon(
+                        Icons.Filled.MoreVert,
+                        contentDescription = stringResource(R.string.more_options)
                     )
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -242,6 +242,7 @@ object Prefs {
     val autoFocusTypeAnswer by booleanPref(R.string.type_in_answer_focus_key, true)
     val showAnswerFeedback by booleanPref(R.string.show_answer_feedback_key, defaultValue = true)
     val showAnswerButtonBadges by booleanPref(R.string.show_answer_button_badges_key, defaultValue = true)
+    val moreOptionsInTopAppBar by booleanPref(R.string.more_options_in_top_app_bar_key, defaultValue = false)
     val showAnswerButtons by booleanPref(R.string.show_answer_buttons_key, true)
     val applyHiramekiCss by stringPref(R.string.apply_hirameki_css_preference, defaultValue = HIRAMEKI_CSS_ALL)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.view.View
 import android.widget.Checkable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
@@ -94,11 +95,31 @@ class AnkiToggleView @JvmOverloads constructor(
             val interactionSource = remember { MutableInteractionSource() }
             AnkiToggle(
                 checked = isCheckedState, onCheckedChange = { newChecked ->
-                    isChecked = newChecked
-                    performClick()
+                    if (onCheckedChangeListener != null) {
+                        isChecked = newChecked
+                        performClick()
+                    } else if (hasOnClickListeners()) {
+                        performClick()
+                    } else {
+                        isChecked = newChecked
+                        if (!triggerParentClick()) {
+                            performClick()
+                        }
+                    }
                 }, interactionSource = interactionSource, enabled = isEnabledState
             )
         }
+    }
+
+    private fun triggerParentClick(): Boolean {
+        var current: android.view.ViewParent? = parent
+        while (current is View) {
+            if (current.hasOnClickListeners()) {
+                return current.performClick()
+            }
+            current = current.parent
+        }
+        return false
     }
 
     private class SavedState : BaseSavedState {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
@@ -99,6 +99,7 @@ class AnkiToggleView @JvmOverloads constructor(
                         isChecked = newChecked
                         performClick()
                     } else if (hasOnClickListeners()) {
+                        isChecked = newChecked
                         performClick()
                     } else {
                         isChecked = newChecked

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/compose/components/AnkiToggleView.kt
@@ -95,17 +95,12 @@ class AnkiToggleView @JvmOverloads constructor(
             val interactionSource = remember { MutableInteractionSource() }
             AnkiToggle(
                 checked = isCheckedState, onCheckedChange = { newChecked ->
-                    if (onCheckedChangeListener != null) {
+                    if (onCheckedChangeListener != null || hasOnClickListeners()) {
                         isChecked = newChecked
                         performClick()
-                    } else if (hasOnClickListeners()) {
+                    } else if (!triggerParentClick()) {
                         isChecked = newChecked
                         performClick()
-                    } else {
-                        isChecked = newChecked
-                        if (!triggerParentClick()) {
-                            performClick()
-                        }
                     }
                 }, interactionSource = interactionSource, enabled = isEnabledState
             )

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -449,6 +449,8 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
     <string name="show_answer_buttons" maxLength="41">Show answer buttons</string>
     <string name="show_answer_button_badges" maxLength="41">Show answer button badges</string>
     <string name="show_answer_button_badges_summ" maxLength="100">Display the answer difficulty labels on the answer buttons</string>
+    <string name="more_options_in_top_app_bar" maxLength="41">Move \'More options\' to top app bar</string>
+    <string name="more_options_in_top_app_bar_summ" maxLength="100">Display the overflow options menu in the top app bar instead of the bottom toolbar</string>
     <string name="hide_hard_and_easy" maxLength="41">Hide ‘Hard’ and ‘Easy’ buttons</string>
     <string name="reviewer_frame_style" maxLength="41">Frame style</string>
     <string name="reviewer_frame_style_card" maxLength="41" comment="Style name of the 'Card' card frame of the Study Screen"

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -247,4 +247,5 @@
     <string name="reviewer_toolbar_position_key">reviewerToolbarPosition</string>
     <string name="apply_hirameki_css_preference">applyHiramekiCss</string>
     <string name="reviewer_css_category">reviewer_css_category</string>
+    <string name="more_options_in_top_app_bar_key">moreOptionsInTopAppBar</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -60,6 +60,11 @@
             android:key="@string/show_answer_button_badges_key"
             android:title="@string/show_answer_button_badges"
             android:summary="@string/show_answer_button_badges_summ" />
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/more_options_in_top_app_bar_key"
+            android:title="@string/more_options_in_top_app_bar"
+            android:summary="@string/more_options_in_top_app_bar_summ" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/reviewer_css_styling" android:key="@string/reviewer_css_category">
         <ListPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.browser.RepositionCardsRequest.ContainsNonNewCardsError
 import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.ioDispatcher
+import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.QueueType

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/compose/components/AnkiToggleViewTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/compose/components/AnkiToggleViewTest.kt
@@ -1,0 +1,42 @@
+package com.ichi2.anki.ui.compose.components
+
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AnkiToggleViewTest {
+
+    @Test
+    fun testInitialStateAndSetChecked() {
+        val toggleView = AnkiToggleView(ApplicationProvider.getApplicationContext())
+        assertFalse(toggleView.isChecked)
+
+        var listenerCalled = false
+        var lastCheckedValue = false
+        toggleView.setOnCheckedChangeListener { _, checked ->
+            listenerCalled = true
+            lastCheckedValue = checked
+        }
+
+        toggleView.isChecked = true
+        assertTrue(toggleView.isChecked)
+        assertTrue(listenerCalled)
+        assertTrue(lastCheckedValue)
+    }
+
+    @Test
+    fun testToggle() {
+        val toggleView = AnkiToggleView(ApplicationProvider.getApplicationContext())
+        assertFalse(toggleView.isChecked)
+        toggleView.toggle()
+        assertTrue(toggleView.isChecked)
+        toggleView.toggle()
+        assertFalse(toggleView.isChecked)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a user feature toggle under **Settings → Reviewing** ("More options in top app bar") that moves the overflow (`MoreVert`) menu from the bottom floating toolbar to the top right app bar during card review. 

When enabled:
- The overflow icon is rendered in `ReviewerTopBar`.
- The answer buttons ("Show Answer" and the 4 rating buttons) expand horizontally to consume the freed-up space in the floating toolbar, making them larger and significantly easier to tap.
- Fixes an issue in `AnkiToggleView` where switch preference toggles inside `SwitchPreferenceCompat` were not persisting to `SharedPreferences`.

---

## Key Changes

### 1. Feature Toggle & Preferences
- **`preferences.xml` & `10-preferences.xml`**: Added `more_options_in_top_app_bar_key` key and localized string resources (`title` & `summary`) with `maxLength` annotations.
- **`preferences_reviewing.xml`**: Added `<SwitchPreferenceCompat>` for the new preference under Advanced settings.
- **`Prefs.kt`**: Added `moreOptionsInTopAppBar` delegate property.

### 2. Reviewer UI & Layout Expansion
- **`ReviewerTopBar.kt`**: Added `showMoreOptions` and `onMoreOptionsClick` parameters to render the `MoreVert` icon in top bar actions when enabled.
- **`AnswerButtons.kt`**:
  - Conditionally hides `MoreVert` from `HorizontalFloatingToolbar` when `moreOptionsInTopAppBar` is `true`.
  - Expands rating buttons (`ButtonGroup`) content padding from `8.dp` (`ExtraSmallContentPadding`) to `18.dp` (`+20.dp` per button, `+80.dp` total across the toolbar) so the buttons become larger instead of the toolbar shrinking.
  - Expands "Show Answer" button horizontal padding by `+24.dp`.
  - Added Compose previews `AnswerButtonsExpandedRatingPreview` and `AnswerButtonsExpandedShowAnswerPreview`.
- **`ReviewerCompose.kt`**: Connected `Prefs.moreOptionsInTopAppBar` state to `ReviewerTopBar` and `AnswerButtons`.

### 3. Setting Persistence Fix (`AnkiToggleView`)
- **`AnkiToggleView.kt`**: Updated `AnkiToggleView` (the custom Compose interop view for `@layout/preference_material_switch_widget`) to propagate touch clicks up the view tree (`triggerParentClick()`) to `PreferenceViewHolder.itemView`. This ensures `SwitchPreferenceCompat.onClick()` is invoked, `mChecked` is updated, and `persistBoolean()` writes setting changes to `SharedPreferences`.

---

## How to Test

1. Open **Settings → Reviewing → Advanced**.
2. Toggle **"More options in top app bar"** to **ON**.
3. Navigate back to Settings to confirm the toggle **persists as ON**.
4. Open the Reviewer screen:
   - Verify the `MoreVert` menu icon appears in the top-right app bar.
   - Verify the bottom floating toolbar no longer shows `MoreVert`.
   - Verify the 4 rating buttons (and "Show Answer" button) expand to take up the full toolbar width, appearing larger and easier to tap.
5. Open Compose Previews in Android Studio for `AnswerButtons.kt` to inspect the expanded button layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reviewing preference to move the “More options” menu to the top app bar.
  * Added a top-app-bar overflow button when enabled.
  * Improved review controls with clearer rating badges, animations, haptic feedback, and accessibility descriptions.

* **Bug Fixes**
  * Improved toggle behavior when clicks are handled by parent views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->