### PR TITLE
Implement whiteboard clearing when transitioning to a new card

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -94,8 +94,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode = 22300122
-        versionName = "1.1.8"
+        versionCode = 22300121
+        versionName = "1.1.7"
         minSdk = libs.versions.minSdk.get().toInteger()
 
         // After #13695: change .tests_emulator.yml

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -94,8 +94,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode = 22300121
-        versionName = "1.1.7"
+        versionCode = 22300122
+        versionName = "1.1.8"
         minSdk = libs.versions.minSdk.get().toInteger()
 
         // After #13695: change .tests_emulator.yml

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -114,7 +114,9 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import kotlin.coroutines.resume
 
-open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
+open class Reviewer :
+    AbstractFlashcardViewer(),
+    ReviewerUi {
     override var currentCard: Card?
         get() = viewModel.currentCardFlow.value
         set(value) {
@@ -168,25 +170,28 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
-        addNoteLauncher = registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult(),
-            FlashCardViewerResultCallback(),
-        )
+        addNoteLauncher =
+            registerForActivityResult(
+                ActivityResultContracts.StartActivityForResult(),
+                FlashCardViewerResultCallback(),
+            )
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
         val composeView = ComposeView(this)
-        val coordinatorLayout = CoordinatorLayout(this).apply {
-            id = R.id.root_layout
-            isFocusable = true
-            isFocusableInTouchMode = true
-            addView(
-                composeView, android.view.ViewGroup.LayoutParams(
-                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                    android.view.ViewGroup.LayoutParams.MATCH_PARENT
+        val coordinatorLayout =
+            CoordinatorLayout(this).apply {
+                id = R.id.root_layout
+                isFocusable = true
+                isFocusableInTouchMode = true
+                addView(
+                    composeView,
+                    android.view.ViewGroup.LayoutParams(
+                        android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                        android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                    ),
                 )
-            )
-        }
+            }
         setContentView(coordinatorLayout)
 
         if (!ensureStoragePermissions()) {
@@ -199,7 +204,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                 com.ichi2.anki.reviewer.compose.ReviewerContent(
                     viewModel = viewModel,
                     whiteboardViewModel = whiteboardViewModel,
-                    voicePlaybackViewModel = voicePlaybackViewModel
+                    voicePlaybackViewModel = voicePlaybackViewModel,
                 )
             }
         }
@@ -243,14 +248,12 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                         }
                     }
                     is ReviewerEffect.NavigateToDeckOptions -> {
-                        val i = DeckOptions.getIntent(
-                            this@Reviewer,
-                            getColUnsafe.decks.current().id,
-                        )
+                        val i =
+                            DeckOptions.getIntent(
+                                this@Reviewer,
+                                getColUnsafe.decks.current().id,
+                            )
                         deckOptionsLauncher.launch(i)
-                    }
-                    is ReviewerEffect.ClearWhiteboard -> {
-                        // Handled in Compose
                     }
                 }
             }
@@ -352,7 +355,6 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         // Select the deck
         getColUnsafe.decks.select(did)
     }
-
 
     public override fun fitsSystemWindows(): Boolean = !fullscreenMode.isFullScreenReview()
 
@@ -505,10 +507,11 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
 
             R.id.action_open_deck_options -> {
                 Timber.i("Reviewer:: Opening deck options")
-                val i = DeckOptions.getIntent(
-                    this,
-                    getColUnsafe.decks.current().id,
-                )
+                val i =
+                    DeckOptions.getIntent(
+                        this,
+                        getColUnsafe.decks.current().id,
+                    )
                 deckOptionsLauncher.launch(i)
             }
 
@@ -623,7 +626,10 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         grantResults: IntArray,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == ReviewerConstants.REQUEST_AUDIO_PERMISSION && permissions.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        if (requestCode == ReviewerConstants.REQUEST_AUDIO_PERMISSION &&
+            permissions.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        ) {
             // Audio permission granted, start recording
             voicePlaybackViewModel.toggleRecording(this)
         }
@@ -652,10 +658,11 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
             return
         }
         Timber.i("opening card info")
-        val intent = CardInfoDestination(
-            currentCard!!.id,
-            TR.cardStatsCurrentCard(TR.decksStudy()),
-        ).toIntent(this)
+        val intent =
+            CardInfoDestination(
+                currentCard!!.id,
+                TR.cardStatsCurrentCard(TR.decksStudy()),
+            ).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
         startActivityWithAnimation(intent, animation)
@@ -789,12 +796,14 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                 changePenColorIcon.isVisible = true
             }
             val whiteboardIcon =
-                ContextCompat.getDrawable(applicationContext, R.drawable.ic_gesture_white)!!
+                ContextCompat
+                    .getDrawable(applicationContext, R.drawable.ic_gesture_white)!!
                     .mutate()
             val stylusIcon =
                 ContextCompat.getDrawable(this, R.drawable.ic_gesture_stylus)!!.mutate()
             val whiteboardColorPaletteIcon =
-                ContextCompat.getDrawable(applicationContext, R.drawable.ic_color_lens_white_24dp)!!
+                ContextCompat
+                    .getDrawable(applicationContext, R.drawable.ic_color_lens_white_24dp)!!
                     .mutate()
             val eraserIcon =
                 ContextCompat.getDrawable(applicationContext, R.drawable.ic_eraser)!!.mutate()
@@ -879,10 +888,11 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         try {
             if (menu is MenuBuilder) {
                 // Use reflection to bypass package-private visibility
-                val method = menu.javaClass.getDeclaredMethod(
-                    "setOptionalIconsVisible",
-                    Boolean::class.javaPrimitiveType,
-                )
+                val method =
+                    menu.javaClass.getDeclaredMethod(
+                        "setOptionalIconsVisible",
+                        Boolean::class.javaPrimitiveType,
+                    )
                 method.isAccessible = true
                 method.invoke(menu, true)
             }
@@ -1020,9 +1030,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         }
     }
 
-    override fun getCardMediaPlayers(): List<CardMediaPlayer> {
-        return super.getCardMediaPlayers() + viewModel.cardMediaPlayer
-    }
+    override fun getCardMediaPlayers(): List<CardMediaPlayer> = super.getCardMediaPlayers() + viewModel.cardMediaPlayer
 
     override fun initControls() {
         super.initControls()
@@ -1137,30 +1145,40 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
     override suspend fun handlePostRequest(
         uri: String,
         bytes: ByteArray,
-    ): ByteArray = if (uri.startsWith(ANKI_PREFIX)) {
-        when (val methodName = uri.substring(ANKI_PREFIX.length)) {
-            "getSchedulingStatesWithContext" -> getSchedulingStatesWithContext()
-            "setSchedulingStates" -> setSchedulingStates(bytes)
-            "i18nResources" -> withCol { i18nResourcesRaw(bytes) }
-            else -> throw IllegalArgumentException("unhandled request: $methodName")
+    ): ByteArray =
+        if (uri.startsWith(ANKI_PREFIX)) {
+            when (val methodName = uri.substring(ANKI_PREFIX.length)) {
+                "getSchedulingStatesWithContext" -> getSchedulingStatesWithContext()
+                "setSchedulingStates" -> setSchedulingStates(bytes)
+                "i18nResources" -> withCol { i18nResourcesRaw(bytes) }
+                else -> throw IllegalArgumentException("unhandled request: $methodName")
+            }
+        } else if (uri.startsWith(ANKIDROID_JS_PREFIX)) {
+            jsApi.handleJsApiRequest(
+                uri.substring(ANKIDROID_JS_PREFIX.length),
+                bytes,
+                returnDefaultValues = false,
+            )
+        } else {
+            throw IllegalArgumentException("unhandled request: $uri")
         }
-    } else if (uri.startsWith(ANKIDROID_JS_PREFIX)) {
-        jsApi.handleJsApiRequest(
-            uri.substring(ANKIDROID_JS_PREFIX.length),
-            bytes,
-            returnDefaultValues = false,
-        )
-    } else {
-        throw IllegalArgumentException("unhandled request: $uri")
-    }
 
     private fun getSchedulingStatesWithContext(): ByteArray {
         val state = queueState ?: return ByteArray(0)
-        return state.schedulingStatesWithContext().toBuilder().mergeStates(
-            state.states.toBuilder().mergeCurrent(
-                state.states.current.toBuilder().setCustomData(state.topCard.customData).build(),
-            ).build(),
-        ).build().toByteArray()
+        return state
+            .schedulingStatesWithContext()
+            .toBuilder()
+            .mergeStates(
+                state.states
+                    .toBuilder()
+                    .mergeCurrent(
+                        state.states.current
+                            .toBuilder()
+                            .setCustomData(state.topCard.customData)
+                            .build(),
+                    ).build(),
+            ).build()
+            .toByteArray()
     }
 
     private fun setSchedulingStates(bytes: ByteArray): ByteArray {
@@ -1227,24 +1245,25 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
     fun hasDrawerSwipeConflicts(): Boolean = hasDrawerSwipeConflicts
 
     override fun getCardDataForJsApi(): AnkiDroidJsAPI.CardDataForJsApi {
-        val cardDataForJsAPI = AnkiDroidJsAPI.CardDataForJsApi().apply {
-            newCardCount = queueState?.counts?.new ?: -1
-            lrnCardCount = queueState?.counts?.lrn ?: -1
-            revCardCount = queueState?.counts?.rev ?: -1
-            if (currentCard != null) {
-                val s = getColUnsafe.sched
-                nextTime1 = s.nextIvlStr(currentCard!!, Rating.AGAIN)
-                nextTime2 = s.nextIvlStr(currentCard!!, Rating.HARD)
-                nextTime3 = s.nextIvlStr(currentCard!!, Rating.GOOD)
-                nextTime4 = s.nextIvlStr(currentCard!!, Rating.EASY)
-            } else {
-                nextTime1 = ""
-                nextTime2 = ""
-                nextTime3 = ""
-                nextTime4 = ""
+        val cardDataForJsAPI =
+            AnkiDroidJsAPI.CardDataForJsApi().apply {
+                newCardCount = queueState?.counts?.new ?: -1
+                lrnCardCount = queueState?.counts?.lrn ?: -1
+                revCardCount = queueState?.counts?.rev ?: -1
+                if (currentCard != null) {
+                    val s = getColUnsafe.sched
+                    nextTime1 = s.nextIvlStr(currentCard!!, Rating.AGAIN)
+                    nextTime2 = s.nextIvlStr(currentCard!!, Rating.HARD)
+                    nextTime3 = s.nextIvlStr(currentCard!!, Rating.GOOD)
+                    nextTime4 = s.nextIvlStr(currentCard!!, Rating.EASY)
+                } else {
+                    nextTime1 = ""
+                    nextTime2 = ""
+                    nextTime3 = ""
+                    nextTime4 = ""
+                }
+                eta = this@Reviewer.eta
             }
-            eta = this@Reviewer.eta
-        }
         return cardDataForJsAPI
     }
 
@@ -1255,41 +1274,44 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
         const val EXTRA_DECK_ID = "deckId"
 
         /** Maps ViewerCommand to corresponding Flag for toggle operations */
-        private val VIEWER_COMMAND_TO_FLAG = mapOf(
-            ViewerCommand.TOGGLE_FLAG_RED to Flag.RED,
-            ViewerCommand.TOGGLE_FLAG_ORANGE to Flag.ORANGE,
-            ViewerCommand.TOGGLE_FLAG_GREEN to Flag.GREEN,
-            ViewerCommand.TOGGLE_FLAG_BLUE to Flag.BLUE,
-            ViewerCommand.TOGGLE_FLAG_PINK to Flag.PINK,
-            ViewerCommand.TOGGLE_FLAG_TURQUOISE to Flag.TURQUOISE,
-            ViewerCommand.TOGGLE_FLAG_PURPLE to Flag.PURPLE,
-        )
+        private val VIEWER_COMMAND_TO_FLAG =
+            mapOf(
+                ViewerCommand.TOGGLE_FLAG_RED to Flag.RED,
+                ViewerCommand.TOGGLE_FLAG_ORANGE to Flag.ORANGE,
+                ViewerCommand.TOGGLE_FLAG_GREEN to Flag.GREEN,
+                ViewerCommand.TOGGLE_FLAG_BLUE to Flag.BLUE,
+                ViewerCommand.TOGGLE_FLAG_PINK to Flag.PINK,
+                ViewerCommand.TOGGLE_FLAG_TURQUOISE to Flag.TURQUOISE,
+                ViewerCommand.TOGGLE_FLAG_PURPLE to Flag.PURPLE,
+            )
 
         /** Maps ViewerCommand to corresponding user action number */
-        private val VIEWER_COMMAND_TO_USER_ACTION = mapOf(
-            ViewerCommand.USER_ACTION_1 to 1,
-            ViewerCommand.USER_ACTION_2 to 2,
-            ViewerCommand.USER_ACTION_3 to 3,
-            ViewerCommand.USER_ACTION_4 to 4,
-            ViewerCommand.USER_ACTION_5 to 5,
-            ViewerCommand.USER_ACTION_6 to 6,
-            ViewerCommand.USER_ACTION_7 to 7,
-            ViewerCommand.USER_ACTION_8 to 8,
-            ViewerCommand.USER_ACTION_9 to 9,
-        )
+        private val VIEWER_COMMAND_TO_USER_ACTION =
+            mapOf(
+                ViewerCommand.USER_ACTION_1 to 1,
+                ViewerCommand.USER_ACTION_2 to 2,
+                ViewerCommand.USER_ACTION_3 to 3,
+                ViewerCommand.USER_ACTION_4 to 4,
+                ViewerCommand.USER_ACTION_5 to 5,
+                ViewerCommand.USER_ACTION_6 to 6,
+                ViewerCommand.USER_ACTION_7 to 7,
+                ViewerCommand.USER_ACTION_8 to 8,
+                ViewerCommand.USER_ACTION_9 to 9,
+            )
 
         /** Menu item IDs for user actions, ordered 1-9 */
-        private val USER_ACTION_MENU_IDS = listOf(
-            R.id.user_action_1,
-            R.id.user_action_2,
-            R.id.user_action_3,
-            R.id.user_action_4,
-            R.id.user_action_5,
-            R.id.user_action_6,
-            R.id.user_action_7,
-            R.id.user_action_8,
-            R.id.user_action_9,
-        )
+        private val USER_ACTION_MENU_IDS =
+            listOf(
+                R.id.user_action_1,
+                R.id.user_action_2,
+                R.id.user_action_3,
+                R.id.user_action_4,
+                R.id.user_action_5,
+                R.id.user_action_6,
+                R.id.user_action_7,
+                R.id.user_action_8,
+                R.id.user_action_9,
+            )
 
         fun getIntent(context: Context): Intent = Intent(context, Reviewer::class.java)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -249,6 +249,11 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                         )
                         deckOptionsLauncher.launch(i)
                     }
+                    is ReviewerEffect.ClearWhiteboard -> {
+                        if (::whiteboardController.isInitialized) {
+                            whiteboardController.updateForNewCard()
+                        }
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -250,9 +250,7 @@ open class Reviewer : AbstractFlashcardViewer(), ReviewerUi {
                         deckOptionsLauncher.launch(i)
                     }
                     is ReviewerEffect.ClearWhiteboard -> {
-                        if (::whiteboardController.isInitialized) {
-                            whiteboardController.updateForNewCard()
-                        }
+                        // Handled in Compose
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -69,13 +69,22 @@ import java.io.File
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-sealed class MediaError(open val message: String) {
-    data class PlaybackError(val uri: Uri, override val message: String) : MediaError(message)
-    data class TtsError(val error: TtsPlayer.TtsError, override val message: String) :
-        MediaError(message)
+sealed class MediaError(
+    open val message: String,
+) {
+    data class PlaybackError(
+        val uri: Uri,
+        override val message: String,
+    ) : MediaError(message)
+
+    data class TtsError(
+        val error: TtsPlayer.TtsError,
+        override val message: String,
+    ) : MediaError(message)
 }
 
 data class ReviewerState(
+    val cardDisplayIndex: Long = 0L,
     val newCount: Int = 0,
     val learnCount: Int = 0,
     val reviewCount: Int = 0,
@@ -96,11 +105,12 @@ data class ReviewerState(
     val isFinished: Boolean = false,
     val isWhiteboardEnabled: Boolean = false,
     val isVoicePlaybackEnabled: Boolean = false,
-    val mediaError: MediaError? = null
+    val mediaError: MediaError? = null,
 )
 
 data class AnswerFeedback(
-    val rating: CardAnswer.Rating, val id: String = UUID.randomUUID().toString()
+    val rating: CardAnswer.Rating,
+    val id: String = UUID.randomUUID().toString(),
 )
 
 data class ReviewerJavascriptCommand(
@@ -112,53 +122,116 @@ private const val MAX_PENDING_JAVASCRIPT_COMMANDS = 16
 
 sealed class ReviewerEvent {
     object ShowAnswer : ReviewerEvent()
-    data class RateCard(val rating: CardAnswer.Rating) : ReviewerEvent()
+
+    data class RateCard(
+        val rating: CardAnswer.Rating,
+    ) : ReviewerEvent()
+
     object LoadInitialCard : ReviewerEvent()
-    data class OnTypedAnswerChanged(val newText: String) : ReviewerEvent()
+
+    data class OnTypedAnswerChanged(
+        val newText: String,
+    ) : ReviewerEvent()
+
     object ToggleMark : ReviewerEvent()
-    data class SetFlag(val flag: Int) : ReviewerEvent()
-    data class LinkClicked(val url: String) : ReviewerEvent()
-    data class PlayAudio(val side: String, val index: Int) : ReviewerEvent()
+
+    data class SetFlag(
+        val flag: Int,
+    ) : ReviewerEvent()
+
+    data class LinkClicked(
+        val url: String,
+    ) : ReviewerEvent()
+
+    data class PlayAudio(
+        val side: String,
+        val index: Int,
+    ) : ReviewerEvent()
+
     object EditCard : ReviewerEvent()
+
     object BuryCard : ReviewerEvent()
+
     object SuspendCard : ReviewerEvent()
+
     object UnanswerCard : ReviewerEvent()
+
     object ReloadCard : ReviewerEvent()
+
     object Redo : ReviewerEvent()
+
     object ToggleWhiteboard : ReviewerEvent()
-    data class OnWhiteboardStateChanged(val enabled: Boolean) : ReviewerEvent()
+
+    data class OnWhiteboardStateChanged(
+        val enabled: Boolean,
+    ) : ReviewerEvent()
+
     object EditTags : ReviewerEvent()
+
     object DeleteNote : ReviewerEvent()
+
     object RescheduleCard : ReviewerEvent()
+
     object DismissSetDueDateDialog : ReviewerEvent()
-    data class SetDueDateConfirmed(val count: Int) : ReviewerEvent()
+
+    data class SetDueDateConfirmed(
+        val count: Int,
+    ) : ReviewerEvent()
+
     object ReplayMedia : ReviewerEvent()
+
     object ToggleVoicePlayback : ReviewerEvent()
-    data class OnVoicePlaybackStateChanged(val enabled: Boolean) : ReviewerEvent()
+
+    data class OnVoicePlaybackStateChanged(
+        val enabled: Boolean,
+    ) : ReviewerEvent()
+
     object DeckOptions : ReviewerEvent()
+
     object MediaErrorHandled : ReviewerEvent()
+
     object AnswerFeedbackShown : ReviewerEvent()
+
     object Undo : ReviewerEvent()
 }
 
 sealed class ReviewerEffect {
-    data class NavigateToEditCard(val cardId: CardId) : ReviewerEffect()
+    data class NavigateToEditCard(
+        val cardId: CardId,
+    ) : ReviewerEffect()
+
     object NavigateToDeckPicker : ReviewerEffect()
-    data class ShowSnackbar(val message: String) : ReviewerEffect()
+
+    data class ShowSnackbar(
+        val message: String,
+    ) : ReviewerEffect()
+
     object PerformRedo : ReviewerEffect()
+
     object ToggleWhiteboard : ReviewerEffect()
-    data class ShowDeleteNoteDialog(val card: Card) : ReviewerEffect()
-    data class ReplayMedia(val card: Card) : ReviewerEffect()
+
+    data class ShowDeleteNoteDialog(
+        val card: Card,
+    ) : ReviewerEffect()
+
+    data class ReplayMedia(
+        val card: Card,
+    ) : ReviewerEffect()
+
     object ToggleVoicePlayback : ReviewerEffect()
+
     object NavigateToDeckOptions : ReviewerEffect()
-    data class ShowTimeboxReachedDialog(val timebox: Collection.TimeboxReached) : ReviewerEffect()
-    object ClearWhiteboard : ReviewerEffect()
+
+    data class ShowTimeboxReachedDialog(
+        val timebox: Collection.TimeboxReached,
+    ) : ReviewerEffect()
 }
 
 class ReviewerViewModel(
-    app: Application, private val dispatcher: CoroutineDispatcher = ioDispatcher
-) : AndroidViewModel(app), PostRequestHandler {
-
+    app: Application,
+    private val dispatcher: CoroutineDispatcher = ioDispatcher,
+) : AndroidViewModel(app),
+    PostRequestHandler {
     private val server = AnkiServer(this)
     var jsApi: com.ichi2.anki.AnkiDroidJsAPI? = null
 
@@ -206,33 +279,43 @@ class ReviewerViewModel(
     val flowOfDeleteResult: SharedFlow<Int> = _flowOfDeleteResult.asSharedFlow()
     private val nextJavascriptCommandId = AtomicInteger(0)
     internal val typeAnswer = TypeAnswer.createInstance(app.sharedPrefs())
-    internal val cardMediaPlayer: CardMediaPlayer = CardMediaPlayer({ script ->
-        enqueueJavascriptCommand(script)
-    }, object : MediaErrorListener {
-        override fun onError(uri: Uri): MediaErrorBehavior {
-            Timber.w("Error playing media: %s", uri)
-            val message = getApplication<Application>().getString(R.string.media_load_failed)
-            _state.update { it.copy(mediaError = MediaError.PlaybackError(uri, message)) }
-            return MediaErrorBehavior.CONTINUE_MEDIA
-        }
+    internal val cardMediaPlayer: CardMediaPlayer =
+        CardMediaPlayer(
+            { script ->
+                enqueueJavascriptCommand(script)
+            },
+            object : MediaErrorListener {
+                override fun onError(uri: Uri): MediaErrorBehavior {
+                    Timber.w("Error playing media: %s", uri)
+                    val message = getApplication<Application>().getString(R.string.media_load_failed)
+                    _state.update { it.copy(mediaError = MediaError.PlaybackError(uri, message)) }
+                    return MediaErrorBehavior.CONTINUE_MEDIA
+                }
 
-        override fun onMediaPlayerError(
-            mp: MediaPlayer?, which: Int, extra: Int, uri: Uri
-        ): MediaErrorBehavior {
-            Timber.w("Error playing media: %s", uri)
-            val message = getApplication<Application>().getString(R.string.media_load_failed)
-            _state.update { it.copy(mediaError = MediaError.PlaybackError(uri, message)) }
-            return MediaErrorBehavior.CONTINUE_MEDIA
-        }
+                override fun onMediaPlayerError(
+                    mp: MediaPlayer?,
+                    which: Int,
+                    extra: Int,
+                    uri: Uri,
+                ): MediaErrorBehavior {
+                    Timber.w("Error playing media: %s", uri)
+                    val message = getApplication<Application>().getString(R.string.media_load_failed)
+                    _state.update { it.copy(mediaError = MediaError.PlaybackError(uri, message)) }
+                    return MediaErrorBehavior.CONTINUE_MEDIA
+                }
 
-        override fun onTtsError(error: TtsPlayer.TtsError, isAutomaticPlayback: Boolean) {
-            Timber.w("TTS error: %s", error)
-            if (!isAutomaticPlayback) {
-                val message = getApplication<Application>().getString(R.string.tts_playback_failed)
-                _state.update { it.copy(mediaError = MediaError.TtsError(error, message)) }
-            }
-        }
-    })
+                override fun onTtsError(
+                    error: TtsPlayer.TtsError,
+                    isAutomaticPlayback: Boolean,
+                ) {
+                    Timber.w("TTS error: %s", error)
+                    if (!isAutomaticPlayback) {
+                        val message = getApplication<Application>().getString(R.string.tts_playback_failed)
+                        _state.update { it.copy(mediaError = MediaError.TtsError(error, message)) }
+                    }
+                }
+            },
+        )
 
     /** A job that is running for the current card. This is used to prevent multiple actions from running at the same time. */
     private var cardActionJob: Job? = null
@@ -253,9 +336,11 @@ class ReviewerViewModel(
      */
     private fun launchCardAction(block: suspend () -> Unit) {
         if (cardActionJob?.isActive == true || _state.value.isFinished) return
-        trackCardAction(viewModelScope.launch(dispatcher) {
-            block()
-        })
+        trackCardAction(
+            viewModelScope.launch(dispatcher) {
+                block()
+            },
+        )
     }
 
     /**
@@ -269,10 +354,12 @@ class ReviewerViewModel(
             return
         }
 
-        trackCardAction(viewModelScope.launch(dispatcher) {
-            currentJob.join()
-            block()
-        })
+        trackCardAction(
+            viewModelScope.launch(dispatcher) {
+                currentJob.join()
+                block()
+            },
+        )
     }
 
     init {
@@ -293,10 +380,13 @@ class ReviewerViewModel(
 
     private fun enqueueJavascriptCommand(script: String) {
         _evalCommand.update { commands ->
-            (commands + ReviewerJavascriptCommand(
-                nextJavascriptCommandId.incrementAndGet(),
-                script
-            )).takeLast(MAX_PENDING_JAVASCRIPT_COMMANDS)
+            (
+                commands +
+                    ReviewerJavascriptCommand(
+                        nextJavascriptCommandId.incrementAndGet(),
+                        script,
+                    )
+            ).takeLast(MAX_PENDING_JAVASCRIPT_COMMANDS)
         }
     }
 
@@ -304,7 +394,10 @@ class ReviewerViewModel(
         _evalCommand.value = emptyList()
     }
 
-    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray =
+    override suspend fun handlePostRequest(
+        uri: String,
+        bytes: ByteArray,
+    ): ByteArray =
         if (uri.startsWith(AnkiServer.ANKI_PREFIX)) {
             val path = uri.substring(AnkiServer.ANKI_PREFIX.length)
             when {
@@ -312,7 +405,9 @@ class ReviewerViewModel(
                     val api =
                         checkNotNull(jsApi) { "jsApi must be set before handling jsapi/ requests" }
                     api.handleJsApiRequest(
-                        path.substring("jsapi/".length), bytes, returnDefaultValues = false
+                        path.substring("jsapi/".length),
+                        bytes,
+                        returnDefaultValues = false,
                     )
                 }
 
@@ -327,10 +422,11 @@ class ReviewerViewModel(
         when (event) {
             is ReviewerEvent.ShowAnswer -> showAnswer()
             is ReviewerEvent.RateCard -> rateCard(event.rating)
-            is ReviewerEvent.LoadInitialCard -> launchCardAction {
-                withCol { startTimebox() }
-                loadCardSuspend()
-            }
+            is ReviewerEvent.LoadInitialCard ->
+                launchCardAction {
+                    withCol { startTimebox() }
+                    loadCardSuspend()
+                }
 
             is ReviewerEvent.OnTypedAnswerChanged -> onTypedAnswerChanged(event.newText)
             is ReviewerEvent.ToggleMark -> toggleMark()
@@ -409,9 +505,10 @@ class ReviewerViewModel(
         val targetCardId = cardId ?: return
         launchCardAction {
             cardMediaPlayer.stop()
-            val deletedCount = undoableOp(this@ReviewerViewModel) {
-                removeNotes(cardIds = listOf(targetCardId))
-            }.count
+            val deletedCount =
+                undoableOp(this@ReviewerViewModel) {
+                    removeNotes(cardIds = listOf(targetCardId))
+                }.count
             loadCardSuspend()
             _flowOfDeleteResult.emit(deletedCount)
         }
@@ -549,25 +646,26 @@ class ReviewerViewModel(
 
             queue = this.sched.currentQueueState()
 
-            updatedState = _state.value.copy(
-                mediaError = null,
-                newCount = queue?.counts?.new ?: 0,
-                learnCount = queue?.counts?.lrn ?: 0,
-                reviewCount = queue?.counts?.rev ?: 0,
-                questionHtml = processedQuestionHtml,
-                answerHtml = processedAnswerHtml,
-                bodyClass = bodyClassForCardOrd(card.ord),
-                baseUrl = server.baseUrl(),
-                isAnswerShown = false,
-                showTypeInAnswer = typeAnswer.correct != null,
-                nextTimes = List(4) { "" },
-                chosenAnswer = "",
-                typedAnswer = "",
-                isMarked = note.hasTag(this, "marked"),
-                flag = card.userFlag(),
-                mediaDirectory = this.media.dir,
-                isFinished = false
-            )
+            updatedState =
+                _state.value.copy(
+                    mediaError = null,
+                    newCount = queue?.counts?.new ?: 0,
+                    learnCount = queue?.counts?.lrn ?: 0,
+                    reviewCount = queue?.counts?.rev ?: 0,
+                    questionHtml = processedQuestionHtml,
+                    answerHtml = processedAnswerHtml,
+                    bodyClass = bodyClassForCardOrd(card.ord),
+                    baseUrl = server.baseUrl(),
+                    isAnswerShown = false,
+                    showTypeInAnswer = typeAnswer.correct != null,
+                    nextTimes = List(4) { "" },
+                    chosenAnswer = "",
+                    typedAnswer = "",
+                    isMarked = note.hasTag(this, "marked"),
+                    flag = card.userFlag(),
+                    mediaDirectory = this.media.dir,
+                    isFinished = false,
+                )
         }
         queue?.timeboxReached?.let { _effect.emit(ReviewerEffect.ShowTimeboxReachedDialog(it)) }
         _state.value = requireNotNull(updatedState)
@@ -613,17 +711,21 @@ class ReviewerViewModel(
 
     fun onVideoPaused() = cardMediaPlayer.onVideoPaused()
 
-    private fun playAudio(side: String, index: Int) {
+    private fun playAudio(
+        side: String,
+        index: Int,
+    ) {
         viewModelScope.launch {
             val card = currentCard ?: return@launch
-            val avTag = withCol {
-                val renderOutput = card.renderOutput(this)
-                when (side) {
-                    "q" -> renderOutput.questionAvTags.getOrNull(index)
-                    "a" -> renderOutput.answerAvTags.getOrNull(index)
-                    else -> null
+            val avTag =
+                withCol {
+                    val renderOutput = card.renderOutput(this)
+                    when (side) {
+                        "q" -> renderOutput.questionAvTags.getOrNull(index)
+                        "a" -> renderOutput.answerAvTags.getOrNull(index)
+                        else -> null
+                    }
                 }
-            }
             if (avTag is SoundOrVideoTag) {
                 cardMediaPlayer.playOne(avTag)
             }
@@ -636,12 +738,13 @@ class ReviewerViewModel(
         _state.update { it.copy(typedAnswer = newText) }
     }
 
-    private suspend fun getNextCard(): Pair<Card, CurrentQueueState>? = withCol {
-        this.sched.currentQueueState()?.let {
-            it.topCard.renderOutput(this, reload = true)
-            Pair(it.topCard, it)
+    private suspend fun getNextCard(): Pair<Card, CurrentQueueState>? =
+        withCol {
+            this.sched.currentQueueState()?.let {
+                it.topCard.renderOutput(this, reload = true)
+                Pair(it.topCard, it)
+            }
         }
-    }
 
     internal suspend fun loadCardSuspend() {
         val cardAndQueueState = getNextCard()
@@ -654,7 +757,7 @@ class ReviewerViewModel(
                     newCount = 0,
                     learnCount = 0,
                     reviewCount = 0,
-                    isMediaAutoplayEnabled = false
+                    isMediaAutoplayEnabled = false,
                 )
             }
             _effect.emit(ReviewerEffect.NavigateToDeckPicker)
@@ -681,6 +784,7 @@ class ReviewerViewModel(
                 processHtml(answerHtml, renderOutput, this, showAudioPlayButtons)
             _state.update {
                 it.copy(
+                    cardDisplayIndex = it.cardDisplayIndex + 1,
                     mediaError = null,
                     newCount = queue.counts.new,
                     learnCount = queue.counts.lrn,
@@ -698,12 +802,11 @@ class ReviewerViewModel(
                     flag = card.userFlag(),
                     isMediaAutoplayEnabled = cardMediaPlayer.config.autoplay,
                     mediaDirectory = this.media.dir,
-                    isFinished = false
+                    isFinished = false,
                 )
             }
         }
         cardMediaPlayer.autoplayAllForSide(SingleCardSide.FRONT.toCardSide())
-        _effect.emit(ReviewerEffect.ClearWhiteboard)
     }
 
     private fun showAnswer() {
@@ -726,7 +829,7 @@ class ReviewerViewModel(
                     it.copy(
                         answerHtml = processedAnswerHtml,
                         isAnswerShown = true,
-                        nextTimes = paddedLabels
+                        nextTimes = paddedLabels,
                     )
                 }
             }
@@ -746,11 +849,12 @@ class ReviewerViewModel(
             }
 
             if (rating == CardAnswer.Rating.AGAIN && wasLeech) {
-                val leechMessage: String = if (queue.topCard.queue.buriedOrSuspended()) {
-                    getApplication<Application>().resources.getString(R.string.leech_suspend_notification)
-                } else {
-                    getApplication<Application>().resources.getString(R.string.leech_notification)
-                }
+                val leechMessage: String =
+                    if (queue.topCard.queue.buriedOrSuspended()) {
+                        getApplication<Application>().resources.getString(R.string.leech_suspend_notification)
+                    } else {
+                        getApplication<Application>().resources.getString(R.string.leech_notification)
+                    }
                 _effect.emit(ReviewerEffect.ShowSnackbar(leechMessage))
             }
 
@@ -768,7 +872,9 @@ class ReviewerViewModel(
         viewModelScope.launch {
             _state.update {
                 it.copy(
-                    isAnswerShown = false, nextTimes = List(4) { "" }, chosenAnswer = ""
+                    isAnswerShown = false,
+                    nextTimes = List(4) { "" },
+                    chosenAnswer = "",
                 )
             }
         }
@@ -777,9 +883,10 @@ class ReviewerViewModel(
     private fun toggleMark() {
         viewModelScope.launch {
             val card = currentCard ?: return@launch
-            val note = withCol {
-                card.note(this)
-            }
+            val note =
+                withCol {
+                    card.note(this)
+                }
             try {
                 NoteService.toggleMark(note, handler = this@ReviewerViewModel)
                 val isMarked = NoteService.isMarked(note)
@@ -834,13 +941,14 @@ class ReviewerViewModel(
         showAudioPlayButtons: Boolean,
     ): String {
         val escapedHtml = collection.media.escapeMediaFilenames(html)
-        val processedHtml = expandSounds(
-            content = escapedHtml,
-            renderOutput = renderOutput,
-            showAudioPlayButtons = showAudioPlayButtons,
-            mediaDir = collection.media.dir,
-            replayButtonContentDescription = getApplication<Application>().getString(R.string.replay_media),
-        )
+        val processedHtml =
+            expandSounds(
+                content = escapedHtml,
+                renderOutput = renderOutput,
+                showAudioPlayButtons = showAudioPlayButtons,
+                mediaDir = collection.media.dir,
+                replayButtonContentDescription = getApplication<Application>().getString(R.string.replay_media),
+            )
         return CardHtmlBuilder.wrapWithStyles(processedHtml, renderOutput.css)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerViewModel.kt
@@ -152,6 +152,7 @@ sealed class ReviewerEffect {
     object ToggleVoicePlayback : ReviewerEffect()
     object NavigateToDeckOptions : ReviewerEffect()
     data class ShowTimeboxReachedDialog(val timebox: Collection.TimeboxReached) : ReviewerEffect()
+    object ClearWhiteboard : ReviewerEffect()
 }
 
 class ReviewerViewModel(
@@ -702,6 +703,7 @@ class ReviewerViewModel(
             }
         }
         cardMediaPlayer.autoplayAllForSide(SingleCardSide.FRONT.toCardSide())
+        _effect.emit(ReviewerEffect.ClearWhiteboard)
     }
 
     private fun showAnswer() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/WhiteboardController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/WhiteboardController.kt
@@ -161,9 +161,7 @@ class WhiteboardController(
     }
 
     fun updateForNewCard() {
-        if (isEnabled) {
-            viewModel.reset()
-        }
+        viewModel.reset()
     }
 
     fun changePenColor() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -240,6 +240,10 @@ fun ReviewerContent(
                     pendingDeleteCardId = effect.card.id
                 }
 
+                is ReviewerEffect.ClearWhiteboard -> {
+                    whiteboardViewModel?.reset()
+                }
+
                 else -> {
                     // All other effects are handled by the Activity
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -68,6 +68,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -125,44 +126,56 @@ private val WhiteboardBottomBarOffset = 48.dp
 private const val AnswerIndicatorDuration = 1000L
 
 // You can rename this class to be more descriptive
-class InvertedTopCornersShape(private val cornerRadius: Dp) : Shape {
+class InvertedTopCornersShape(
+    private val cornerRadius: Dp,
+) : Shape {
     override fun createOutline(
-        size: Size, layoutDirection: LayoutDirection, density: Density
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
     ): Outline {
         val cornerRadiusPx = with(density) { cornerRadius.toPx() }
 
-        val path = Path().apply {
-            // --- Top-Left Corner Path ---
-            moveTo(0f, 0f) // Start at the top-left point
-            lineTo(cornerRadiusPx, 0f) // Line to the start of the arc
-            // Arc from (r, 0) down to (0, r)
-            arcTo(
-                rect = Rect(
-                    left = 0f, top = 0f, right = 2 * cornerRadiusPx, bottom = 2 * cornerRadiusPx
-                ), startAngleDegrees = 270f,   // Top-center of the rect
-                sweepAngleDegrees = -90f, // Sweep counter-clockwise
-                forceMoveTo = false
-            )
-            // lineTo(0f, 0f) is implicitly added by close()
-            close() // Close the path, drawing a line from (0, r) back to (0, 0)
+        val path =
+            Path().apply {
+                // --- Top-Left Corner Path ---
+                moveTo(0f, 0f) // Start at the top-left point
+                lineTo(cornerRadiusPx, 0f) // Line to the start of the arc
+                // Arc from (r, 0) down to (0, r)
+                arcTo(
+                    rect =
+                        Rect(
+                            left = 0f,
+                            top = 0f,
+                            right = 2 * cornerRadiusPx,
+                            bottom = 2 * cornerRadiusPx,
+                        ),
+                    startAngleDegrees = 270f, // Top-center of the rect
+                    sweepAngleDegrees = -90f, // Sweep counter-clockwise
+                    forceMoveTo = false,
+                )
+                // lineTo(0f, 0f) is implicitly added by close()
+                close() // Close the path, drawing a line from (0, r) back to (0, 0)
 
-            // --- Top-Right Corner Path ---
-            moveTo(size.width, 0f) // Start at the top-right point
-            lineTo(size.width - cornerRadiusPx, 0f) // Line to the start of the arc
-            // Arc from (width - r, 0) down to (width, r)
-            arcTo(
-                rect = Rect(
-                    left = size.width - 2 * cornerRadiusPx,
-                    top = 0f,
-                    right = size.width,
-                    bottom = 2 * cornerRadiusPx
-                ), startAngleDegrees = 270f, // Top-center of the rect
-                sweepAngleDegrees = 90f,  // Sweep clockwise
-                forceMoveTo = false
-            )
-            // lineTo(size.width, 0f) is implicitly added by close()
-            close() // Close the path, drawing a line from (width, r) back to (width, 0)
-        }
+                // --- Top-Right Corner Path ---
+                moveTo(size.width, 0f) // Start at the top-right point
+                lineTo(size.width - cornerRadiusPx, 0f) // Line to the start of the arc
+                // Arc from (width - r, 0) down to (width, r)
+                arcTo(
+                    rect =
+                        Rect(
+                            left = size.width - 2 * cornerRadiusPx,
+                            top = 0f,
+                            right = size.width,
+                            bottom = 2 * cornerRadiusPx,
+                        ),
+                    startAngleDegrees = 270f, // Top-center of the rect
+                    sweepAngleDegrees = 90f, // Sweep clockwise
+                    forceMoveTo = false,
+                )
+                // lineTo(size.width, 0f) is implicitly added by close()
+                close() // Close the path, drawing a line from (width, r) back to (width, 0)
+            }
         return Outline.Generic(path)
     }
 }
@@ -172,7 +185,7 @@ class InvertedTopCornersShape(private val cornerRadius: Dp) : Shape {
 fun ReviewerContent(
     viewModel: ReviewerViewModel,
     whiteboardViewModel: WhiteboardViewModel?,
-    voicePlaybackViewModel: VoicePlaybackViewModel?
+    voicePlaybackViewModel: VoicePlaybackViewModel?,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
@@ -216,19 +229,33 @@ fun ReviewerContent(
         }
     }
 
-    val editCardLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
-    ) {
-        viewModel.onEvent(ReviewerEvent.ReloadCard)
+    // Reset whiteboard on card transitions; guarded with rememberSaveable to prevent
+    // wiping the user's sketch on configuration changes (e.g. screen rotation)
+    var lastHandledCardIndex by rememberSaveable { mutableLongStateOf(-1L) }
+    LaunchedEffect(state.cardDisplayIndex) {
+        if (lastHandledCardIndex != -1L && state.cardDisplayIndex != lastHandledCardIndex) {
+            whiteboardViewModel?.reset()
+        }
+        lastHandledCardIndex = state.cardDisplayIndex
     }
+
+    val editCardLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+        ) {
+            viewModel.onEvent(ReviewerEvent.ReloadCard)
+        }
 
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
             when (effect) {
                 is ReviewerEffect.NavigateToEditCard -> {
-                    val intent = NoteEditorLauncher.EditCard(
-                        effect.cardId, ActivityTransitionAnimation.Direction.FADE
-                    ).toIntent(currentContext)
+                    val intent =
+                        NoteEditorLauncher
+                            .EditCard(
+                                effect.cardId,
+                                ActivityTransitionAnimation.Direction.FADE,
+                            ).toIntent(currentContext)
                     editCardLauncher.launch(intent)
                 }
 
@@ -240,10 +267,6 @@ fun ReviewerContent(
 
                 is ReviewerEffect.ShowDeleteNoteDialog -> {
                     pendingDeleteCardId = effect.card.id
-                }
-
-                is ReviewerEffect.ClearWhiteboard -> {
-                    whiteboardViewModel?.reset()
                 }
 
                 else -> {
@@ -262,16 +285,18 @@ fun ReviewerContent(
 
     LaunchedEffect(viewModel.flowOfDeleteResult) {
         viewModel.flowOfDeleteResult.collectLatest { count ->
-            val message = currentContext.resources.getQuantityString(
-                R.plurals.card_browser_cards_deleted,
-                count,
-                count,
-            )
-            val result = snackbarHostState.showSnackbar(
-                message = message,
-                actionLabel = undoLabel,
-                duration = SnackbarDuration.Short,
-            )
+            val message =
+                currentContext.resources.getQuantityString(
+                    R.plurals.card_browser_cards_deleted,
+                    count,
+                    count,
+                )
+            val result =
+                snackbarHostState.showSnackbar(
+                    message = message,
+                    actionLabel = undoLabel,
+                    duration = SnackbarDuration.Short,
+                )
             if (result == SnackbarResult.ActionPerformed) {
                 viewModel.undoDelete()
             }
@@ -292,7 +317,8 @@ fun ReviewerContent(
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(snackbarHost = {
             SnackbarHost(
-                snackbarHostState, modifier = Modifier.padding(bottom = toolbarHeightDp + 32.dp)
+                snackbarHostState,
+                modifier = Modifier.padding(bottom = toolbarHeightDp + 32.dp),
             ) { data ->
                 Snackbar(
                     snackbarData = data,
@@ -314,33 +340,35 @@ fun ReviewerContent(
                 onSetFlag = { viewModel.onEvent(ReviewerEvent.SetFlag(it)) },
                 isAnswerShown = state.isAnswerShown,
                 showMoreOptions = Prefs.moreOptionsInTopAppBar,
-                onMoreOptionsClick = { showBottomSheet = true }
+                onMoreOptionsClick = { showBottomSheet = true },
             ) { viewModel.onEvent(ReviewerEvent.UnanswerCard) }
         }) { paddingValues ->
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surfaceContainer)
-                    .padding(
-                        top = paddingValues.calculateTopPadding(),
-                        start = paddingValues.calculateStartPadding(layoutDirection),
-                        end = paddingValues.calculateEndPadding(layoutDirection)
-                    ),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainer)
+                        .padding(
+                            top = paddingValues.calculateTopPadding(),
+                            start = paddingValues.calculateStartPadding(layoutDirection),
+                            end = paddingValues.calculateEndPadding(layoutDirection),
+                        ),
             ) {
                 Box(
-                    modifier = Modifier.background(MaterialTheme.colorScheme.background)
+                    modifier = Modifier.background(MaterialTheme.colorScheme.background),
                 ) {
                     val invertedTopCornersShape =
                         remember { InvertedTopCornersShape(cornerRadius = 32.dp) }
 
                     Surface(
-                        modifier = Modifier
-                            .align(Alignment.TopStart)
-                            .zIndex(1F)
-                            .height(100.dp)
-                            .fillMaxWidth(),
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopStart)
+                                .zIndex(1F)
+                                .height(100.dp)
+                                .fillMaxWidth(),
                         shape = invertedTopCornersShape,
-                        color = MaterialTheme.colorScheme.surfaceContainer
+                        color = MaterialTheme.colorScheme.surfaceContainer,
                     ) {}
 
                     Flashcard(
@@ -356,7 +384,7 @@ fun ReviewerContent(
                             viewModel.onEvent(ReviewerEvent.LinkClicked(it))
                         },
                         isAnswerShown = state.isAnswerShown,
-                        toolbarHeight = (toolbarHeightDp + WhiteboardBottomBarOffset).value.toInt()
+                        toolbarHeight = (toolbarHeightDp + WhiteboardBottomBarOffset).value.toInt(),
                     )
 
                     // Whiteboard canvas and toolbar
@@ -364,34 +392,41 @@ fun ReviewerContent(
                         val toolbarAlignment by whiteboardViewModel.toolbarAlignment.collectAsStateWithLifecycle()
 
                         // Canvas padding based on toolbar alignment
-                        val canvasPadding = when (toolbarAlignment) {
-                            ToolbarAlignment.BOTTOM -> Modifier.padding(bottom = totalBottomPadding + WhiteboardBottomBarOffset)
-                            ToolbarAlignment.LEFT -> Modifier.padding(start = WhiteboardToolbarWidth)
-                            ToolbarAlignment.RIGHT -> Modifier.padding(end = WhiteboardToolbarWidth)
-                        }
+                        val canvasPadding =
+                            when (toolbarAlignment) {
+                                ToolbarAlignment.BOTTOM -> Modifier.padding(bottom = totalBottomPadding + WhiteboardBottomBarOffset)
+                                ToolbarAlignment.LEFT -> Modifier.padding(start = WhiteboardToolbarWidth)
+                                ToolbarAlignment.RIGHT -> Modifier.padding(end = WhiteboardToolbarWidth)
+                            }
                         WhiteboardCanvas(
-                            viewModel = whiteboardViewModel, modifier = canvasPadding
+                            viewModel = whiteboardViewModel,
+                            modifier = canvasPadding,
                         )
 
                         // Toolbar positioning
-                        val composeAlignment = when (toolbarAlignment) {
-                            ToolbarAlignment.BOTTOM -> Alignment.BottomCenter
-                            ToolbarAlignment.LEFT -> Alignment.CenterStart
-                            ToolbarAlignment.RIGHT -> Alignment.CenterEnd
-                        }
-                        val toolbarPadding = when (toolbarAlignment) {
-                            ToolbarAlignment.BOTTOM -> Modifier
-                                .offset(y = -ScreenOffset - toolbarHeightDp - 8.dp)
-                                .padding(bottom = paddingValues.calculateBottomPadding())
+                        val composeAlignment =
+                            when (toolbarAlignment) {
+                                ToolbarAlignment.BOTTOM -> Alignment.BottomCenter
+                                ToolbarAlignment.LEFT -> Alignment.CenterStart
+                                ToolbarAlignment.RIGHT -> Alignment.CenterEnd
+                            }
+                        val toolbarPadding =
+                            when (toolbarAlignment) {
+                                ToolbarAlignment.BOTTOM ->
+                                    Modifier
+                                        .offset(y = -ScreenOffset - toolbarHeightDp - 8.dp)
+                                        .padding(bottom = paddingValues.calculateBottomPadding())
 
-                            ToolbarAlignment.LEFT -> Modifier.padding(
-                                start = 8.dp
-                            )
+                                ToolbarAlignment.LEFT ->
+                                    Modifier.padding(
+                                        start = 8.dp,
+                                    )
 
-                            ToolbarAlignment.RIGHT -> Modifier.padding(
-                                end = 8.dp
-                            )
-                        }
+                                ToolbarAlignment.RIGHT ->
+                                    Modifier.padding(
+                                        end = 8.dp,
+                                    )
+                            }
                         WhiteboardToolbar(
                             viewModel = whiteboardViewModel,
                             onBrushClick = { _, index ->
@@ -416,10 +451,12 @@ fun ReviewerContent(
                                     whiteboardViewModel.enableEraser()
                                 }
                             },
-                            modifier = Modifier
-                                .align(composeAlignment)
-                                .then(toolbarPadding)
-                                .onSizeChanged { whiteboardToolbarHeight = it.height })
+                            modifier =
+                                Modifier
+                                    .align(composeAlignment)
+                                    .then(toolbarPadding)
+                                    .onSizeChanged { whiteboardToolbarHeight = it.height },
+                        )
                     }
 
                     // Voice Playback Toolbar
@@ -434,41 +471,46 @@ fun ReviewerContent(
                                 onDismiss = {
                                     viewModel.onEvent(ReviewerEvent.ToggleVoicePlayback)
                                 },
-                                modifier = Modifier
-                                    .align(Alignment.BottomCenter)
-                                    .offset(y = -ScreenOffset - toolbarHeightDp - 16.dp)
-                                    .padding(bottom = paddingValues.calculateBottomPadding())
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.BottomCenter)
+                                        .offset(y = -ScreenOffset - toolbarHeightDp - 16.dp)
+                                        .padding(bottom = paddingValues.calculateBottomPadding()),
                             )
                         }
                     }
 
                     AnswerButtons(
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .offset(y = -ScreenOffset)
-                            .padding(bottom = paddingValues.calculateBottomPadding())
-                            .onSizeChanged { toolbarHeight = it.height },
+                        modifier =
+                            Modifier
+                                .align(Alignment.BottomCenter)
+                                .offset(y = -ScreenOffset)
+                                .padding(bottom = paddingValues.calculateBottomPadding())
+                                .onSizeChanged { toolbarHeight = it.height },
                         isAnswerShown = state.isAnswerShown,
                         showButtonBadges = Prefs.showAnswerButtonBadges,
                         showTypeInAnswer = state.showTypeInAnswer,
                         typedAnswer = state.typedAnswer,
                         onTypedAnswerChanged = {
                             viewModel.onEvent(
-                                ReviewerEvent.OnTypedAnswerChanged(it)
+                                ReviewerEvent.OnTypedAnswerChanged(it),
                             )
                         },
                         onShowAnswer = { viewModel.onEvent(ReviewerEvent.ShowAnswer) },
                         onRateCard = { viewModel.onEvent(ReviewerEvent.RateCard(it)) },
                         nextTimes = state.nextTimes,
                         moreOptionsInTopAppBar = Prefs.moreOptionsInTopAppBar,
-                        onMoreOptionsClick = { showBottomSheet = true })
+                        onMoreOptionsClick = { showBottomSheet = true },
+                    )
 
                     AnswerIndicator(
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(end = 16.dp, top = 16.dp),
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(end = 16.dp, top = 16.dp),
                         feedback = state.answerFeedback,
-                        onDismissed = { viewModel.onEvent(ReviewerEvent.AnswerFeedbackShown) })
+                        onDismissed = { viewModel.onEvent(ReviewerEvent.AnswerFeedbackShown) },
+                    )
                 }
             }
         }
@@ -487,45 +529,57 @@ fun ReviewerContent(
                         listOf(
                             Triple(R.string.undo, Icons.AutoMirrored.Filled.Undo) {
                                 viewModel.onEvent(ReviewerEvent.Undo)
-                            }, Triple(
+                            },
+                            Triple(
                                 if (state.isWhiteboardEnabled) R.string.disable_whiteboard else R.string.enable_whiteboard,
-                                Icons.Filled.Edit
+                                Icons.Filled.Edit,
                             ) {
                                 viewModel.onEvent(ReviewerEvent.ToggleWhiteboard)
-                            }, Triple(R.string.cardeditor_title_edit_card, Icons.Filled.EditNote) {
+                            },
+                            Triple(R.string.cardeditor_title_edit_card, Icons.Filled.EditNote) {
                                 viewModel.onEvent(ReviewerEvent.EditCard)
-                            }, Triple(R.string.menu_edit_tags, Icons.AutoMirrored.Filled.Label) {
+                            },
+                            Triple(R.string.menu_edit_tags, Icons.AutoMirrored.Filled.Label) {
                                 viewModel.onEvent(ReviewerEvent.EditTags)
-                            }, Triple(R.string.menu_bury_card, Icons.Filled.VisibilityOff) {
+                            },
+                            Triple(R.string.menu_bury_card, Icons.Filled.VisibilityOff) {
                                 viewModel.onEvent(ReviewerEvent.BuryCard)
-                            }, Triple(R.string.menu_suspend_card, Icons.Filled.Pause) {
+                            },
+                            Triple(R.string.menu_suspend_card, Icons.Filled.Pause) {
                                 viewModel.onEvent(ReviewerEvent.SuspendCard)
-                            }, Triple(R.string.menu_delete_note, Icons.Filled.Delete) {
+                            },
+                            Triple(R.string.menu_delete_note, Icons.Filled.Delete) {
                                 viewModel.onEvent(ReviewerEvent.DeleteNote)
-                            }, Triple(R.string.card_editor_reschedule_card, Icons.Filled.Schedule) {
+                            },
+                            Triple(R.string.card_editor_reschedule_card, Icons.Filled.Schedule) {
                                 viewModel.onEvent(ReviewerEvent.RescheduleCard)
-                            }, Triple(R.string.replay_media, Icons.Filled.Replay) {
+                            },
+                            Triple(R.string.replay_media, Icons.Filled.Replay) {
                                 viewModel.onEvent(ReviewerEvent.ReplayMedia)
-                            }, Triple(
+                            },
+                            Triple(
                                 if (state.isVoicePlaybackEnabled) R.string.menu_disable_voice_playback else R.string.menu_enable_voice_playback,
-                                Icons.Filled.RecordVoiceOver
+                                Icons.Filled.RecordVoiceOver,
                             ) {
                                 viewModel.onEvent(ReviewerEvent.ToggleVoicePlayback)
-                            }, Triple(R.string.deck_options, Icons.Filled.Tune) {
+                            },
+                            Triple(R.string.deck_options, Icons.Filled.Tune) {
                                 viewModel.onEvent(ReviewerEvent.DeckOptions)
-                            })
+                            },
+                        )
                     }
                 menuOptions.forEach { (textRes, icon, action) ->
                     ListItem(
                         leadingContent = { Icon(icon, contentDescription = null) },
-                        modifier = Modifier.clickable {
-                            scope.launch { sheetState.hide() }.invokeOnCompletion {
-                                if (!sheetState.isVisible) {
-                                    showBottomSheet = false
+                        modifier =
+                            Modifier.clickable {
+                                scope.launch { sheetState.hide() }.invokeOnCompletion {
+                                    if (!sheetState.isVisible) {
+                                        showBottomSheet = false
+                                    }
                                 }
-                            }
-                            action()
-                        }
+                                action()
+                            },
                     ) { Text(stringResource(textRes)) }
                 }
             }
@@ -542,7 +596,8 @@ fun ReviewerContent(
                     whiteboardViewModel.addBrush(color)
                     showColorPickerDialog = false
                 },
-                onDismiss = { showColorPickerDialog = false })
+                onDismiss = { showColorPickerDialog = false },
+            )
         }
 
         // Brush removal confirmation dialog
@@ -557,7 +612,8 @@ fun ReviewerContent(
                                 whiteboardViewModel.removeBrush(index)
                             }
                             brushIndexToRemove = null
-                        }) {
+                        },
+                    ) {
                         Text(stringResource(R.string.dialog_remove))
                     }
                 },
@@ -565,19 +621,24 @@ fun ReviewerContent(
                     TextButton(onClick = { brushIndexToRemove = null }) {
                         Text(stringResource(R.string.dialog_cancel))
                     }
-                })
+                },
+            )
         }
 
         // Brush options dialog
         if (showBrushOptions && whiteboardViewModel != null) {
             BrushOptionsDialog(
-                viewModel = whiteboardViewModel, onDismissRequest = { showBrushOptions = false })
+                viewModel = whiteboardViewModel,
+                onDismissRequest = { showBrushOptions = false },
+            )
         }
 
         // Eraser options dialog
         if (showEraserOptions && whiteboardViewModel != null) {
             EraserOptionsDialog(
-                viewModel = whiteboardViewModel, onDismissRequest = { showEraserOptions = false })
+                viewModel = whiteboardViewModel,
+                onDismissRequest = { showEraserOptions = false },
+            )
         }
 
         // Set Due Date Dialog
@@ -612,7 +673,8 @@ fun ReviewerContent(
                             showThemedToast(activity, R.string.something_wrong, true)
                         }
                     }
-                })
+                },
+            )
         }
 
         // Tags dialog
@@ -630,7 +692,8 @@ fun ReviewerContent(
                 title = stringResource(R.string.card_details_tags),
                 confirmButtonText = stringResource(R.string.dialog_ok),
                 showFilterByDeckToggle = true,
-                onAddTag = { viewModel.registerNewTag(it) })
+                onAddTag = { viewModel.registerNewTag(it) },
+            )
         }
     }
 }
@@ -638,7 +701,9 @@ fun ReviewerContent(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AnswerIndicator(
-    modifier: Modifier = Modifier, feedback: AnswerFeedback?, onDismissed: () -> Unit
+    modifier: Modifier = Modifier,
+    feedback: AnswerFeedback?,
+    onDismissed: () -> Unit,
 ) {
     var lastFeedback by remember { mutableStateOf<AnswerFeedback?>(null) }
     val currentOnDismissed by rememberUpdatedState(onDismissed)
@@ -655,7 +720,7 @@ fun AnswerIndicator(
         visible = feedback != null,
         enter = fadeIn(),
         exit = fadeOut(animationSpec = MaterialTheme.motionScheme.slowEffectsSpec()),
-        modifier = modifier
+        modifier = modifier,
     ) {
         // Use the cached lastFeedback to avoid disappearing mid-animation
         lastFeedback?.let { current ->
@@ -667,17 +732,18 @@ fun AnswerIndicator(
                 Text(
                     modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
                     text = stringResource(current.rating.toResId()),
-                    style = MaterialTheme.typography.labelSmall
+                    style = MaterialTheme.typography.labelSmall,
                 )
             }
         }
     }
 }
 
-private fun CardAnswer.Rating.toResId(): Int = when (this) {
-    CardAnswer.Rating.AGAIN -> R.string.ease_button_again
-    CardAnswer.Rating.HARD -> R.string.ease_button_hard
-    CardAnswer.Rating.GOOD -> R.string.ease_button_good
-    CardAnswer.Rating.EASY -> R.string.ease_button_easy
-    else -> R.string.unknown_rating
-}
+private fun CardAnswer.Rating.toResId(): Int =
+    when (this) {
+        CardAnswer.Rating.AGAIN -> R.string.ease_button_again
+        CardAnswer.Rating.HARD -> R.string.ease_button_hard
+        CardAnswer.Rating.GOOD -> R.string.ease_button_good
+        CardAnswer.Rating.EASY -> R.string.ease_button_easy
+        else -> R.string.unknown_rating
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/compose/ReviewerCompose.kt
@@ -223,7 +223,7 @@ fun ReviewerContent(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.effect.collectLatest { effect ->
+        viewModel.effect.collect { effect ->
             when (effect) {
                 is ReviewerEffect.NavigateToEditCard -> {
                     val intent = NoteEditorLauncher.EditCard(
@@ -233,7 +233,9 @@ fun ReviewerContent(
                 }
 
                 is ReviewerEffect.ShowSnackbar -> {
-                    snackbarHostState.showSnackbar(effect.message)
+                    // Launch independently so a later effect doesn't cancel
+                    // the suspending showSnackbar call
+                    launch { snackbarHostState.showSnackbar(effect.message) }
                 }
 
                 is ReviewerEffect.ShowDeleteNoteDialog -> {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
@@ -219,18 +219,31 @@ class ReviewerViewModelTest : RobolectricTest() {
         addBasicNote("Front 2", "Back 2")
 
         val testDispatcher = StandardTestDispatcher(testScheduler)
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+        val viewModel =
+            ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
 
         viewModel.effect.test {
             testScheduler.advanceUntilIdle()
             advanceRobolectricLooper()
+
+            // Consume the initial ClearWhiteboard emitted by LoadInitialCard
+            val initialEffect = awaitItem()
+            assertThat(
+                "Initial card load should emit ClearWhiteboard",
+                initialEffect,
+                equalTo(ReviewerEffect.ClearWhiteboard)
+            )
 
             viewModel.onEvent(ReviewerEvent.RateCard(anki.scheduler.CardAnswer.Rating.EASY))
             testScheduler.advanceUntilIdle()
             advanceRobolectricLooper()
 
             val effect = awaitItem()
-            assertThat("ClearWhiteboard effect should be emitted on answering card", effect, equalTo(ReviewerEffect.ClearWhiteboard))
+            assertThat(
+                "ClearWhiteboard effect should be emitted on answering card",
+                effect,
+                equalTo(ReviewerEffect.ClearWhiteboard)
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -260,8 +273,16 @@ class ReviewerViewModelTest : RobolectricTest() {
         advanceRobolectricLooper()
 
         val reloadedNote = col.getNote(note.id)
-        assertThat("Note should be marked after toggle", NoteService.isMarked(reloadedNote), equalTo(true))
-        assertThat("State should reflect marked note", viewModel.state.value.isMarked, equalTo(true))
+        assertThat(
+            "Note should be marked after toggle",
+            NoteService.isMarked(reloadedNote),
+            equalTo(true)
+        )
+        assertThat(
+            "State should reflect marked note",
+            viewModel.state.value.isMarked,
+            equalTo(true)
+        )
     }
 
     @Test
@@ -310,8 +331,16 @@ class ReviewerViewModelTest : RobolectricTest() {
             advanceRobolectricLooper()
 
             val reloadedNote = col.getNote(note.id)
-            assertThat("Note should remain unmarked after failure", NoteService.isMarked(reloadedNote), equalTo(false))
-            assertThat("State should remain unchanged after failure", viewModel.state.value.isMarked, equalTo(false))
+            assertThat(
+                "Note should remain unmarked after failure",
+                NoteService.isMarked(reloadedNote),
+                equalTo(false)
+            )
+            assertThat(
+                "State should remain unchanged after failure",
+                viewModel.state.value.isMarked,
+                equalTo(false)
+            )
         } finally {
             unmockkObject(NoteService)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
@@ -214,6 +214,28 @@ class ReviewerViewModelTest : RobolectricTest() {
     }
 
     @Test
+    fun `answering a card emits ClearWhiteboard effect`() = runTest {
+        addBasicNote("Front 1", "Back 1")
+        addBasicNote("Front 2", "Back 2")
+
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+
+        viewModel.effect.test {
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            viewModel.onEvent(ReviewerEvent.RateCard(anki.scheduler.CardAnswer.Rating.EASY))
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            val effect = awaitItem()
+            assertThat("ClearWhiteboard effect should be emitted on answering card", effect, equalTo(ReviewerEffect.ClearWhiteboard))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `voice playback state is updated via event`() = runTest {
         addBasicNote()
         val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ReviewerViewModelTest.kt
@@ -43,383 +43,482 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class ReviewerViewModelTest : RobolectricTest() {
-
     // Must use IN_MEMORY_WITH_MEDIA to provide media directory access
     override fun getCollectionStorageMode() = CollectionStorageMode.IN_MEMORY_WITH_MEDIA
 
     @Test
-    fun `initial state has empty counts`() = runTest {
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
-
-        // When there are no cards, the review should finish
-        val state = viewModel.state.first()
-        assertThat("No cards means review is finished", state.isFinished, equalTo(true))
-        assertThat("New count should be 0", state.newCount, equalTo(0))
-        assertThat("Learn count should be 0", state.learnCount, equalTo(0))
-        assertThat("Review count should be 0", state.reviewCount, equalTo(0))
-    }
-
-    @Test
-    fun `card loads successfully when cards exist`() = runTest {
-        // Add a card so there's something to review
-        addBasicNote("Front", "Back")
-
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
-
-        val state = viewModel.state.first()
-        assertThat(
-            "Review should not be finished when cards exist", state.isFinished, equalTo(false)
-        )
-        assertThat("New count should be 1", state.newCount, equalTo(1))
-    }
-
-    @Test
-    fun `video tags render as inline video in reviewer html`() = runTest {
-        addBasicNote("Front [sound:test.mp4]", "Back")
-
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val viewModel =
-            ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
-        testScheduler.advanceUntilIdle()
-        advanceRobolectricLooper()
-
-        val state = viewModel.state.first()
-        assertThat(
-            "Video tags should render as inline video", state.questionHtml, containsString("<video")
-        )
-        assertThat(
-            "Video tags should include the file name for JS playback",
-            state.questionHtml,
-            containsString("data-file=\"test.mp4\"")
-        )
-        assertThat(
-            "Video tags should report completion through the WebView",
-            state.questionHtml,
-            containsString("videoended:q:0")
-        )
-        assertThat(
-            "Video tags should not fall back to replay buttons",
-            state.questionHtml,
-            not(containsString("href=playsound:q:0"))
-        )
-    }
-
-    @Test
-    fun `audio tags remain replay buttons in reviewer html`() = runTest {
-        addBasicNote("Front [sound:test.mp3]", "Back")
-
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val viewModel =
-            ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
-        testScheduler.advanceUntilIdle()
-        advanceRobolectricLooper()
-
-        val state = viewModel.state.first()
-        assertThat(
-            "Audio tags should still render replay links",
-            state.questionHtml,
-            containsString("href=\"playsound:q:0\"")
-        )
-        assertThat(
-            "Audio tags should render the shared replay button wrapper",
-            state.questionHtml,
-            containsString("class=\"replay-button soundLink\"")
-        )
-        assertThat(
-            "Audio tags should render the historical triangle play icon",
-            state.questionHtml,
-            containsString("class=\"play-action\"")
-        )
-        assertThat(
-            "Audio tags should paint the icon from currentColor",
-            state.questionHtml,
-            containsString("fill=\"currentColor\"")
-        )
-        assertThat(
-            "Audio tags should not hardcode icon colors in the markup",
-            state.questionHtml,
-            not(containsString("fill=\"black\""))
-        )
-        assertThat(
-            "Audio tags should not render inline video",
-            state.questionHtml,
-            not(containsString("<video"))
-        )
-    }
-
-    @Test
-    fun `video autoplay emits javascript when autoplay is enabled`() = runTest {
-        addBasicNote("Front [sound:test.mp4]", "Back")
-
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val viewModel =
-            ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
-
-        viewModel.evalCommand.test {
-            assertThat(
-                "No JavaScript should be queued before the scheduler runs",
-                awaitItem().isEmpty(),
-                equalTo(true)
-            )
-            testScheduler.advanceUntilIdle()
+    fun `initial state has empty counts`() =
+        runTest {
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
             advanceRobolectricLooper()
 
-            val script = awaitItem().single().script
-            assertThat(
-                "Autoplay should wait until the DOM is ready",
-                script,
-                containsString("document.readyState")
-            )
-            assertThat(
-                "Autoplay should target the inline video element",
-                script,
-                containsString("video.play();")
-            )
-            assertThat(
-                "Autoplay should target the card video file", script, containsString("test.mp4")
-            )
-            cancelAndIgnoreRemainingEvents()
+            // When there are no cards, the review should finish
+            val state = viewModel.state.first()
+            assertThat("No cards means review is finished", state.isFinished, equalTo(true))
+            assertThat("New count should be 0", state.newCount, equalTo(0))
+            assertThat("Learn count should be 0", state.learnCount, equalTo(0))
+            assertThat("Review count should be 0", state.reviewCount, equalTo(0))
         }
-    }
 
     @Test
-    fun `typed answer is updated via event`() = runTest {
-        addBasicNote()
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
+    fun `card loads successfully when cards exist`() =
+        runTest {
+            // Add a card so there's something to review
+            addBasicNote("Front", "Back")
 
-        viewModel.onEvent(ReviewerEvent.OnTypedAnswerChanged("test answer"))
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
 
-        val state = viewModel.state.first()
-        assertThat("Typed answer should be updated", state.typedAnswer, equalTo("test answer"))
-    }
-
-    @Test
-    fun `whiteboard state is updated via event`() = runTest {
-        addBasicNote()
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
-
-        viewModel.onEvent(ReviewerEvent.OnWhiteboardStateChanged(true))
-
-        val state = viewModel.state.first()
-        assertThat("Whiteboard should be enabled", state.isWhiteboardEnabled, equalTo(true))
-
-        viewModel.onEvent(ReviewerEvent.OnWhiteboardStateChanged(false))
-
-        val state2 = viewModel.state.first()
-        assertThat("Whiteboard should be disabled", state2.isWhiteboardEnabled, equalTo(false))
-    }
+            val state = viewModel.state.first()
+            assertThat(
+                "Review should not be finished when cards exist",
+                state.isFinished,
+                equalTo(false),
+            )
+            assertThat("New count should be 1", state.newCount, equalTo(1))
+        }
 
     @Test
-    fun `answering a card emits ClearWhiteboard effect`() = runTest {
-        addBasicNote("Front 1", "Back 1")
-        addBasicNote("Front 2", "Back 2")
+    fun `video tags render as inline video in reviewer html`() =
+        runTest {
+            addBasicNote("Front [sound:test.mp4]", "Back")
 
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val viewModel =
-            ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
-
-        viewModel.effect.test {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
             testScheduler.advanceUntilIdle()
             advanceRobolectricLooper()
 
-            // Consume the initial ClearWhiteboard emitted by LoadInitialCard
-            val initialEffect = awaitItem()
+            val state = viewModel.state.first()
             assertThat(
-                "Initial card load should emit ClearWhiteboard",
-                initialEffect,
-                equalTo(ReviewerEffect.ClearWhiteboard)
+                "Video tags should render as inline video",
+                state.questionHtml,
+                containsString("<video"),
+            )
+            assertThat(
+                "Video tags should include the file name for JS playback",
+                state.questionHtml,
+                containsString("data-file=\"test.mp4\""),
+            )
+            assertThat(
+                "Video tags should report completion through the WebView",
+                state.questionHtml,
+                containsString("videoended:q:0"),
+            )
+            assertThat(
+                "Video tags should not fall back to replay buttons",
+                state.questionHtml,
+                not(containsString("href=playsound:q:0")),
+            )
+        }
+
+    @Test
+    fun `audio tags remain replay buttons in reviewer html`() =
+        runTest {
+            addBasicNote("Front [sound:test.mp3]", "Back")
+
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            val state = viewModel.state.first()
+            assertThat(
+                "Audio tags should still render replay links",
+                state.questionHtml,
+                containsString("href=\"playsound:q:0\""),
+            )
+            assertThat(
+                "Audio tags should render the shared replay button wrapper",
+                state.questionHtml,
+                containsString("class=\"replay-button soundLink\""),
+            )
+            assertThat(
+                "Audio tags should render the historical triangle play icon",
+                state.questionHtml,
+                containsString("class=\"play-action\""),
+            )
+            assertThat(
+                "Audio tags should paint the icon from currentColor",
+                state.questionHtml,
+                containsString("fill=\"currentColor\""),
+            )
+            assertThat(
+                "Audio tags should not hardcode icon colors in the markup",
+                state.questionHtml,
+                not(containsString("fill=\"black\"")),
+            )
+            assertThat(
+                "Audio tags should not render inline video",
+                state.questionHtml,
+                not(containsString("<video")),
+            )
+        }
+
+    @Test
+    fun `video autoplay emits javascript when autoplay is enabled`() =
+        runTest {
+            addBasicNote("Front [sound:test.mp4]", "Back")
+
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+
+            viewModel.evalCommand.test {
+                assertThat(
+                    "No JavaScript should be queued before the scheduler runs",
+                    awaitItem().isEmpty(),
+                    equalTo(true),
+                )
+                testScheduler.advanceUntilIdle()
+                advanceRobolectricLooper()
+
+                val script = awaitItem().single().script
+                assertThat(
+                    "Autoplay should wait until the DOM is ready",
+                    script,
+                    containsString("document.readyState"),
+                )
+                assertThat(
+                    "Autoplay should target the inline video element",
+                    script,
+                    containsString("video.play();"),
+                )
+                assertThat(
+                    "Autoplay should target the card video file",
+                    script,
+                    containsString("test.mp4"),
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `typed answer is updated via event`() =
+        runTest {
+            addBasicNote()
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            viewModel.onEvent(ReviewerEvent.OnTypedAnswerChanged("test answer"))
+
+            val state = viewModel.state.first()
+            assertThat("Typed answer should be updated", state.typedAnswer, equalTo("test answer"))
+        }
+
+    @Test
+    fun `whiteboard state is updated via event`() =
+        runTest {
+            addBasicNote()
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            viewModel.onEvent(ReviewerEvent.OnWhiteboardStateChanged(true))
+
+            val state = viewModel.state.first()
+            assertThat("Whiteboard should be enabled", state.isWhiteboardEnabled, equalTo(true))
+
+            viewModel.onEvent(ReviewerEvent.OnWhiteboardStateChanged(false))
+
+            val state2 = viewModel.state.first()
+            assertThat("Whiteboard should be disabled", state2.isWhiteboardEnabled, equalTo(false))
+        }
+
+    @Test
+    fun `initial card load sets cardDisplayIndex to 1`() =
+        runTest {
+            addBasicNote("Front 1", "Back 1")
+
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            val state = viewModel.state.first()
+            assertThat(
+                "Initial card load should set cardDisplayIndex to 1",
+                state.cardDisplayIndex,
+                equalTo(1L),
+            )
+        }
+
+    @Test
+    fun `answering a card increments cardDisplayIndex`() =
+        runTest {
+            addBasicNote("Front 1", "Back 1")
+            addBasicNote("Front 2", "Back 2")
+
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            assertThat(
+                "Initial cardDisplayIndex is 1",
+                viewModel.state.first().cardDisplayIndex,
+                equalTo(1L),
             )
 
             viewModel.onEvent(ReviewerEvent.RateCard(anki.scheduler.CardAnswer.Rating.EASY))
             testScheduler.advanceUntilIdle()
             advanceRobolectricLooper()
 
-            val effect = awaitItem()
             assertThat(
-                "ClearWhiteboard effect should be emitted on answering card",
-                effect,
-                equalTo(ReviewerEffect.ClearWhiteboard)
+                "Answering card increments cardDisplayIndex to 2",
+                viewModel.state.first().cardDisplayIndex,
+                equalTo(2L),
             )
-            cancelAndIgnoreRemainingEvents()
         }
-    }
 
     @Test
-    fun `voice playback state is updated via event`() = runTest {
-        addBasicNote()
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
+    fun `answering same card in 1-card deck increments cardDisplayIndex`() =
+        runTest {
+            addBasicNote("Front 1", "Back 1")
 
-        viewModel.onEvent(ReviewerEvent.OnVoicePlaybackStateChanged(true))
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
 
-        val state = viewModel.state.first()
-        assertThat("Voice playback should be enabled", state.isVoicePlaybackEnabled, equalTo(true))
-    }
-
-    @Test
-    fun `toggleMark updates reviewer state after note is marked`() = runTest {
-        val note = addBasicNote("Front", "Back")
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
-
-        assertThat("Note should start unmarked", NoteService.isMarked(note), equalTo(false))
-        assertThat("State should start unmarked", viewModel.state.value.isMarked, equalTo(false))
-
-        viewModel.onEvent(ReviewerEvent.ToggleMark)
-        advanceRobolectricLooper()
-
-        val reloadedNote = col.getNote(note.id)
-        assertThat(
-            "Note should be marked after toggle",
-            NoteService.isMarked(reloadedNote),
-            equalTo(true)
-        )
-        assertThat(
-            "State should reflect marked note",
-            viewModel.state.value.isMarked,
-            equalTo(true)
-        )
-    }
-
-    @Test
-    fun `toggleMark uses canonical mark state instead of flipping reviewer state`() = runTest {
-        val note = addBasicNote("Front", "Back")
-        NoteService.toggleMark(note)
-
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
-
-        assertThat("State should start marked", viewModel.state.value.isMarked, equalTo(true))
-
-        mockkObject(NoteService)
-        try {
-            coEvery {
-                NoteService.toggleMark(note = any(), handler = viewModel)
-            } answers { }
-            coEvery { NoteService.isMarked(note = any()) } returns true
-
-            viewModel.onEvent(ReviewerEvent.ToggleMark)
+            testScheduler.advanceUntilIdle()
             advanceRobolectricLooper()
 
             assertThat(
-                "State should follow the canonical note mark state",
-                viewModel.state.value.isMarked,
-                equalTo(true)
+                "Initial cardDisplayIndex is 1",
+                viewModel.state.first().cardDisplayIndex,
+                equalTo(1L),
             )
-        } finally {
-            unmockkObject(NoteService)
+
+            // Rating AGAIN keeps the same card in the learning queue
+            viewModel.onEvent(ReviewerEvent.RateCard(anki.scheduler.CardAnswer.Rating.AGAIN))
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            assertThat(
+                "Repeating same card increments cardDisplayIndex to 2",
+                viewModel.state.first().cardDisplayIndex,
+                equalTo(2L),
+            )
         }
-    }
 
     @Test
-    fun `toggleMark leaves reviewer state unchanged when note toggle fails`() = runTest {
-        val note = addBasicNote("Front", "Back")
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
+    fun `reloading card retains cardDisplayIndex`() =
+        runTest {
+            addBasicNote("Front 1", "Back 1")
 
-        mockkObject(NoteService)
-        try {
-            coEvery {
-                NoteService.toggleMark(note = any(), handler = viewModel)
-            } throws IllegalStateException("toggle failed")
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            assertThat(
+                "Initial cardDisplayIndex is 1",
+                viewModel.state.first().cardDisplayIndex,
+                equalTo(1L),
+            )
+
+            viewModel.onEvent(ReviewerEvent.ReloadCard)
+            testScheduler.advanceUntilIdle()
+            advanceRobolectricLooper()
+
+            assertThat(
+                "Reloading same card keeps cardDisplayIndex at 1",
+                viewModel.state.first().cardDisplayIndex,
+                equalTo(1L),
+            )
+        }
+
+    @Test
+    fun `voice playback state is updated via event`() =
+        runTest {
+            addBasicNote()
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            viewModel.onEvent(ReviewerEvent.OnVoicePlaybackStateChanged(true))
+
+            val state = viewModel.state.first()
+            assertThat("Voice playback should be enabled", state.isVoicePlaybackEnabled, equalTo(true))
+        }
+
+    @Test
+    fun `toggleMark updates reviewer state after note is marked`() =
+        runTest {
+            val note = addBasicNote("Front", "Back")
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            assertThat("Note should start unmarked", NoteService.isMarked(note), equalTo(false))
+            assertThat("State should start unmarked", viewModel.state.value.isMarked, equalTo(false))
 
             viewModel.onEvent(ReviewerEvent.ToggleMark)
             advanceRobolectricLooper()
 
             val reloadedNote = col.getNote(note.id)
             assertThat(
-                "Note should remain unmarked after failure",
+                "Note should be marked after toggle",
                 NoteService.isMarked(reloadedNote),
-                equalTo(false)
+                equalTo(true),
             )
             assertThat(
-                "State should remain unchanged after failure",
+                "State should reflect marked note",
                 viewModel.state.value.isMarked,
-                equalTo(false)
+                equalTo(true),
             )
-        } finally {
-            unmockkObject(NoteService)
         }
-    }
 
     @Test
-    fun `showAnswer updates state correctly`() = runTest {
-        addBasicNote("Front", "Back")
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
+    fun `toggleMark uses canonical mark state instead of flipping reviewer state`() =
+        runTest {
+            val note = addBasicNote("Front", "Back")
+            NoteService.toggleMark(note)
 
-        // Initially answer should not be shown
-        var state = viewModel.state.first()
-        assertThat("Answer should not be shown initially", state.isAnswerShown, equalTo(false))
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
 
-        viewModel.onEvent(ReviewerEvent.ShowAnswer)
-        advanceRobolectricLooper()
+            assertThat("State should start marked", viewModel.state.value.isMarked, equalTo(true))
 
-        state = viewModel.state.first()
-        assertThat(
-            "Answer should be shown after ShowAnswer event", state.isAnswerShown, equalTo(true)
-        )
-        assertThat(
-            "Next times should be populated", state.nextTimes.any { it.isNotEmpty() }, equalTo(true)
-        )
-    }
+            mockkObject(NoteService)
+            try {
+                coEvery {
+                    NoteService.toggleMark(note = any(), handler = viewModel)
+                } answers { }
+                coEvery { NoteService.isMarked(note = any()) } returns true
 
-    @Test
-    fun `rateCard loads next card`() = runTest {
-        // Add two cards so we can verify navigation to next
-        addBasicNote("Front1", "Back1")
-        addBasicNote("Front2", "Back2")
+                viewModel.onEvent(ReviewerEvent.ToggleMark)
+                advanceRobolectricLooper()
 
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
-
-        var state = viewModel.state.first()
-        assertThat("Should have 2 new cards", state.newCount, equalTo(2))
-
-        // Show answer first (required before rating)
-        viewModel.onEvent(ReviewerEvent.ShowAnswer)
-        advanceRobolectricLooper()
-
-        // Rate the card
-        viewModel.onEvent(ReviewerEvent.RateCard(anki.scheduler.CardAnswer.Rating.GOOD))
-        advanceRobolectricLooper()
-
-        state = viewModel.state.first()
-        // After rating, we should be on the next card with answer hidden
-        assertThat("Answer should be hidden after rating", state.isAnswerShown, equalTo(false))
-        assertThat("New count should decrease", state.newCount, equalTo(1))
-    }
+                assertThat(
+                    "State should follow the canonical note mark state",
+                    viewModel.state.value.isMarked,
+                    equalTo(true),
+                )
+            } finally {
+                unmockkObject(NoteService)
+            }
+        }
 
     @Test
-    fun `confirmDeleteNote deletes current note and loads next card`() = runTest {
-        addBasicNote("Front1", "Back1")
-        addBasicNote("Front2", "Back2")
+    fun `toggleMark leaves reviewer state unchanged when note toggle fails`() =
+        runTest {
+            val note = addBasicNote("Front", "Back")
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
 
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
+            mockkObject(NoteService)
+            try {
+                coEvery {
+                    NoteService.toggleMark(note = any(), handler = viewModel)
+                } throws IllegalStateException("toggle failed")
 
-        val initialState = viewModel.state.first()
-        assertThat(
-            "Initial card should be loaded before deleting",
-            initialState.questionHtml,
-            containsString("Front1")
-        )
-        assertThat("Should have 2 new cards before deleting", initialState.newCount, equalTo(2))
+                viewModel.onEvent(ReviewerEvent.ToggleMark)
+                advanceRobolectricLooper()
 
-        viewModel.confirmDeleteNote()
-        advanceRobolectricLooper()
+                val reloadedNote = col.getNote(note.id)
+                assertThat(
+                    "Note should remain unmarked after failure",
+                    NoteService.isMarked(reloadedNote),
+                    equalTo(false),
+                )
+                assertThat(
+                    "State should remain unchanged after failure",
+                    viewModel.state.value.isMarked,
+                    equalTo(false),
+                )
+            } finally {
+                unmockkObject(NoteService)
+            }
+        }
 
-        val state = viewModel.state.first()
-        assertThat("Reviewer should continue with the next card", state.isFinished, equalTo(false))
-        assertThat(
-            "New count should decrease after deleting the current note", state.newCount, equalTo(1)
-        )
-        assertThat("The next card should be loaded", state.questionHtml, containsString("Front2"))
-    }
+    @Test
+    fun `showAnswer updates state correctly`() =
+        runTest {
+            addBasicNote("Front", "Back")
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            // Initially answer should not be shown
+            var state = viewModel.state.first()
+            assertThat("Answer should not be shown initially", state.isAnswerShown, equalTo(false))
+
+            viewModel.onEvent(ReviewerEvent.ShowAnswer)
+            advanceRobolectricLooper()
+
+            state = viewModel.state.first()
+            assertThat(
+                "Answer should be shown after ShowAnswer event",
+                state.isAnswerShown,
+                equalTo(true),
+            )
+            assertThat(
+                "Next times should be populated",
+                state.nextTimes.any { it.isNotEmpty() },
+                equalTo(true),
+            )
+        }
+
+    @Test
+    fun `rateCard loads next card`() =
+        runTest {
+            // Add two cards so we can verify navigation to next
+            addBasicNote("Front1", "Back1")
+            addBasicNote("Front2", "Back2")
+
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            var state = viewModel.state.first()
+            assertThat("Should have 2 new cards", state.newCount, equalTo(2))
+
+            // Show answer first (required before rating)
+            viewModel.onEvent(ReviewerEvent.ShowAnswer)
+            advanceRobolectricLooper()
+
+            // Rate the card
+            viewModel.onEvent(ReviewerEvent.RateCard(anki.scheduler.CardAnswer.Rating.GOOD))
+            advanceRobolectricLooper()
+
+            state = viewModel.state.first()
+            // After rating, we should be on the next card with answer hidden
+            assertThat("Answer should be hidden after rating", state.isAnswerShown, equalTo(false))
+            assertThat("New count should decrease", state.newCount, equalTo(1))
+        }
+
+    @Test
+    fun `confirmDeleteNote deletes current note and loads next card`() =
+        runTest {
+            addBasicNote("Front1", "Back1")
+            addBasicNote("Front2", "Back2")
+
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
+
+            val initialState = viewModel.state.first()
+            assertThat(
+                "Initial card should be loaded before deleting",
+                initialState.questionHtml,
+                containsString("Front1"),
+            )
+            assertThat("Should have 2 new cards before deleting", initialState.newCount, equalTo(2))
+
+            viewModel.confirmDeleteNote()
+            advanceRobolectricLooper()
+
+            val state = viewModel.state.first()
+            assertThat("Reviewer should continue with the next card", state.isFinished, equalTo(false))
+            assertThat(
+                "New count should decrease after deleting the current note",
+                state.newCount,
+                equalTo(1),
+            )
+            assertThat("The next card should be loaded", state.questionHtml, containsString("Front2"))
+        }
 
     @Test
     fun `undoDelete restores note when undo is requested immediately from delete result`() =
@@ -454,54 +553,56 @@ class ReviewerViewModelTest : RobolectricTest() {
         }
 
     @Test
-    fun `undoDelete restores note after deleting the final card`() = runTest {
-        addBasicNote("Front1", "Back1")
+    fun `undoDelete restores note after deleting the final card`() =
+        runTest {
+            addBasicNote("Front1", "Back1")
 
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val viewModel =
-            ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
-        advanceRobolectricLooper()
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val viewModel =
+                ReviewerViewModel(ApplicationProvider.getApplicationContext(), testDispatcher)
+            advanceRobolectricLooper()
 
-        var deletedCount: Int? = null
-        launch {
-            viewModel.flowOfDeleteResult.collect { count ->
-                deletedCount = count
-                viewModel.undoDelete()
-                cancel()
+            var deletedCount: Int? = null
+            launch {
+                viewModel.flowOfDeleteResult.collect { count ->
+                    deletedCount = count
+                    viewModel.undoDelete()
+                    cancel()
+                }
             }
+            advanceUntilIdle()
+
+            viewModel.confirmDeleteNote()
+            advanceUntilIdle()
+            advanceRobolectricLooper()
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat("Delete result should report one deleted note", deletedCount, equalTo(1))
+            assertThat(
+                "Undo should restore the deleted note even after finishing review",
+                col.noteCount(),
+                equalTo(1),
+            )
+            assertThat("Review should resume after undo", state.isFinished, equalTo(false))
         }
-        advanceUntilIdle()
-
-        viewModel.confirmDeleteNote()
-        advanceUntilIdle()
-        advanceRobolectricLooper()
-        advanceUntilIdle()
-
-        val state = viewModel.state.value
-        assertThat("Delete result should report one deleted note", deletedCount, equalTo(1))
-        assertThat(
-            "Undo should restore the deleted note even after finishing review",
-            col.noteCount(),
-            equalTo(1)
-        )
-        assertThat("Review should resume after undo", state.isFinished, equalTo(false))
-    }
 
     @Test
-    fun `card actions are blocked when review is finished`() = runTest {
-        // Create a ViewModel with no cards (will be finished immediately)
-        val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
-        advanceRobolectricLooper()
+    fun `card actions are blocked when review is finished`() =
+        runTest {
+            // Create a ViewModel with no cards (will be finished immediately)
+            val viewModel = ReviewerViewModel(ApplicationProvider.getApplicationContext())
+            advanceRobolectricLooper()
 
-        val state = viewModel.state.first()
-        assertThat("Review should be finished with no cards", state.isFinished, equalTo(true))
+            val state = viewModel.state.first()
+            assertThat("Review should be finished with no cards", state.isFinished, equalTo(true))
 
-        // Try to show answer - should have no effect since isFinished is true
-        viewModel.onEvent(ReviewerEvent.ShowAnswer)
-        advanceRobolectricLooper()
+            // Try to show answer - should have no effect since isFinished is true
+            viewModel.onEvent(ReviewerEvent.ShowAnswer)
+            advanceRobolectricLooper()
 
-        val stateAfter = viewModel.state.first()
-        assertThat("State should remain finished", stateAfter.isFinished, equalTo(true))
-        assertThat("Answer should not be shown", stateAfter.isAnswerShown, equalTo(false))
-    }
+            val stateAfter = viewModel.state.first()
+            assertThat("State should remain finished", stateAfter.isFinished, equalTo(true))
+            assertThat("Answer should not be shown", stateAfter.isAnswerShown, equalTo(false))
+        }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewModelTest.kt
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2026 the Anki-Android contributors
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer.whiteboard
+
+import android.content.Context
+import android.graphics.Path
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WhiteboardViewModelTest : RobolectricTest() {
+    private lateinit var viewModel: WhiteboardViewModel
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sharedPreferences = context.getSharedPreferences("whiteboard_test_prefs", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        val repository = WhiteboardRepository(sharedPreferences)
+        viewModel = WhiteboardViewModel(repository)
+        viewModel.loadState(isDarkMode = false)
+    }
+
+    @Test
+    fun `reset clears paths and clears undo and redo stacks`() {
+        val path = Path().apply { lineTo(10f, 10f) }
+        viewModel.addPath(path)
+
+        assertThat("Paths should contain 1 path after drawing", viewModel.paths.value, hasSize(1))
+        assertThat("Can undo should be true", viewModel.canUndo.value, equalTo(true))
+
+        viewModel.reset()
+
+        assertThat("Paths should be empty after reset", viewModel.paths.value.isEmpty(), equalTo(true))
+        assertThat("Can undo should be false after reset", viewModel.canUndo.value, equalTo(false))
+        assertThat("Can redo should be false after reset", viewModel.canRedo.value, equalTo(false))
+    }
+
+    @Test
+    fun `clearCanvas empties paths but preserves undo history`() {
+        val path = Path().apply { lineTo(20f, 20f) }
+        viewModel.addPath(path)
+
+        assertThat("Paths should contain 1 path", viewModel.paths.value, hasSize(1))
+
+        viewModel.clearCanvas()
+
+        assertThat("Paths should be empty after clearCanvas", viewModel.paths.value.isEmpty(), equalTo(true))
+        assertThat("Can undo should remain true after clearCanvas", viewModel.canUndo.value, equalTo(true))
+
+        viewModel.undo()
+
+        assertThat("Paths should be restored after undo", viewModel.paths.value, hasSize(1))
+    }
+
+    @Test
+    fun `undo and redo work as expected for drawing actions`() {
+        val path1 = Path().apply { lineTo(10f, 10f) }
+        val path2 = Path().apply { lineTo(20f, 20f) }
+
+        viewModel.addPath(path1)
+        viewModel.addPath(path2)
+
+        assertThat("Paths should contain 2 paths", viewModel.paths.value, hasSize(2))
+
+        viewModel.undo()
+        assertThat("Paths should contain 1 path after 1 undo", viewModel.paths.value, hasSize(1))
+        assertThat("Can redo should be true", viewModel.canRedo.value, equalTo(true))
+
+        viewModel.redo()
+        assertThat("Paths should contain 2 paths after redo", viewModel.paths.value, hasSize(2))
+    }
+}


### PR DESCRIPTION
- Added `ReviewerEffect.ClearWhiteboard` to signal when the whiteboard should be reset.
- Updated `ReviewerViewModel` to emit the `ClearWhiteboard` effect during the `displayCard` flow.
- Implemented effect handling in both `Reviewer` (legacy View-based) and `ReviewerCompose` to reset the whiteboard state.
- Simplified `WhiteboardController.updateForNewCard` to reset the ViewModel unconditionally.
- Added a unit test in `ReviewerViewModelTest` to verify that the clear effect is emitted after rating a card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Whiteboard content now resets reliably when moving to a new card.
  - Existing sketches are preserved during configuration changes, such as screen rotation.
  - Whiteboard undo and redo behavior remains consistent after resetting or clearing the canvas.

- **Improvements**
  - Card transitions are tracked more reliably, including repeated answers in single-card decks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->